### PR TITLE
Modify gRPC configuration parameters in Config class

### DIFF
--- a/src/main/java/io/weaviate/client/Config.java
+++ b/src/main/java/io/weaviate/client/Config.java
@@ -26,10 +26,10 @@ public class Config {
   private int proxyPort;
   @Getter
   private String proxyScheme;
-  @Setter
-  private boolean useGRPC;
   @Getter @Setter
-  private String grpcAddress;
+  private boolean gRPCSecured;
+  @Getter @Setter
+  private String gRPCHost;
 
   public Config(String scheme, String host) {
     this(scheme, host, null, DEFAULT_TIMEOUT_SECONDS, DEFAULT_TIMEOUT_SECONDS, DEFAULT_TIMEOUT_SECONDS);
@@ -49,7 +49,7 @@ public class Config {
     this.socketTimeout = socketTimeout;
   }
 
-  public Config(String scheme, String host, Map<String, String> headers, int timeout, boolean useGRPC) {
+  public Config(String scheme, String host, Map<String, String> headers, int timeout, boolean gRPCSecured, String gRPCHost) {
     this.scheme = scheme;
     this.host = host;
     this.version = "v1";
@@ -57,7 +57,8 @@ public class Config {
     this.connectionTimeout = timeout;
     this.connectionRequestTimeout = timeout;
     this.socketTimeout = timeout;
-    this.useGRPC = useGRPC;
+    this.gRPCSecured = gRPCSecured;
+    this.gRPCHost = gRPCHost;
   }
 
   public String getBaseURL() {
@@ -71,6 +72,6 @@ public class Config {
   }
 
   public boolean useGRPC() {
-    return this.useGRPC;
+    return this.gRPCHost != null && !this.gRPCHost.trim().isEmpty();
   }
 }

--- a/src/main/java/io/weaviate/client/base/grpc/GrpcClient.java
+++ b/src/main/java/io/weaviate/client/base/grpc/GrpcClient.java
@@ -18,7 +18,7 @@ public class GrpcClient {
       }
     }
     ManagedChannelBuilder<?> channelBuilder = ManagedChannelBuilder.forTarget(getAddress(config));
-    if (config.getScheme().equals("https")) {
+    if (config.isGRPCSecured()) {
       channelBuilder = channelBuilder.useTransportSecurity();
     } else {
       channelBuilder.usePlaintext();
@@ -29,16 +29,16 @@ public class GrpcClient {
   }
 
   private static String getAddress(Config config) {
-    if (config.getGrpcAddress() != null) {
-      return config.getGrpcAddress();
-    }
-    String host = config.getHost();
-    if (!host.contains(":")) {
-      if (config.getScheme() != null && config.getScheme().equals("https")) {
+    if (config.getGRPCHost() != null) {
+      String host = config.getGRPCHost();
+      if (host.contains(":")) {
+        return host;
+      }
+      if (config.isGRPCSecured()) {
         return String.format("%s:443", host);
       }
       return String.format("%s:80", host);
     }
-    return host;
+    return "";
   }
 }

--- a/src/test/java/io/weaviate/integration/client/batch/ClientBatchGrpcCreateTest.java
+++ b/src/test/java/io/weaviate/integration/client/batch/ClientBatchGrpcCreateTest.java
@@ -197,8 +197,10 @@ public class ClientBatchGrpcCreateTest {
 
   private WeaviateClient createClient(Boolean useGRPC) {
     Config config = new Config("http", host + ":" + port);
-    config.setUseGRPC(useGRPC);
-    config.setGrpcAddress(grpcHost + ":" + grpcPort);
+    if (useGRPC) {
+      config.setGRPCSecured(false);
+      config.setGRPCHost(grpcHost + ":" + grpcPort);
+    }
     return new WeaviateClient(config);
   }
 


### PR DESCRIPTION
This PR changes how we configure `gRPC` connection in Java client.

Assuming that REST endpoint works on `localhost:8080` and gRPC endpoint works on `localhost:50051`

1. One can set the `gRPC` settings using `Config` constructor:

```
new Config("https", "localhost:8080", null, 10, false, "localhost:50051")
```

3. One can set `gRPC` settings using `setGRPCSecured` and `setGRPCHost` methods:

```
Config config = Config config = new Config("http", "localhost:8080");
config.setGRPCSecured(false);
config.setGRPCHost("localhost:50051");
```