### PR TITLE
fix. Exclude WeaviateErrorMessage#throwable field from gson (de)seria…

### DIFF
--- a/src/main/java/io/weaviate/client/base/WeaviateErrorMessage.java
+++ b/src/main/java/io/weaviate/client/base/WeaviateErrorMessage.java
@@ -12,5 +12,5 @@ import lombok.experimental.FieldDefaults;
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public class WeaviateErrorMessage {
   String message;
-  Throwable throwable;
+  transient Throwable throwable; // transient = not serialized by gson. This field is only used on Java.
 }


### PR DESCRIPTION
# Problem

If an error occurs in weaviate, the gson serialization always fails and a WeaviateError object holding the gson error is returned.

As a result, it is hard for developers to write recovery processing by distinguishing the cause of the error.

```
WeaviateErrorMessage(message=Failed making field 'java.lang.Throwable#detailMessage' accessible; either increase its visibility or write a custom TypeAdapter for its declaring type., throwable=com.google.gson.JsonIOException: Failed making field 'java.lang.Throwable#detailMessage' accessible; either increase its visibility or write a custom TypeAdapter for its declaring type.)
```

Additionally, as mentioned in https://github.com/weaviate/java-client/pull/201, SerializerTest.{testErrorResponseWithNoError,testErrorResponse} is fail.

```
com.google.gson.JsonIOException: Failed making field 'java.lang.Throwable#detailMessage' accessible; either increase its visibility or write a custom TypeAdapter for its declaring type.
```

# Cause

From Java 17, gson cannot access the private fields for each class by reflection.

# Solution

In this PR, the `transient` keyword is added to WeaviateErrorMessage#throwable field to exclude from gson serialization/deserialization.
WeaviateErrorMessage#throwable is only used on Java, so it does not need to serialize/deserialize by gson.
