### PR TITLE
chore: fix tests for engineers running on Java 9+

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,26 @@ In order to get start using the java client one needs to add it's dependency:
 </dependency>
 ```
 
+
+### For applications on Java 9 or above
+
+The client utilizes Gson for JSON serialization/deserialization and Gson uses reflection of internal `java.lang` classes
+to do it. This is not allowed by default in Java 9 and above.
+
+To work around this, it's necessary to add this JVM commandline argument:
+```
+--add-opens=java.base/java.lang=ALL-UNNAMED
+```
+
+If you're using Gradle, you can add this instead to your `application` block in your `build.gradle.kts` file:
+
+```kotlin
+applicationDefaultJvmArgs += listOf(
+  "--add-opens=java.base/java.lang=ALL-UNNAMED",
+)
+```
+
+
 Here's a simple code to start up working with Java client:
 
 1. Add dependency to your java project.

--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,17 @@
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.22.2</version>
+          <configuration>
+            <argLine>
+              <!--
+                Gson (used for JSON serialization) utilizes reflection and needs to be able to access private fields of
+                Java core classes. For that to work correctly after Java 9, we need to open up some of the core Java
+                classes to reflection.
+                @see: https://www.oracle.com/corporate/features/understanding-java-9-modules.html
+              -->
+              --add-opens=java.base/java.lang=ALL-UNNAMED
+            </argLine>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
For engineers running on Java 9 or above, some of the tests (like `SerializerTest`) fail.

This is because when the client receives errors from Weaviate, it attempts to deserialize into `Exception`s through the use of Gson. Gson internally uses reflection on internal variables like `Throwable#detailMessage`, which is barred due to the "strict encapsulation" module system introduced in Java 9 and above. 

The result is an illegal reflection error.

To fix this, the internal `java.lang` module was opened up so tests run as intended for contributors running Java 9 or above.

As this is the case for end users as well, a message was added to the README to let users of the library know with instructions to tweak their build tools to work around this.