### PR TITLE
Fix gRPC channel shutdown error

### DIFF
--- a/src/main/java/io/weaviate/client/v1/batch/Batch.java
+++ b/src/main/java/io/weaviate/client/v1/batch/Batch.java
@@ -1,32 +1,32 @@
 package io.weaviate.client.v1.batch;
 
+import io.weaviate.client.Config;
 import io.weaviate.client.base.http.HttpClient;
 import io.weaviate.client.base.util.BeaconPath;
 import io.weaviate.client.base.util.DbVersionSupport;
-import io.weaviate.client.grpc.protocol.v1.WeaviateGrpc;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 import io.weaviate.client.v1.batch.api.ObjectsBatchDeleter;
 import io.weaviate.client.v1.batch.api.ObjectsBatcher;
 import io.weaviate.client.v1.batch.api.ReferencePayloadBuilder;
 import io.weaviate.client.v1.batch.api.ReferencesBatcher;
 import io.weaviate.client.v1.batch.util.ObjectsPath;
 import io.weaviate.client.v1.batch.util.ReferencesPath;
-import io.weaviate.client.Config;
 import io.weaviate.client.v1.data.Data;
 
 public class Batch {
   private final Config config;
   private final HttpClient httpClient;
-  private final WeaviateGrpc.WeaviateBlockingStub grpcClient;
+  private final AccessTokenProvider tokenProvider;
   private final BeaconPath beaconPath;
   private final ObjectsPath objectsPath;
   private final ReferencesPath referencesPath;
   private final Data data;
 
   public Batch(HttpClient httpClient, Config config, DbVersionSupport dbVersionSupport,
-    WeaviateGrpc.WeaviateBlockingStub grpcClient, Data data) {
+    AccessTokenProvider tokenProvider, Data data) {
     this.config = config;
     this.httpClient = httpClient;
-    this.grpcClient = grpcClient;
+    this.tokenProvider = tokenProvider;
     this.beaconPath = new BeaconPath(dbVersionSupport);
     this.objectsPath = new ObjectsPath();
     this.referencesPath = new ReferencesPath();
@@ -38,7 +38,7 @@ public class Batch {
   }
 
   public ObjectsBatcher objectsBatcher(ObjectsBatcher.BatchRetriesConfig batchRetriesConfig) {
-    return ObjectsBatcher.create(httpClient, config, data, objectsPath, grpcClient, batchRetriesConfig);
+    return ObjectsBatcher.create(httpClient, config, data, objectsPath, tokenProvider, batchRetriesConfig);
   }
 
   public ObjectsBatcher objectsAutoBatcher() {
@@ -64,7 +64,7 @@ public class Batch {
 
   public ObjectsBatcher objectsAutoBatcher(ObjectsBatcher.BatchRetriesConfig batchRetriesConfig,
                                            ObjectsBatcher.AutoBatchConfig autoBatchConfig) {
-    return ObjectsBatcher.createAuto(httpClient, config, data, objectsPath, grpcClient, batchRetriesConfig, autoBatchConfig);
+    return ObjectsBatcher.createAuto(httpClient, config, data, objectsPath, tokenProvider, batchRetriesConfig, autoBatchConfig);
   }
 
   public ObjectsBatchDeleter objectsBatchDeleter() {


### PR DESCRIPTION
This PR fixes this error that started occurring in tests:

```
2023-11-14 13:17:49 5.15.0 SEVERE *~*~*~ Previous channel ManagedChannelImpl{logId=1, target=localhost:32774} was not shutdown properly!!! ~*~*~*
    Make sure to call shutdown()/shutdownNow() and wait until awaitTermination() returns true. 
java.lang.RuntimeException: ManagedChannel allocation site
	at io.grpc.internal.ManagedChannelOrphanWrapper$ManagedChannelReference.<init>(ManagedChannelOrphanWrapper.java:102)
	at io.grpc.internal.ManagedChannelOrphanWrapper.<init>(ManagedChannelOrphanWrapper.java:60)
	at io.grpc.internal.ManagedChannelOrphanWrapper.<init>(ManagedChannelOrphanWrapper.java:51)
	at io.grpc.internal.ManagedChannelImplBuilder.build(ManagedChannelImplBuilder.java:655)
	at io.grpc.ForwardingChannelBuilder2.build(ForwardingChannelBuilder2.java:261)
	at io.weaviate.client.base.grpc.GrpcClient.create(GrpcClient.java:30)
	at io.weaviate.client.WeaviateClient.<init>(WeaviateClient.java:46)
	at io.weaviate.client.WeaviateClient.<init>(WeaviateClient.java:33)
	at io.weaviate.integration.client.batch.ClientBatchGrpcCreateTest.createClient(ClientBatchGrpcCreateTest.java:204)
	at io.weaviate.integration.client.batch.ClientBatchGrpcCreateTest.testCreateBatch(ClientBatchGrpcCreateTest.java:172)
	at io.weaviate.integration.client.batch.ClientBatchGrpcCreateTest.shouldCreateBatchUsingGRPC(ClientBatchGrpcCreateTest.java:47)
```