### PR TITLE
feat: Add `indexNullState` and `indexPropertyLength` field support in `InvertedIndexConfig`

### DIFF
--- a/src/main/java/io/weaviate/client/v1/misc/model/InvertedIndexConfig.java
+++ b/src/main/java/io/weaviate/client/v1/misc/model/InvertedIndexConfig.java
@@ -16,4 +16,5 @@ public class InvertedIndexConfig {
   Integer cleanupIntervalSeconds;
   Boolean indexTimestamps;
   Boolean indexNullState;
+  Boolean indexPropertyLength;
 }

--- a/src/main/java/io/weaviate/client/v1/misc/model/InvertedIndexConfig.java
+++ b/src/main/java/io/weaviate/client/v1/misc/model/InvertedIndexConfig.java
@@ -15,4 +15,5 @@ public class InvertedIndexConfig {
   StopwordConfig stopwords;
   Integer cleanupIntervalSeconds;
   Boolean indexTimestamps;
+  Boolean indexNullState;
 }

--- a/src/test/java/io/weaviate/integration/client/schema/ClientSchemaTest.java
+++ b/src/test/java/io/weaviate/integration/client/schema/ClientSchemaTest.java
@@ -494,6 +494,34 @@ public class ClientSchemaTest {
   }
 
   @Test
+  public void testCreateClassWithInvertedIndexContainingIndexNullState() {
+    // given
+    InvertedIndexConfig invertedIndexConfig = InvertedIndexConfig.builder()
+      .indexNullState(true)
+      .build();
+
+    WeaviateClass clazz = WeaviateClass.builder()
+      .className("Band")
+      .description("Band that plays and produces music")
+      .vectorIndexType("hnsw")
+      .vectorizer("text2vec-contextionary")
+      .invertedIndexConfig(invertedIndexConfig)
+      .build();
+
+    // when
+    Result<Boolean> createStatus = client.schema().classCreator().withClass(clazz).run();
+    Result<WeaviateClass> bandClass = client.schema().classGetter().withClassName(clazz.getClassName()).run();
+
+    // then
+    assertNotNull(createStatus);
+    assertTrue(createStatus.getResult());
+    assertNotNull(bandClass);
+    assertNotNull(bandClass.getResult());
+    assertNull(bandClass.getError());
+    assertTrue(bandClass.getResult().getInvertedIndexConfig().getIndexNullState());
+  }
+
+  @Test
   public void testCreateClassWithStopwordsConfig() {
     // given
     StopwordConfig stopwordConfig = StopwordConfig.builder()

--- a/src/test/java/io/weaviate/integration/client/schema/ClientSchemaTest.java
+++ b/src/test/java/io/weaviate/integration/client/schema/ClientSchemaTest.java
@@ -522,6 +522,34 @@ public class ClientSchemaTest {
   }
 
   @Test
+  public void testCreateClassWithInvertedIndexContainingIndexPropertyLength() {
+    // given
+    InvertedIndexConfig invertedIndexConfig = InvertedIndexConfig.builder()
+      .indexPropertyLength(true)
+      .build();
+
+    WeaviateClass clazz = WeaviateClass.builder()
+      .className("Band")
+      .description("Band that plays and produces music")
+      .vectorIndexType("hnsw")
+      .vectorizer("text2vec-contextionary")
+      .invertedIndexConfig(invertedIndexConfig)
+      .build();
+
+    // when
+    Result<Boolean> createStatus = client.schema().classCreator().withClass(clazz).run();
+    Result<WeaviateClass> bandClass = client.schema().classGetter().withClassName(clazz.getClassName()).run();
+
+    // then
+    assertNotNull(createStatus);
+    assertTrue(createStatus.getResult());
+    assertNotNull(bandClass);
+    assertNotNull(bandClass.getResult());
+    assertNull(bandClass.getError());
+    assertTrue(bandClass.getResult().getInvertedIndexConfig().getIndexPropertyLength());
+  }
+
+  @Test
   public void testCreateClassWithStopwordsConfig() {
     // given
     StopwordConfig stopwordConfig = StopwordConfig.builder()


### PR DESCRIPTION
These fields were introduced in Weaviate v1.16 but support was missing in this client. This fixes that.