### PR TITLE
Add http proxy options

### DIFF
--- a/src/main/java/io/weaviate/client/Config.java
+++ b/src/main/java/io/weaviate/client/Config.java
@@ -12,6 +12,10 @@ public class Config {
   private final int connectionTimeout;
   private final int connectionRequestTimeout;
   private final int socketTimeout;
+  private String proxyUrl;
+  private int proxyPort;
+  private String proxyScheme;
+
 
   public Config(String scheme, String host) {
     this(scheme, host, null, DEFAULT_TIMEOUT_SECONDS, DEFAULT_TIMEOUT_SECONDS, DEFAULT_TIMEOUT_SECONDS);
@@ -50,4 +54,23 @@ public class Config {
   public int getSocketTimeout() {
     return socketTimeout;
   }
+
+  public void setProxy(String proxyUrl, int proxyPort, String proxyScheme) {
+    this.proxyUrl = proxyUrl;
+    this.proxyPort = proxyPort;
+    this.proxyScheme = proxyScheme;
+  }
+
+  public String getProxyUrl() {
+    return proxyUrl;
+  }
+
+  public int getProxyPort() {
+    return proxyPort;
+  }
+
+  public String getProxyScheme() {
+    return proxyScheme;
+  }
+  
 }

--- a/src/main/java/io/weaviate/client/Config.java
+++ b/src/main/java/io/weaviate/client/Config.java
@@ -12,7 +12,7 @@ public class Config {
   private final int connectionTimeout;
   private final int connectionRequestTimeout;
   private final int socketTimeout;
-  private String proxyUrl;
+  private String proxyHost;
   private int proxyPort;
   private String proxyScheme;
 
@@ -55,14 +55,14 @@ public class Config {
     return socketTimeout;
   }
 
-  public void setProxy(String proxyUrl, int proxyPort, String proxyScheme) {
-    this.proxyUrl = proxyUrl;
+  public void setProxy(String proxyHost, int proxyPort, String proxyScheme) {
+    this.proxyHost = proxyHost;
     this.proxyPort = proxyPort;
     this.proxyScheme = proxyScheme;
   }
 
-  public String getProxyUrl() {
-    return proxyUrl;
+  public String getProxyHost() {
+    return proxyHost;
   }
 
   public int getProxyPort() {

--- a/src/main/java/io/weaviate/client/base/http/builder/HttpApacheClientBuilder.java
+++ b/src/main/java/io/weaviate/client/base/http/builder/HttpApacheClientBuilder.java
@@ -16,8 +16,8 @@ public class HttpApacheClientBuilder {
       .setConnectionRequestTimeout(config.getConnectionRequestTimeout() * 1000)
       .setSocketTimeout(config.getSocketTimeout() * 1000);
       
-    if (config.getProxyUrl() != null) {
-      requestConfigBuilder.setProxy(new HttpHost(config.getProxyUrl(), config.getProxyPort(), config.getProxyScheme()));
+    if (config.getProxyHost() != null) {
+      requestConfigBuilder.setProxy(new HttpHost(config.getProxyHost(), config.getProxyPort(), config.getProxyScheme()));
     }
 
     RequestConfig requestConfig = requestConfigBuilder.build();

--- a/src/main/java/io/weaviate/client/base/http/builder/HttpApacheClientBuilder.java
+++ b/src/main/java/io/weaviate/client/base/http/builder/HttpApacheClientBuilder.java
@@ -1,5 +1,6 @@
 package io.weaviate.client.base.http.builder;
 
+import org.apache.http.HttpHost;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.HttpClientBuilder;
 import io.weaviate.client.Config;
@@ -10,10 +11,16 @@ public class HttpApacheClientBuilder {
   private HttpApacheClientBuilder() {}
 
   public static CommonsHttpClientImpl.CloseableHttpClientBuilder build(Config config) {
-    RequestConfig requestConfig = RequestConfig.custom()
+    RequestConfig.Builder requestConfigBuilder = RequestConfig.custom()
       .setConnectTimeout(config.getConnectionTimeout() * 1000)
       .setConnectionRequestTimeout(config.getConnectionRequestTimeout() * 1000)
-      .setSocketTimeout(config.getSocketTimeout() * 1000).build();
+      .setSocketTimeout(config.getSocketTimeout() * 1000);
+      
+    if (config.getProxyUrl() != null) {
+      requestConfigBuilder.setProxy(new HttpHost(config.getProxyUrl(), config.getProxyPort(), config.getProxyScheme()));
+    }
+
+    RequestConfig requestConfig = requestConfigBuilder.build();
     return HttpClientBuilder.create().setDefaultRequestConfig(requestConfig)::build;
   }
 }

--- a/src/test/java/io/weaviate/client/ConfigTest.java
+++ b/src/test/java/io/weaviate/client/ConfigTest.java
@@ -32,4 +32,22 @@ public class ConfigTest extends TestCase {
     Assert.assertEquals("https://localhost:8080/v1", config.getBaseURL());
     Assert.assertEquals(1, config.getHeaders().size());
   }
+
+  @Test
+  public void testConfigProxy() {
+    // given
+    String scheme = "https";
+    String domain = "localhost:8080";
+    String proxyUrl = "proxy";
+    int proxyPort = 8080;
+    String proxyScheme = "http";
+    // when
+    Config config = new Config(scheme, domain);
+    config.setProxy(proxyUrl, proxyPort, proxyScheme);
+    // then
+    Assert.assertEquals("https://localhost:8080/v1", config.getBaseURL());
+    Assert.assertEquals("proxy", config.getProxyUrl());
+    Assert.assertEquals(8080, config.getProxyPort());
+    Assert.assertEquals("http", config.getProxyScheme());
+  }
 }

--- a/src/test/java/io/weaviate/client/ConfigTest.java
+++ b/src/test/java/io/weaviate/client/ConfigTest.java
@@ -38,15 +38,15 @@ public class ConfigTest extends TestCase {
     // given
     String scheme = "https";
     String domain = "localhost:8080";
-    String proxyUrl = "proxy";
+    String proxyHost = "proxy";
     int proxyPort = 8080;
     String proxyScheme = "http";
     // when
     Config config = new Config(scheme, domain);
-    config.setProxy(proxyUrl, proxyPort, proxyScheme);
+    config.setProxy(proxyHost, proxyPort, proxyScheme);
     // then
     Assert.assertEquals("https://localhost:8080/v1", config.getBaseURL());
-    Assert.assertEquals("proxy", config.getProxyUrl());
+    Assert.assertEquals("proxy", config.getProxyHost());
     Assert.assertEquals(8080, config.getProxyPort());
     Assert.assertEquals("http", config.getProxyScheme());
   }

--- a/src/test/java/io/weaviate/integration/client/proxy/ClientProxyTest.java
+++ b/src/test/java/io/weaviate/integration/client/proxy/ClientProxyTest.java
@@ -28,10 +28,8 @@ public class ClientProxyTest {
   ).withExposedService("weaviate_1", 8080, Wait.forHttp("/v1/.well-known/ready").forStatusCode(200)
   ).withExposedService("proxy_1", 80, Wait.forHttp("/").forStatusCode(503));
 
-
   @Test
   public void testProxyUnset() {
-
     Config config = new Config("http", "weaviate.local");
 
     client = new WeaviateClient(config);
@@ -59,6 +57,4 @@ public class ClientProxyTest {
     assertNull(meta.getError());
     assertEquals("http://[::]:8080", meta.getResult().getHostname());
   }
-
-
 }

--- a/src/test/java/io/weaviate/integration/client/proxy/ClientProxyTest.java
+++ b/src/test/java/io/weaviate/integration/client/proxy/ClientProxyTest.java
@@ -1,0 +1,64 @@
+package io.weaviate.integration.client.proxy;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.testcontainers.containers.DockerComposeContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import io.weaviate.client.Config;
+import io.weaviate.client.WeaviateClient;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.misc.model.Meta;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static io.weaviate.integration.client.WeaviateVersion.EXPECTED_WEAVIATE_VERSION;
+
+public class ClientProxyTest {
+
+  private WeaviateClient client;
+
+  @ClassRule
+  public static DockerComposeContainer<?> compose = new DockerComposeContainer<>(
+    new File("src/test/resources/docker-compose-proxy.yaml")
+  ).withExposedService("weaviate_1", 8080, Wait.forHttp("/v1/.well-known/ready").forStatusCode(200)
+  ).withExposedService("proxy_1", 80, Wait.forHttp("/").forStatusCode(503));
+
+
+  @Test
+  public void testProxyUnset() {
+
+    Config config = new Config("http", "weaviate.local");
+
+    client = new WeaviateClient(config);
+    // when
+    Result<Meta> meta = client.misc().metaGetter().run();
+    // then
+    assertNotNull(meta);
+    assertNotNull(meta.getError());
+  }
+
+  @Test
+  public void testProxySet() {
+    String proxyHost = compose.getServiceHost("proxy_1", 80);
+    Integer port = compose.getServicePort("proxy_1", 80);
+    String proxyScheme = "http";
+
+    Config config = new Config("http", "weaviate.local");
+    config.setProxy(proxyHost, port, proxyScheme);
+
+    client = new WeaviateClient(config);
+    // when
+    Result<Meta> meta = client.misc().metaGetter().run();
+    // then
+    assertNotNull(meta);
+    assertNull(meta.getError());
+    assertEquals("http://[::]:8080", meta.getResult().getHostname());
+  }
+
+
+}

--- a/src/test/resources/docker-compose-proxy.yaml
+++ b/src/test/resources/docker-compose-proxy.yaml
@@ -20,8 +20,6 @@ services:
       VIRTUAL_PORT: 8080
   proxy:
     image: nginxproxy/nginx-proxy:alpine
-    ports:
-      - "8090:80"
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
 ...

--- a/src/test/resources/docker-compose-proxy.yaml
+++ b/src/test/resources/docker-compose-proxy.yaml
@@ -1,0 +1,27 @@
+---
+version: '3.4'
+services:
+  weaviate:
+    command:
+    - --host
+    - 0.0.0.0
+    - --port
+    - '8080'
+    - --scheme
+    - http
+    image: semitechnologies/weaviate:1.21.0
+    restart: on-failure:0
+    environment:
+      LOG_LEVEL: "debug"
+      QUERY_DEFAULTS_LIMIT: 25
+      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'
+      PERSISTENCE_DATA_PATH: "./data"
+      VIRTUAL_HOST: weaviate.local
+      VIRTUAL_PORT: 8080
+  proxy:
+    image: nginxproxy/nginx-proxy:alpine
+    ports:
+      - "8090:80"
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+...


### PR DESCRIPTION
Usecase is for when you would want the Java client to have a proxy but not entire JVM (so don't want to use JVM flags `http.proxyHost` and `http.proxyPort`) i.e. in Spark.

I opted for using a setter as this config will rarely be used. I've also added an integration test using `nginx-proxy`.