### PR TITLE
Bring back the old Config constructor that's without gRPC settings

### DIFF
--- a/src/main/java/io/weaviate/client/Config.java
+++ b/src/main/java/io/weaviate/client/Config.java
@@ -49,6 +49,10 @@ public class Config {
     this.socketTimeout = socketTimeout;
   }
 
+  public Config(String scheme, String host, Map<String, String> headers, int timeout) {
+    this(scheme, host, headers, timeout, false, "");
+  }
+
   public Config(String scheme, String host, Map<String, String> headers, int timeout, boolean gRPCSecured, String gRPCHost) {
     this.scheme = scheme;
     this.host = host;


### PR DESCRIPTION
The `4.4.0` made a small breaking change to the `Config` class :(. 
I'm bringing back Config's class constructor which is without the `gRPC` settings.