### PR TITLE
feat: Introduce `indexSearchable` and `indexFilterable`

### DIFF
--- a/src/main/java/io/weaviate/client/v1/schema/model/Property.java
+++ b/src/main/java/io/weaviate/client/v1/schema/model/Property.java
@@ -18,4 +18,6 @@ public class Property {
   String tokenization;
   Boolean indexInverted;
   Object moduleConfig;
+  Boolean indexFilterable;
+  Boolean indexSearchable;
 }

--- a/src/test/java/io/weaviate/client/v1/schema/model/PropertyTest.java
+++ b/src/test/java/io/weaviate/client/v1/schema/model/PropertyTest.java
@@ -21,9 +21,13 @@ public class PropertyTest extends TestCase {
             .description("price")
             .name("price")
             .moduleConfig(moduleConfig)
+            .indexFilterable(true)
+            .indexSearchable(true)
             .build();
+
     String expected = "{\"name\":\"price\",\"dataType\":[\"number\"],\"description\":\"price\"," +
-            "\"moduleConfig\":{\"text2vec-contextionary\":{\"vectorizePropertyName\":false}}}";
+            "\"moduleConfig\":{\"text2vec-contextionary\":{\"vectorizePropertyName\":false}}," +
+            "\"indexFilterable\":true,\"indexSearchable\":true}";
     // when
     String result = new GsonBuilder().create().toJson(priceProperty);
     // then


### PR DESCRIPTION
This adds support for enabling/disabling the two indexes in the inverted indices on a per property level as per the docs here: https://weaviate.io/developers/weaviate/configuration/indexes#configure-the-inverted-index