### PR TITLE
Switch to vector bytes field to send vector when using gRPC

### DIFF
--- a/src/main/java/io/weaviate/client/WeaviateClient.java
+++ b/src/main/java/io/weaviate/client/WeaviateClient.java
@@ -5,6 +5,7 @@ import io.weaviate.client.base.http.builder.HttpApacheClientBuilder;
 import io.weaviate.client.base.http.impl.CommonsHttpClientImpl;
 import io.weaviate.client.base.util.DbVersionProvider;
 import io.weaviate.client.base.util.DbVersionSupport;
+import io.weaviate.client.base.util.GrpcVersionSupport;
 import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 import io.weaviate.client.v1.backup.Backup;
 import io.weaviate.client.v1.batch.Batch;
@@ -22,6 +23,7 @@ public class WeaviateClient {
   private final Config config;
   private final DbVersionProvider dbVersionProvider;
   private final DbVersionSupport dbVersionSupport;
+  private final GrpcVersionSupport grpcVersionSupport;
   private final HttpClient httpClient;
   private final AccessTokenProvider tokenProvider;
 
@@ -38,6 +40,7 @@ public class WeaviateClient {
     this.httpClient = httpClient;
     dbVersionProvider = initDbVersionProvider();
     dbVersionSupport = new DbVersionSupport(dbVersionProvider);
+    grpcVersionSupport = new GrpcVersionSupport(dbVersionProvider);
     this.tokenProvider = tokenProvider;
   }
 
@@ -56,7 +59,7 @@ public class WeaviateClient {
 
   public Batch batch() {
     dbVersionProvider.refresh();
-    return new Batch(httpClient, config, dbVersionSupport, tokenProvider, data());
+    return new Batch(httpClient, config, dbVersionSupport, grpcVersionSupport, tokenProvider, data());
   }
 
   public Backup backup() {

--- a/src/main/java/io/weaviate/client/base/util/GrpcVersionSupport.java
+++ b/src/main/java/io/weaviate/client/base/util/GrpcVersionSupport.java
@@ -1,0 +1,26 @@
+package io.weaviate.client.base.util;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+
+@RequiredArgsConstructor
+public class GrpcVersionSupport {
+
+  private final DbVersionProvider provider;
+
+  public boolean supportsVectorBytesField() {
+    String[] versionNumbers = StringUtils.split(provider.getVersion(), ".");
+    if (versionNumbers != null && versionNumbers.length >= 2) {
+      int major = Integer.parseInt(versionNumbers[0]);
+      int minor = Integer.parseInt(versionNumbers[1]);
+      if (major == 1 && minor == 22 && versionNumbers.length == 3) {
+        String patch = versionNumbers[2];
+        if (!patch.contains("rc") && Integer.parseInt(patch) >= 6) {
+          return true;
+        }
+      }
+      return (major == 1 && minor >= 23) || major >= 2;
+    }
+    return false;
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/batch/Batch.java
+++ b/src/main/java/io/weaviate/client/v1/batch/Batch.java
@@ -4,6 +4,7 @@ import io.weaviate.client.Config;
 import io.weaviate.client.base.http.HttpClient;
 import io.weaviate.client.base.util.BeaconPath;
 import io.weaviate.client.base.util.DbVersionSupport;
+import io.weaviate.client.base.util.GrpcVersionSupport;
 import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 import io.weaviate.client.v1.batch.api.ObjectsBatchDeleter;
 import io.weaviate.client.v1.batch.api.ObjectsBatcher;
@@ -20,14 +21,16 @@ public class Batch {
   private final BeaconPath beaconPath;
   private final ObjectsPath objectsPath;
   private final ReferencesPath referencesPath;
+  private final GrpcVersionSupport grpcVersionSupport;
   private final Data data;
 
-  public Batch(HttpClient httpClient, Config config, DbVersionSupport dbVersionSupport,
+  public Batch(HttpClient httpClient, Config config, DbVersionSupport dbVersionSupport, GrpcVersionSupport grpcVersionSupport,
     AccessTokenProvider tokenProvider, Data data) {
     this.config = config;
     this.httpClient = httpClient;
     this.tokenProvider = tokenProvider;
     this.beaconPath = new BeaconPath(dbVersionSupport);
+    this.grpcVersionSupport = grpcVersionSupport;
     this.objectsPath = new ObjectsPath();
     this.referencesPath = new ReferencesPath();
     this.data = data;
@@ -38,7 +41,7 @@ public class Batch {
   }
 
   public ObjectsBatcher objectsBatcher(ObjectsBatcher.BatchRetriesConfig batchRetriesConfig) {
-    return ObjectsBatcher.create(httpClient, config, data, objectsPath, tokenProvider, batchRetriesConfig);
+    return ObjectsBatcher.create(httpClient, config, data, objectsPath, tokenProvider, grpcVersionSupport, batchRetriesConfig);
   }
 
   public ObjectsBatcher objectsAutoBatcher() {
@@ -64,7 +67,7 @@ public class Batch {
 
   public ObjectsBatcher objectsAutoBatcher(ObjectsBatcher.BatchRetriesConfig batchRetriesConfig,
                                            ObjectsBatcher.AutoBatchConfig autoBatchConfig) {
-    return ObjectsBatcher.createAuto(httpClient, config, data, objectsPath, tokenProvider, batchRetriesConfig, autoBatchConfig);
+    return ObjectsBatcher.createAuto(httpClient, config, data, objectsPath, tokenProvider, grpcVersionSupport, batchRetriesConfig, autoBatchConfig);
   }
 
   public ObjectsBatchDeleter objectsBatchDeleter() {

--- a/src/test/java/io/weaviate/client/base/util/GrpcVersionSupportTest.java
+++ b/src/test/java/io/weaviate/client/base/util/GrpcVersionSupportTest.java
@@ -1,0 +1,71 @@
+package io.weaviate.client.base.util;
+
+import com.jparams.junit4.JParamsTestRunner;
+import com.jparams.junit4.data.DataMethod;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+@RunWith(JParamsTestRunner.class)
+public class GrpcVersionSupportTest {
+
+  private AutoCloseable openedMocks;
+  @InjectMocks
+  private GrpcVersionSupport grpcVersionProvider;
+  @Mock
+  private DbVersionProvider dbVersionProviderMock;
+
+  @Before
+  public void setUp() {
+    openedMocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    openedMocks.close();
+  }
+
+  @Test
+  @DataMethod(source = GrpcVersionSupportTest.class, method = "provideNotSupported")
+  public void shouldNotSupportVectorBytes(String dbVersion) {
+    Mockito.when(dbVersionProviderMock.getVersion()).thenReturn(dbVersion);
+
+    assertThat(grpcVersionProvider.supportsVectorBytesField()).isFalse();
+  }
+
+  public static Object[][] provideNotSupported() {
+    return new Object[][]{
+      {"0.11"},
+      {"1.13.9"},
+      {"1.22.0-rc.0"},
+      {"1.22.4"},
+      {"1.22.5"},
+    };
+  }
+
+  @Test
+  @DataMethod(source = GrpcVersionSupportTest.class, method = "provideSupported")
+  public void shouldSupportVectorBytes(String dbVersion) {
+    Mockito.when(dbVersionProviderMock.getVersion()).thenReturn(dbVersion);
+
+    assertThat(grpcVersionProvider.supportsVectorBytesField()).isTrue();
+  }
+
+  public static Object[][] provideSupported() {
+    return new Object[][]{
+      {"1.22.6"},
+      {"1.23.0-rc.0"},
+      {"1.23.10"},
+      {"1.30.1"},
+      {"1.31"},
+      {"2.31"},
+      {"10.11.12"},
+    };
+  }
+}

--- a/src/test/java/io/weaviate/integration/client/WeaviateContainer.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateContainer.java
@@ -1,0 +1,42 @@
+package io.weaviate.integration.client;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+public class WeaviateContainer {
+
+  public static class DockerContainer {
+    private final GenericContainer<?> container;
+
+    private DockerContainer(GenericContainer<?> container) {
+      this.container = container;
+    }
+
+    public void start() {
+      container.start();
+    }
+
+    public Integer getMappedPort(int originalPort) {
+      return container.getMappedPort(originalPort);
+    }
+
+    public void stop() {
+      container.stop();
+    }
+  }
+
+  public static DockerContainer create(String image) {
+    Map<String, String> env = new HashMap<>();
+    env.put("AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED", "true");
+    env.put("QUERY_DEFAULTS_LIMIT", "20");
+    env.put("PERSISTENCE_DATA_PATH", "./data");
+    env.put("DEFAULT_VECTORIZER_MODULE", "none");
+    GenericContainer<?> weaviate = new GenericContainer<>(image)
+      .withEnv(env)
+      .withExposedPorts(8080, 50051)
+      .waitingFor(Wait.forListeningPorts(8080, 50051));
+    return new DockerContainer(weaviate);
+  }
+}

--- a/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
@@ -3,9 +3,9 @@ package io.weaviate.integration.client;
 public class WeaviateVersion {
 
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_VERSION = "1.22.4";
+  public static final String EXPECTED_WEAVIATE_VERSION = "1.22.6";
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_GIT_HASH = "350f8c5";
+  public static final String EXPECTED_WEAVIATE_GIT_HASH = "0cc2d22";
 
   private WeaviateVersion() {}
 }

--- a/src/test/java/io/weaviate/integration/client/batch/ClientBatchGrpcVectorBytesTest.java
+++ b/src/test/java/io/weaviate/integration/client/batch/ClientBatchGrpcVectorBytesTest.java
@@ -1,0 +1,99 @@
+package io.weaviate.integration.client.batch;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.WeaviateClient;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.batch.model.ObjectGetResponse;
+import io.weaviate.client.v1.data.model.WeaviateObject;
+import io.weaviate.client.v1.schema.model.DataType;
+import io.weaviate.client.v1.schema.model.Property;
+import io.weaviate.client.v1.schema.model.WeaviateClass;
+import io.weaviate.integration.client.WeaviateContainer;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.ARRAY;
+import org.junit.Test;
+
+public class ClientBatchGrpcVectorBytesTest {
+
+  @Test
+  public void shouldSendVectorWith_v1_22_5() {
+    testWeaviate("semitechnologies/weaviate:1.22.5");
+  }
+
+  @Test
+  public void shouldSendVectorWith_v1_22_6() {
+    testWeaviate("semitechnologies/weaviate:1.22.6");
+  }
+
+  private void testWeaviate(String image) {
+    WeaviateContainer.DockerContainer container = WeaviateContainer.create(image);
+    try {
+      container.start();
+      // create client
+      Config config = new Config("http", "localhost:" + container.getMappedPort(8080));
+      config.setGRPCSecured(false);
+      config.setGRPCHost("localhost:" + container.getMappedPort(50051));
+      WeaviateClient client = new WeaviateClient(config);
+      // create schema
+      String className = "NoVectorizer";
+      List<Property> properties = Collections.singletonList(
+        Property.builder()
+          .name("name")
+          .dataType(Collections.singletonList(DataType.TEXT))
+          .build());
+      Result<Boolean> createResult = client.schema().classCreator()
+        .withClass(WeaviateClass.builder()
+          .className(className)
+          .properties(properties)
+          .build()
+        )
+        .run();
+      assertThat(createResult).isNotNull()
+        .returns(false, Result::hasErrors)
+        .returns(true, Result::getResult);
+      // create object
+      String id = "00000000-0000-0000-0000-000000000001";
+      Map<String, Object> props = new HashMap<>();
+      props.put("name", "some name");
+      Float[] vector = new Float[]{ 0.11f, 0.22f, 0.33f, 0.123f, -0.900009f, -0.0000000001f };
+      WeaviateObject obj = WeaviateObject.builder()
+        .id(id).className(className).properties(props).vector(vector)
+        .build();
+      Result<ObjectGetResponse[]> result = client.batch().objectsBatcher()
+        .withObjects(obj)
+        .run();
+      assertThat(result).isNotNull()
+        .returns(false, Result::hasErrors)
+        .extracting(Result::getResult).asInstanceOf(ARRAY)
+        .hasSize(1);
+      // fetch that object
+      Result<List<WeaviateObject>> resultObj = client.data().objectsGetter()
+        .withID(obj.getId()).withClassName(obj.getClassName()).withVector()
+        .run();
+      assertThat(resultObj).isNotNull()
+        .returns(false, Result::hasErrors)
+        .extracting(Result::getResult).isNotNull()
+        .extracting(r -> r.get(0)).isNotNull()
+        .satisfies(o -> {
+          assertThat(o.getId()).isEqualTo(obj.getId());
+          assertThat(o.getVector()).isNotEmpty().isEqualTo(vector);
+          assertThat(o.getProperties()).isNotNull()
+            .extracting(Map::size).isEqualTo(obj.getProperties().size());
+          obj.getProperties().keySet().forEach(propName -> {
+            assertThat(o.getProperties().get(propName)).isNotNull();
+          });
+        });
+      // clean up
+      Result<Boolean> delete = client.schema().classDeleter().withClassName(className).run();
+      assertThat(delete).isNotNull()
+        .returns(false, Result::hasErrors)
+        .extracting(Result::getResult).isEqualTo(Boolean.TRUE);
+    } finally {
+      container.stop();
+    }
+  }
+}

--- a/src/test/resources/docker-compose-azure.yaml
+++ b/src/test/resources/docker-compose-azure.yaml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.22.4
+    image: semitechnologies/weaviate:1.22.6
     restart: on-failure:0
     environment:
       PERSISTENCE_DATA_PATH: '/var/lib/weaviate'

--- a/src/test/resources/docker-compose-cluster.yaml
+++ b/src/test/resources/docker-compose-cluster.yaml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.22.4
+    image: semitechnologies/weaviate:1.22.6
     restart: on-failure:0
     environment:
       LOG_LEVEL: 'debug'
@@ -41,7 +41,7 @@ services:
       - '8088'
       - --scheme
       - http
-    image: semitechnologies/weaviate:1.22.4
+    image: semitechnologies/weaviate:1.22.6
     restart: on-failure:0
     environment:
       LOG_LEVEL: 'debug'

--- a/src/test/resources/docker-compose-okta-cc.yaml
+++ b/src/test/resources/docker-compose-okta-cc.yaml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.22.4
+    image: semitechnologies/weaviate:1.22.6
     restart: on-failure:0
     environment:
       PERSISTENCE_DATA_PATH: '/var/lib/weaviate'

--- a/src/test/resources/docker-compose-okta-users.yaml
+++ b/src/test/resources/docker-compose-okta-users.yaml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.22.4
+    image: semitechnologies/weaviate:1.22.6
     restart: on-failure:0
     environment:
       PERSISTENCE_DATA_PATH: '/var/lib/weaviate'

--- a/src/test/resources/docker-compose-proxy.yaml
+++ b/src/test/resources/docker-compose-proxy.yaml
@@ -9,7 +9,7 @@ services:
     - '8080'
     - --scheme
     - http
-    image: semitechnologies/weaviate:1.22.4
+    image: semitechnologies/weaviate:1.22.6
     restart: on-failure:0
     environment:
       LOG_LEVEL: "debug"

--- a/src/test/resources/docker-compose-test.yaml
+++ b/src/test/resources/docker-compose-test.yaml
@@ -9,7 +9,7 @@ services:
     - '8080'
     - --scheme
     - http
-    image: semitechnologies/weaviate:1.22.4
+    image: semitechnologies/weaviate:1.22.6
     links:
       - "contextionary:contextionary"
     restart: on-failure:0

--- a/src/test/resources/docker-compose-wcs.yaml
+++ b/src/test/resources/docker-compose-wcs.yaml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.22.4
+    image: semitechnologies/weaviate:1.22.6
     restart: on-failure:0
     environment:
       PERSISTENCE_DATA_PATH: '/var/lib/weaviate'


### PR DESCRIPTION
Starting of Weaviate `v1.22.6` version gRPC API introduced `vector_bytes` field in order to more efficiently send `vector`. This PR adds support for `vector_bytes` field.