### PR TITLE
Add support for multi target vector search

### DIFF
--- a/src/main/java/io/weaviate/client/v1/graphql/query/argument/HybridArgument.java
+++ b/src/main/java/io/weaviate/client/v1/graphql/query/argument/HybridArgument.java
@@ -27,7 +27,7 @@ public class HybridArgument implements Argument {
   String[] properties;
   String[] targetVectors;
   Searches searches;
-
+  Targets targets;
 
   @Override
   public String build() {
@@ -58,6 +58,9 @@ public class HybridArgument implements Argument {
         searchesArgs.add(searches.nearText.build());
       }
       arg.add(String.format("searches:{%s}", String.join(" ", searchesArgs)));
+    }
+    if (targets != null) {
+      arg.add(String.format("%s", targets.build()));
     }
 
     return String.format("hybrid:{%s}", String.join(" ", arg));

--- a/src/main/java/io/weaviate/client/v1/graphql/query/argument/NearAudioArgument.java
+++ b/src/main/java/io/weaviate/client/v1/graphql/query/argument/NearAudioArgument.java
@@ -21,6 +21,7 @@ public class NearAudioArgument implements Argument {
   Float certainty;
   Float distance;
   String[] targetVectors;
+  Targets targets;
 
   @Override
   public String build() {
@@ -30,6 +31,7 @@ public class NearAudioArgument implements Argument {
       .targetVectors(targetVectors)
       .data(audio)
       .dataFile(audioFile)
+      .targets(targets)
       .mediaField("audio")
       .mediaName("nearAudio")
       .build().build();

--- a/src/main/java/io/weaviate/client/v1/graphql/query/argument/NearDepthArgument.java
+++ b/src/main/java/io/weaviate/client/v1/graphql/query/argument/NearDepthArgument.java
@@ -21,6 +21,7 @@ public class NearDepthArgument implements Argument {
   Float certainty;
   Float distance;
   String[] targetVectors;
+  Targets targets;
 
   @Override
   public String build() {
@@ -30,6 +31,7 @@ public class NearDepthArgument implements Argument {
       .targetVectors(targetVectors)
       .data(depth)
       .dataFile(depthFile)
+      .targets(targets)
       .mediaField("depth")
       .mediaName("nearDepth")
       .build().build();

--- a/src/main/java/io/weaviate/client/v1/graphql/query/argument/NearImageArgument.java
+++ b/src/main/java/io/weaviate/client/v1/graphql/query/argument/NearImageArgument.java
@@ -21,6 +21,7 @@ public class NearImageArgument implements Argument {
   Float certainty;
   Float distance;
   String[] targetVectors;
+  Targets targets;
 
   @Override
   public String build() {
@@ -30,6 +31,7 @@ public class NearImageArgument implements Argument {
       .targetVectors(targetVectors)
       .data(image)
       .dataFile(imageFile)
+      .targets(targets)
       .mediaField("image")
       .mediaName("nearImage")
       .build().build();

--- a/src/main/java/io/weaviate/client/v1/graphql/query/argument/NearImuArgument.java
+++ b/src/main/java/io/weaviate/client/v1/graphql/query/argument/NearImuArgument.java
@@ -21,6 +21,7 @@ public class NearImuArgument implements Argument {
   Float certainty;
   Float distance;
   String[] targetVectors;
+  Targets targets;
 
   @Override
   public String build() {
@@ -30,6 +31,7 @@ public class NearImuArgument implements Argument {
       .targetVectors(targetVectors)
       .data(imu)
       .dataFile(imuFile)
+      .targets(targets)
       .mediaField("imu")
       .mediaName("nearIMU")
       .build().build();

--- a/src/main/java/io/weaviate/client/v1/graphql/query/argument/NearMediaArgumentHelper.java
+++ b/src/main/java/io/weaviate/client/v1/graphql/query/argument/NearMediaArgumentHelper.java
@@ -26,6 +26,7 @@ class NearMediaArgumentHelper {
   Float certainty;
   Float distance;
   String[] targetVectors;
+  Targets targets;
 
 
   public String build() {
@@ -43,6 +44,9 @@ class NearMediaArgumentHelper {
     }
     if (ArrayUtils.isNotEmpty(targetVectors)) {
       fields.add(String.format("targetVectors:%s",  Serializer.arrayWithQuotes(targetVectors)));
+    }
+    if (targets != null) {
+      fields.add(String.format("%s", targets.build()));
     }
 
     return String.format("%s:{%s}", mediaName, String.join(" ", fields));

--- a/src/main/java/io/weaviate/client/v1/graphql/query/argument/NearObjectArgument.java
+++ b/src/main/java/io/weaviate/client/v1/graphql/query/argument/NearObjectArgument.java
@@ -24,6 +24,7 @@ public class NearObjectArgument implements Argument {
   Float certainty;
   Float distance;
   String[] targetVectors;
+  Targets targets;
 
   @Override
   public String build() {
@@ -43,6 +44,9 @@ public class NearObjectArgument implements Argument {
     }
     if (ArrayUtils.isNotEmpty(targetVectors)) {
       arg.add(String.format("targetVectors:%s",  Serializer.arrayWithQuotes(targetVectors)));
+    }
+    if (targets != null) {
+      arg.add(String.format("%s", targets.build()));
     }
 
     return String.format("nearObject:{%s}", String.join(" ", arg));

--- a/src/main/java/io/weaviate/client/v1/graphql/query/argument/NearTextArgument.java
+++ b/src/main/java/io/weaviate/client/v1/graphql/query/argument/NearTextArgument.java
@@ -26,6 +26,7 @@ public class NearTextArgument implements Argument {
   NearTextMoveParameters moveAwayFrom;
   Boolean autocorrect;
   String[] targetVectors;
+  Targets targets;
 
   private String buildMoveParam(String name, NearTextMoveParameters moveParam) {
     Set<String> arg = new LinkedHashSet<>();
@@ -80,6 +81,9 @@ public class NearTextArgument implements Argument {
     }
     if (ArrayUtils.isNotEmpty(targetVectors)) {
       arg.add(String.format("targetVectors:%s",  Serializer.arrayWithQuotes(targetVectors)));
+    }
+    if (targets != null) {
+      arg.add(String.format("%s", targets.build()));
     }
 
     return String.format("nearText:{%s}", String.join(" ", arg));

--- a/src/main/java/io/weaviate/client/v1/graphql/query/argument/NearThermalArgument.java
+++ b/src/main/java/io/weaviate/client/v1/graphql/query/argument/NearThermalArgument.java
@@ -21,6 +21,7 @@ public class NearThermalArgument implements Argument {
   Float certainty;
   Float distance;
   String[] targetVectors;
+  Targets targets;
 
   @Override
   public String build() {
@@ -30,6 +31,7 @@ public class NearThermalArgument implements Argument {
       .targetVectors(targetVectors)
       .data(thermal)
       .dataFile(thermalFile)
+      .targets(targets)
       .mediaField("thermal")
       .mediaName("nearThermal")
       .build().build();

--- a/src/main/java/io/weaviate/client/v1/graphql/query/argument/NearVectorArgument.java
+++ b/src/main/java/io/weaviate/client/v1/graphql/query/argument/NearVectorArgument.java
@@ -1,6 +1,7 @@
 package io.weaviate.client.v1.graphql.query.argument;
 
 import io.weaviate.client.v1.graphql.query.util.Serializer;
+import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -23,6 +24,8 @@ public class NearVectorArgument implements Argument {
   Float certainty;
   Float distance;
   String[] targetVectors;
+  Map<String, Float[]> vectorPerTarget;
+  Targets targets;
 
   @Override
   public String build() {
@@ -39,6 +42,16 @@ public class NearVectorArgument implements Argument {
     }
     if (ArrayUtils.isNotEmpty(targetVectors)) {
       arg.add(String.format("targetVectors:%s",  Serializer.arrayWithQuotes(targetVectors)));
+    }
+    if (vectorPerTarget != null && !vectorPerTarget.isEmpty()) {
+      Set<String> vectorPerTargetArg = new LinkedHashSet<>();
+      for (Map.Entry<String, Float[]> entry : vectorPerTarget.entrySet()) {
+        vectorPerTargetArg.add(String.format("%s:%s", entry.getKey(), Serializer.array(entry.getValue())));
+      }
+      arg.add(String.format("vectorPerTarget:{%s}", String.join(" ", vectorPerTargetArg)));
+    }
+    if (targets != null) {
+      arg.add(String.format("%s", targets.build()));
     }
 
     return String.format("nearVector:{%s}", String.join(" ", arg));

--- a/src/main/java/io/weaviate/client/v1/graphql/query/argument/NearVideoArgument.java
+++ b/src/main/java/io/weaviate/client/v1/graphql/query/argument/NearVideoArgument.java
@@ -21,6 +21,7 @@ public class NearVideoArgument implements Argument {
   Float certainty;
   Float distance;
   String[] targetVectors;
+  Targets targets;
 
   @Override
   public String build() {
@@ -30,6 +31,7 @@ public class NearVideoArgument implements Argument {
       .targetVectors(targetVectors)
       .data(video)
       .dataFile(videoFile)
+      .targets(targets)
       .mediaField("video")
       .mediaName("nearVideo")
       .build().build();

--- a/src/main/java/io/weaviate/client/v1/graphql/query/argument/Targets.java
+++ b/src/main/java/io/weaviate/client/v1/graphql/query/argument/Targets.java
@@ -1,0 +1,64 @@
+package io.weaviate.client.v1.graphql.query.argument;
+
+import io.weaviate.client.v1.graphql.query.util.Serializer;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.FieldDefaults;
+import org.apache.commons.lang3.ArrayUtils;
+
+@Getter
+@Builder
+@ToString
+@EqualsAndHashCode
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+public class Targets {
+  CombinationMethod combinationMethod;
+  String[] targetVectors;
+  Map<String, Float> weights;
+
+  public enum CombinationMethod {
+    minimum("minimum"),
+    average("average"),
+    sum("sum"),
+    manualWeights("manualWeights"),
+    relativeScore("relativeScore");
+
+    private final String type;
+
+    CombinationMethod(String type) {
+      this.type = type;
+    }
+
+    @Override
+    public String toString() {
+      return type;
+    }
+  }
+
+  String build() {
+    Set<String> arg = new LinkedHashSet<>();
+
+    if (combinationMethod != null) {
+      arg.add(String.format("combinationMethod:%s", combinationMethod.name()));
+    }
+    if (ArrayUtils.isNotEmpty(targetVectors)) {
+      arg.add(String.format("targetVectors:%s", Serializer.arrayWithQuotes(targetVectors)));
+    }
+    if (weights != null && !weights.isEmpty()) {
+      Set<String> weightsArg = new LinkedHashSet<>();
+      for (Map.Entry<String, Float> entry : weights.entrySet()) {
+        weightsArg.add(String.format("%s:%s", entry.getKey(), entry.getValue()));
+      }
+      arg.add(String.format("weights:{%s}", String.join(" ", weightsArg)));
+    }
+
+    return String.format("targets:{%s}", String.join(" ", arg));
+  }
+}
+

--- a/src/test/java/io/weaviate/client/v1/graphql/query/argument/HybridArgumentTest.java
+++ b/src/test/java/io/weaviate/client/v1/graphql/query/argument/HybridArgumentTest.java
@@ -1,8 +1,9 @@
 package io.weaviate.client.v1.graphql.query.argument;
 
+import java.util.LinkedHashMap;
 import org.junit.Test;
 
- import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class HybridArgumentTest {
 
@@ -129,5 +130,25 @@ public class HybridArgumentTest {
     String str = hybrid.build();
 
     assertThat(str).isEqualTo("hybrid:{query:\"I'm a simple string\" searches:{nearText:{concepts:[\"concept\"] certainty:0.9}}}");
+  }
+
+  @Test
+  public void shouldCreateArgumentWithTargets() {
+    // given
+    LinkedHashMap<String, Float> weights = new LinkedHashMap<>();
+    weights.put("t1", 0.8f);
+    weights.put("t2", 0.2f);
+    Targets targets = Targets.builder()
+      .targetVectors(new String[]{ "t1", "t2" })
+      .combinationMethod(Targets.CombinationMethod.minimum)
+      .weights(weights)
+      .build();
+    HybridArgument hybrid = HybridArgument.builder()
+      .query("I'm a simple string").targets(targets)
+      .build();
+    // when
+    String str = hybrid.build();
+    // then
+    assertThat(str).isEqualTo("hybrid:{query:\"I'm a simple string\" targets:{combinationMethod:minimum targetVectors:[\"t1\",\"t2\"] weights:{t1:0.8 t2:0.2}}}");
   }
 }

--- a/src/test/java/io/weaviate/client/v1/graphql/query/argument/NearAudioArgumentTest.java
+++ b/src/test/java/io/weaviate/client/v1/graphql/query/argument/NearAudioArgumentTest.java
@@ -1,5 +1,6 @@
 package io.weaviate.client.v1.graphql.query.argument;
 
+import java.util.LinkedHashMap;
 import org.junit.Test;
 
 import java.io.File;
@@ -122,5 +123,29 @@ public class NearAudioArgumentTest {
       .build().build();
 
     assertThat(nearAudio).isEqualTo("nearAudio:{}");
+  }
+
+  @Test
+  public void shouldBuildFromBase64WithTargets() {
+    // given
+    LinkedHashMap<String, Float> weights = new LinkedHashMap<>();
+    weights.put("t1", 0.8f);
+    weights.put("t2", 0.2f);
+    Targets targets = Targets.builder()
+      .targetVectors(new String[]{ "t1", "t2" })
+      .combinationMethod(Targets.CombinationMethod.minimum)
+      .weights(weights)
+      .build();
+    NearTextArgument nearText = NearTextArgument.builder()
+      .concepts(new String[]{"concept"}).targets(targets).build();
+
+    String audioBase64 = "iVBORw0KGgoAAAANS";
+
+    String nearAudio = NearAudioArgument.builder()
+      .audio(audioBase64)
+      .targets(targets)
+      .build().build();
+
+    assertThat(nearAudio).isEqualTo(String.format("nearAudio:{audio:\"%s\" targets:{combinationMethod:minimum targetVectors:[\"t1\",\"t2\"] weights:{t1:0.8 t2:0.2}}}", audioBase64));
   }
 }

--- a/src/test/java/io/weaviate/client/v1/graphql/query/argument/NearDepthArgumentTest.java
+++ b/src/test/java/io/weaviate/client/v1/graphql/query/argument/NearDepthArgumentTest.java
@@ -1,5 +1,6 @@
 package io.weaviate.client.v1.graphql.query.argument;
 
+import java.util.LinkedHashMap;
 import org.junit.Test;
 
 import java.io.File;
@@ -122,5 +123,26 @@ public class NearDepthArgumentTest {
       .build().build();
 
     assertThat(nearDepth).isEqualTo("nearDepth:{}");
+  }
+
+  @Test
+  public void shouldBuildFromBase64WithTargets() {
+    LinkedHashMap<String, Float> weights = new LinkedHashMap<>();
+    weights.put("t1", 0.8f);
+    weights.put("t2", 0.2f);
+    Targets targets = Targets.builder()
+      .targetVectors(new String[]{ "t1", "t2" })
+      .combinationMethod(Targets.CombinationMethod.minimum)
+      .weights(weights)
+      .build();
+
+    String depthBase64 = "iVBORw0KGgoAAAANS";
+
+    String nearDepth = NearDepthArgument.builder()
+      .depth(depthBase64)
+      .targets(targets)
+      .build().build();
+
+    assertThat(nearDepth).isEqualTo(String.format("nearDepth:{depth:\"%s\" targets:{combinationMethod:minimum targetVectors:[\"t1\",\"t2\"] weights:{t1:0.8 t2:0.2}}}", depthBase64));
   }
 }

--- a/src/test/java/io/weaviate/client/v1/graphql/query/argument/NearImageArgumentTest.java
+++ b/src/test/java/io/weaviate/client/v1/graphql/query/argument/NearImageArgumentTest.java
@@ -1,5 +1,6 @@
 package io.weaviate.client.v1.graphql.query.argument;
 
+import java.util.LinkedHashMap;
 import org.junit.Test;
 
 import java.io.File;
@@ -122,5 +123,26 @@ public class NearImageArgumentTest {
       .build().build();
 
     assertThat(nearImage).isEqualTo("nearImage:{}");
+  }
+
+  @Test
+  public void shouldBuildFromBase64WithTargets() {
+    LinkedHashMap<String, Float> weights = new LinkedHashMap<>();
+    weights.put("t1", 0.8f);
+    weights.put("t2", 0.2f);
+    Targets targets = Targets.builder()
+      .targetVectors(new String[]{ "t1", "t2" })
+      .combinationMethod(Targets.CombinationMethod.average)
+      .weights(weights)
+      .build();
+
+    String imageBase64 = "iVBORw0KGgoAAAANS";
+
+    String nearImage = NearImageArgument.builder()
+      .image(imageBase64)
+      .targets(targets)
+      .build().build();
+
+    assertThat(nearImage).isEqualTo(String.format("nearImage:{image:\"%s\" targets:{combinationMethod:average targetVectors:[\"t1\",\"t2\"] weights:{t1:0.8 t2:0.2}}}", imageBase64));
   }
 }

--- a/src/test/java/io/weaviate/client/v1/graphql/query/argument/NearImuArgumentTest.java
+++ b/src/test/java/io/weaviate/client/v1/graphql/query/argument/NearImuArgumentTest.java
@@ -1,5 +1,6 @@
 package io.weaviate.client.v1.graphql.query.argument;
 
+import java.util.LinkedHashMap;
 import org.junit.Test;
 
 import java.io.File;
@@ -122,5 +123,26 @@ public class NearImuArgumentTest {
       .build().build();
 
     assertThat(nearImu).isEqualTo("nearIMU:{}");
+  }
+
+  @Test
+  public void shouldBuildFromBase64WithTargets() {
+    LinkedHashMap<String, Float> weights = new LinkedHashMap<>();
+    weights.put("t1", 0.8f);
+    weights.put("t2", 0.2f);
+    Targets targets = Targets.builder()
+      .targetVectors(new String[]{ "t1", "t2" })
+      .combinationMethod(Targets.CombinationMethod.sum)
+      .weights(weights)
+      .build();
+
+    String imuBase64 = "iVBORw0KGgoAAAANS";
+
+    String nearImu = NearImuArgument.builder()
+      .imu(imuBase64)
+      .targets(targets)
+      .build().build();
+
+    assertThat(nearImu).isEqualTo(String.format("nearIMU:{imu:\"%s\" targets:{combinationMethod:sum targetVectors:[\"t1\",\"t2\"] weights:{t1:0.8 t2:0.2}}}", imuBase64));
   }
 }

--- a/src/test/java/io/weaviate/client/v1/graphql/query/argument/NearMediaArgumentHelperTest.java
+++ b/src/test/java/io/weaviate/client/v1/graphql/query/argument/NearMediaArgumentHelperTest.java
@@ -1,5 +1,6 @@
 package io.weaviate.client.v1.graphql.query.argument;
 
+import java.util.LinkedHashMap;
 import org.junit.Test;
 
 import java.io.File;
@@ -151,5 +152,28 @@ public class NearMediaArgumentHelperTest {
       .build().build();
 
     assertThat(nearMedia).isEqualTo("nearMedia:{}");
+  }
+
+  @Test
+  public void shouldBuildFromBase64WithTargets() {
+    LinkedHashMap<String, Float> weights = new LinkedHashMap<>();
+    weights.put("t1", 0.8f);
+    weights.put("t2", 0.2f);
+    Targets targets = Targets.builder()
+      .targetVectors(new String[]{ "t1", "t2" })
+      .combinationMethod(Targets.CombinationMethod.manualWeights)
+      .weights(weights)
+      .build();
+
+    String mediaBase64 = "iVBORw0KGgoAAAANS";
+
+    String nearMedia = NearMediaArgumentHelper.builder()
+      .data(mediaBase64)
+      .mediaField("media")
+      .mediaName("nearMedia")
+      .targets(targets)
+      .build().build();
+
+    assertThat(nearMedia).isEqualTo(String.format("nearMedia:{media:\"%s\" targets:{combinationMethod:manualWeights targetVectors:[\"t1\",\"t2\"] weights:{t1:0.8 t2:0.2}}}", mediaBase64));
   }
 }

--- a/src/test/java/io/weaviate/client/v1/graphql/query/argument/NearMediaTargetsArgument.java
+++ b/src/test/java/io/weaviate/client/v1/graphql/query/argument/NearMediaTargetsArgument.java
@@ -1,0 +1,4 @@
+package io.weaviate.client.v1.graphql.query.argument;
+
+class NearMediaTargetsArgument {
+}

--- a/src/test/java/io/weaviate/client/v1/graphql/query/argument/NearObjectArgumentTest.java
+++ b/src/test/java/io/weaviate/client/v1/graphql/query/argument/NearObjectArgumentTest.java
@@ -1,5 +1,6 @@
 package io.weaviate.client.v1.graphql.query.argument;
 
+import java.util.LinkedHashMap;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -112,5 +113,25 @@ public class NearObjectArgumentTest {
       .build().build();
 
     assertThat(nearObject).isEqualTo("nearObject:{id:\"id\" beacon:\"beacon\" targetVectors:[\"vector1\"]}");
+  }
+
+  @Test
+  public void testBuildWithTargets() {
+    // given
+    LinkedHashMap<String, Float> weights = new LinkedHashMap<>();
+    weights.put("t1", 0.8f);
+    weights.put("t2", 0.2f);
+    Targets targets = Targets.builder()
+      .targetVectors(new String[]{ "t1", "t2" })
+      .combinationMethod(Targets.CombinationMethod.relativeScore)
+      .weights(weights)
+      .build();
+    NearObjectArgument nearObject = NearObjectArgument.builder()
+      .id("id").targets(targets)
+      .build();
+    // when
+    String arg = nearObject.build();
+    // then
+    assertEquals("nearObject:{id:\"id\" targets:{combinationMethod:relativeScore targetVectors:[\"t1\",\"t2\"] weights:{t1:0.8 t2:0.2}}}", arg);
   }
 }

--- a/src/test/java/io/weaviate/client/v1/graphql/query/argument/NearTextArgumentTest.java
+++ b/src/test/java/io/weaviate/client/v1/graphql/query/argument/NearTextArgumentTest.java
@@ -1,5 +1,6 @@
 package io.weaviate.client.v1.graphql.query.argument;
 
+import java.util.LinkedHashMap;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -623,5 +624,24 @@ public class NearTextArgumentTest {
       .build().build();
 
     assertThat(nearText).isEqualTo("nearText:{concepts:[\"a\",\"b\",\"c\"] targetVectors:[\"vector1\"]}");
+  }
+
+  @Test
+  public void testBuildWithTargets() {
+    // given
+    LinkedHashMap<String, Float> weights = new LinkedHashMap<>();
+    weights.put("t1", 0.8f);
+    weights.put("t2", 0.2f);
+    Targets targets = Targets.builder()
+      .targetVectors(new String[]{ "t1", "t2" })
+      .combinationMethod(Targets.CombinationMethod.minimum)
+      .weights(weights)
+      .build();
+    NearTextArgument nearText = NearTextArgument.builder()
+      .concepts(new String[]{"concept"}).targets(targets).build();
+    // when
+    String arg = nearText.build();
+    // then
+    assertEquals("nearText:{concepts:[\"concept\"] targets:{combinationMethod:minimum targetVectors:[\"t1\",\"t2\"] weights:{t1:0.8 t2:0.2}}}", arg);
   }
 }

--- a/src/test/java/io/weaviate/client/v1/graphql/query/argument/NearThermalArgumentTest.java
+++ b/src/test/java/io/weaviate/client/v1/graphql/query/argument/NearThermalArgumentTest.java
@@ -1,5 +1,6 @@
 package io.weaviate.client.v1.graphql.query.argument;
 
+import java.util.LinkedHashMap;
 import org.junit.Test;
 
 import java.io.File;
@@ -122,5 +123,26 @@ public class NearThermalArgumentTest {
       .build().build();
 
     assertThat(nearThermal).isEqualTo("nearThermal:{}");
+  }
+
+  @Test
+  public void shouldBuildFromBase64WithTargets() {
+    LinkedHashMap<String, Float> weights = new LinkedHashMap<>();
+    weights.put("t1", 0.8f);
+    weights.put("t2", 0.2f);
+    Targets targets = Targets.builder()
+      .targetVectors(new String[]{ "t1", "t2" })
+      .combinationMethod(Targets.CombinationMethod.minimum)
+      .weights(weights)
+      .build();
+
+    String thermalBase64 = "iVBORw0KGgoAAAANS";
+
+    String nearThermal = NearThermalArgument.builder()
+      .thermal(thermalBase64)
+      .targets(targets)
+      .build().build();
+
+    assertThat(nearThermal).isEqualTo(String.format("nearThermal:{thermal:\"%s\" targets:{combinationMethod:minimum targetVectors:[\"t1\",\"t2\"] weights:{t1:0.8 t2:0.2}}}", thermalBase64));
   }
 }

--- a/src/test/java/io/weaviate/client/v1/graphql/query/argument/NearVectorArgumentTest.java
+++ b/src/test/java/io/weaviate/client/v1/graphql/query/argument/NearVectorArgumentTest.java
@@ -1,5 +1,6 @@
 package io.weaviate.client.v1.graphql.query.argument;
 
+import java.util.LinkedHashMap;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,5 +48,29 @@ public class NearVectorArgumentTest {
       .build().build();
 
     assertThat(nearVector).isEqualTo("nearVector:{vector:[1.0,2.0,3.0] targetVectors:[\"vector1\"]}");
+  }
+
+  @Test
+  public void testBuildWithTargets() {
+    // given
+    LinkedHashMap<String, Float[]> vectorPerTarget = new LinkedHashMap<>();
+    vectorPerTarget.put("t1", new Float[]{1f, 2f, 3f});
+    vectorPerTarget.put("t2", new Float[]{.1f, .2f, .3f});
+    LinkedHashMap<String, Float> weights = new LinkedHashMap<>();
+    weights.put("t1", 0.8f);
+    weights.put("t2", 0.2f);
+    Targets targets = Targets.builder()
+      .targetVectors(new String[]{ "t1", "t2" })
+      .combinationMethod(Targets.CombinationMethod.sum)
+      .weights(weights)
+      .build();
+    NearVectorArgument nearVector = NearVectorArgument.builder()
+      .vectorPerTarget(vectorPerTarget)
+      .targets(targets)
+      .build();
+    // when
+    String arg = nearVector.build();
+    // then
+    assertEquals("nearVector:{vectorPerTarget:{t1:[1.0,2.0,3.0] t2:[0.1,0.2,0.3]} targets:{combinationMethod:sum targetVectors:[\"t1\",\"t2\"] weights:{t1:0.8 t2:0.2}}}", arg);
   }
 }

--- a/src/test/java/io/weaviate/client/v1/graphql/query/argument/NearVideoArgumentTest.java
+++ b/src/test/java/io/weaviate/client/v1/graphql/query/argument/NearVideoArgumentTest.java
@@ -1,5 +1,6 @@
 package io.weaviate.client.v1.graphql.query.argument;
 
+import java.util.LinkedHashMap;
 import org.junit.Test;
 
 import java.io.File;
@@ -122,5 +123,26 @@ public class NearVideoArgumentTest {
       .build().build();
 
     assertThat(nearVideo).isEqualTo("nearVideo:{}");
+  }
+
+  @Test
+  public void shouldBuildFromBase64WithTargets() {
+    LinkedHashMap<String, Float> weights = new LinkedHashMap<>();
+    weights.put("t1", 0.8f);
+    weights.put("t2", 0.2f);
+    Targets targets = Targets.builder()
+      .targetVectors(new String[]{ "t1", "t2" })
+      .combinationMethod(Targets.CombinationMethod.relativeScore)
+      .weights(weights)
+      .build();
+
+    String videoBase64 = "iVBORw0KGgoAAAANS";
+
+    String nearVideo = NearVideoArgument.builder()
+      .video(videoBase64)
+      .targets(targets)
+      .build().build();
+
+    assertThat(nearVideo).isEqualTo(String.format("nearVideo:{video:\"%s\" targets:{combinationMethod:relativeScore targetVectors:[\"t1\",\"t2\"] weights:{t1:0.8 t2:0.2}}}", videoBase64));
   }
 }

--- a/src/test/java/io/weaviate/client/v1/graphql/query/argument/TargetsTest.java
+++ b/src/test/java/io/weaviate/client/v1/graphql/query/argument/TargetsTest.java
@@ -1,0 +1,42 @@
+package io.weaviate.client.v1.graphql.query.argument;
+
+import java.util.LinkedHashMap;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class TargetsTest {
+
+  @Test
+  public void testBuild() {
+    // given
+    Targets targets = Targets.builder()
+      .targetVectors(new String[]{ "t1", "t2" })
+      .combinationMethod(Targets.CombinationMethod.average)
+      .build();
+    // when
+    String targetsStr = targets.build();
+    // then
+    assertNotNull(targetsStr);
+    assertEquals("targets:{combinationMethod:average targetVectors:[\"t1\",\"t2\"]}", targetsStr);
+  }
+
+  @Test
+  public void testBuildWithWeights() {
+    // given
+    LinkedHashMap<String, Float> weights = new LinkedHashMap<>();
+    weights.put("t1", 0.8f);
+    weights.put("t2", 0.2f);
+    Targets targets = Targets.builder()
+      .targetVectors(new String[]{ "t1", "t2" })
+      .combinationMethod(Targets.CombinationMethod.manualWeights)
+      .weights(weights)
+      .build();
+    // when
+    String targetsStr = targets.build();
+    // then
+    assertNotNull(targetsStr);
+    assertEquals("targets:{combinationMethod:manualWeights targetVectors:[\"t1\",\"t2\"] weights:{t1:0.8 t2:0.2}}", targetsStr);
+  }
+}

--- a/src/test/java/io/weaviate/integration/client/WeaviateDockerCompose.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateDockerCompose.java
@@ -43,6 +43,7 @@ public class WeaviateDockerCompose implements TestRule {
       if (withOffloadS3) {
         enableModules.add("offload-s3");
         withEnv("OFFLOAD_S3_ENDPOINT", "http://minio:9000");
+        withEnv("OFFLOAD_S3_BUCKET_AUTO_CREATE", "true");
         withEnv("AWS_ACCESS_KEY_ID", MinIO.USER);
         withEnv("AWS_SECRET_KEY", MinIO.PASSWORD);
       }

--- a/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
@@ -3,12 +3,12 @@ package io.weaviate.integration.client;
 public class WeaviateVersion {
 
   // docker image version
-  public static final String WEAVIATE_IMAGE = "preview-fix-license-compliance-issues-97ed59e";
+  public static final String WEAVIATE_IMAGE = "1.26.0-rc.1";
 
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_VERSION = "1.26.0-rc.0";
+  public static final String EXPECTED_WEAVIATE_VERSION = "1.26.0-rc.1";
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_GIT_HASH = "97ed59e";
+  public static final String EXPECTED_WEAVIATE_GIT_HASH = "1f9b2bf";
 
   private WeaviateVersion() {}
 }

--- a/src/test/java/io/weaviate/integration/client/graphql/ClientGraphQLMultiTargetSearchTest.java
+++ b/src/test/java/io/weaviate/integration/client/graphql/ClientGraphQLMultiTargetSearchTest.java
@@ -1,0 +1,319 @@
+package io.weaviate.integration.client.graphql;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.WeaviateClient;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.batch.model.ObjectGetResponse;
+import io.weaviate.client.v1.data.model.WeaviateObject;
+import io.weaviate.client.v1.graphql.model.GraphQLResponse;
+import io.weaviate.client.v1.graphql.query.argument.NearObjectArgument;
+import io.weaviate.client.v1.graphql.query.argument.NearTextArgument;
+import io.weaviate.client.v1.graphql.query.argument.NearVectorArgument;
+import io.weaviate.client.v1.graphql.query.argument.Targets;
+import io.weaviate.client.v1.graphql.query.fields.Field;
+import io.weaviate.client.v1.misc.model.BQConfig;
+import io.weaviate.client.v1.misc.model.PQConfig;
+import io.weaviate.client.v1.misc.model.SQConfig;
+import io.weaviate.client.v1.misc.model.VectorIndexConfig;
+import io.weaviate.client.v1.schema.model.DataType;
+import io.weaviate.client.v1.schema.model.Property;
+import io.weaviate.client.v1.schema.model.WeaviateClass;
+import io.weaviate.integration.client.WeaviateDockerCompose;
+import io.weaviate.integration.client.WeaviateVersion;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.ARRAY;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class ClientGraphQLMultiTargetSearchTest {
+  private WeaviateClient client;
+
+  private final String id1 = "00000000-0000-0000-0000-000000000001";
+  private final String id2 = "00000000-0000-0000-0000-000000000002";
+  private final String id3 = "00000000-0000-0000-0000-000000000003";
+
+  private final String titleAndContent = "titleAndContent";
+  private final String title1 = "title1";
+  private final String title2 = "title2";
+  private final String bringYourOwnVector = "bringYourOwnVector";
+  private final String bringYourOwnVector2 = "bringYourOwnVector2";
+
+  @ClassRule
+  public static WeaviateDockerCompose compose = new WeaviateDockerCompose(WeaviateVersion.WEAVIATE_IMAGE);
+
+  @Before
+  public void before() {
+    String httpHost = compose.getHttpHostAddress();
+    String grpcHost = compose.getGrpcHostAddress();
+    Config config = new Config("http", httpHost);
+    config.setGRPCSecured(false);
+    config.setGRPCHost(grpcHost);
+
+    client = new WeaviateClient(config);
+  }
+
+  @Test
+  public void shouldPerformMultiTargetSearch() throws InterruptedException {
+    String className = "MultiTargetSearch";
+    setupDB(className);
+    Field _additional = Field.builder()
+      .name("_additional")
+      .fields(new Field[]{ Field.builder().name("id").build(), Field.builder().name("distance").build() })
+      .build();
+    // nearText
+    Map<String, Float> weights = new HashMap<>();
+    weights.put(titleAndContent, 0.1f);
+    weights.put(title1, 0.6f);
+    weights.put(title2, 0.3f);
+    Targets targets = Targets.builder()
+      .targetVectors(new String[]{ titleAndContent, title1, title2 })
+      .combinationMethod(Targets.CombinationMethod.manualWeights)
+      .weights(weights)
+      .build();
+    NearTextArgument nearText = client.graphQL().arguments().nearTextArgBuilder()
+      .concepts(new String[]{ "Water black" })
+      .targets(targets)
+      .build();
+    Result<GraphQLResponse> response = client.graphQL().get()
+      .withClassName(className)
+      .withNearText(nearText)
+      .withFields(_additional)
+      .run();
+    assertGetContainsIds(response, className, id1, id2, id3);
+    // nearVector
+    Map<String, Float[]> vectorPerTarget = new HashMap<>();
+    vectorPerTarget.put(bringYourOwnVector, new Float[]{ .99f, .88f, .77f });
+    vectorPerTarget.put(bringYourOwnVector2, new Float[]{ .11f, .22f, .33f });
+    weights = new HashMap<>();
+    weights.put(bringYourOwnVector, 0.1f);
+    weights.put(bringYourOwnVector2, 0.6f);
+    targets = Targets.builder()
+      .targetVectors(new String[]{ bringYourOwnVector, bringYourOwnVector2 })
+      .combinationMethod(Targets.CombinationMethod.manualWeights)
+      .weights(weights)
+      .build();
+    NearVectorArgument nearVector = client.graphQL().arguments().nearVectorArgBuilder()
+      .vectorPerTarget(vectorPerTarget)
+      .targets(targets).build();
+    response = client.graphQL().get()
+      .withClassName(className)
+      .withNearVector(nearVector)
+      .withFields(_additional)
+      .run();
+    assertGetContainsIds(response, className, id2, id3);
+    // nearObject
+    targets = Targets.builder()
+      .targetVectors(new String[]{ bringYourOwnVector, bringYourOwnVector2, titleAndContent, title1, title2 })
+      .combinationMethod(Targets.CombinationMethod.average)
+      .build();
+    NearObjectArgument nearObject = client.graphQL().arguments().nearObjectArgBuilder()
+      .id(id3).targets(targets).build();
+    response = client.graphQL().get()
+      .withClassName(className)
+      .withNearObject(nearObject)
+      .withFields(_additional)
+      .run();
+    assertGetContainsIds(response, className, id2, id3);
+  }
+
+  private void setupDB(String className) {
+    // clean
+    Result<Boolean> delete = client.schema().allDeleter().run();
+    assertThat(delete).isNotNull()
+      .returns(false, Result::hasErrors)
+      .returns(true, Result::getResult);
+    // create class
+    List<Property> properties = Arrays.asList(
+      Property.builder()
+        .name("title")
+        .dataType(Collections.singletonList(DataType.TEXT))
+        .build(),
+      Property.builder()
+        .name("content")
+        .dataType(Collections.singletonList(DataType.TEXT))
+        .build(),
+      Property.builder()
+        .name("title1")
+        .dataType(Collections.singletonList(DataType.TEXT))
+        .build(),
+      Property.builder()
+        .name("title2")
+        .dataType(Collections.singletonList(DataType.TEXT))
+        .build());
+    Map<String, WeaviateClass.VectorConfig> vectorConfig = new HashMap<>();
+    vectorConfig.put(titleAndContent, getTitleAndContentVectorConfig());
+    vectorConfig.put(title1, getTitle1VectorConfig());
+    vectorConfig.put(title2, getTitle2VectorConfig());
+    vectorConfig.put(bringYourOwnVector, getBringYourOwnVectorVectorConfig());
+    vectorConfig.put(bringYourOwnVector2, getBringYourOwnVectorVectorConfig2());
+    Result<Boolean> createResult = client.schema().classCreator()
+      .withClass(WeaviateClass.builder()
+        .className(className)
+        .properties(properties)
+        .vectorConfig(vectorConfig)
+        .build()
+      )
+      .run();
+    assertThat(createResult).isNotNull()
+      .returns(false, Result::hasErrors)
+      .returns(true, Result::getResult);
+    // add data
+    // obj1
+    Map<String, Object> props1 = new HashMap<>();
+    props1.put("title", "The Lord of the Rings");
+    props1.put("content", "A great fantasy novel");
+    props1.put("title1", "J.R.R. Tolkien The Lord of the Rings");
+    props1.put("title2", "Rings");
+    Float[] vector1a = new Float[]{ 0.77f, 0.88f, 0.77f };
+    Map<String, Float[]> vectors1 = new HashMap<>();
+    vectors1.put("bringYourOwnVector", vector1a);
+    // don't add vector for bringYourOwnVector2
+    // obj2
+    Map<String, Object> props2 = new HashMap<>();
+    props2.put("title", "Black Oceans");
+    props2.put("content", "A great science fiction book");
+    props2.put("title1", "Jacek Dukaj Black Oceans");
+    props2.put("title2", "Water");
+    Float[] vector2a = new Float[]{ 0.11f, 0.22f, 0.33f };
+    Float[] vector2b = new Float[]{ 0.11f, 0.11f, 0.11f };
+    Map<String, Float[]> vectors2 = new HashMap<>();
+    vectors2.put("bringYourOwnVector", vector2a);
+    vectors2.put("bringYourOwnVector2", vector2b);
+    // obj2
+    Map<String, Object> props3 = new HashMap<>();
+    props3.put("title", "Into the Water");
+    props3.put("content", "New York Times bestseller and global phenomenon The Girl on the Train returns with Into the Water");
+    props3.put("title1", "Paula Hawkins Into the Water");
+    props3.put("title2", "Water go into it");
+    Float[] vector3a = new Float[]{ 0.99f, 0.88f, 0.77f };
+    Float[] vector3b = new Float[]{ 0.99f, 0.88f, 0.77f };
+    Map<String, Float[]> vectors3 = new HashMap<>();
+    vectors3.put("bringYourOwnVector", vector3a);
+    vectors3.put("bringYourOwnVector2", vector3b);
+
+    WeaviateObject obj1 = createObject(id1, className, props1, vectors1);
+    WeaviateObject obj2 = createObject(id2, className, props2, vectors2);
+    WeaviateObject obj3 = createObject(id3, className, props3, vectors3);
+
+    Result<ObjectGetResponse[]> result = client.batch().objectsBatcher()
+      .withObjects(obj1, obj2, obj3)
+      .run();
+    assertThat(result).isNotNull()
+      .returns(false, Result::hasErrors)
+      .extracting(Result::getResult).asInstanceOf(ARRAY)
+      .hasSize(3);
+  }
+
+  private WeaviateClass.VectorConfig getTitleAndContentVectorConfig() {
+    Map<String, Object> titleAndContent = new HashMap<>();
+    Map<String, Object> text2vecContextionarySettings = new HashMap<>();
+    text2vecContextionarySettings.put("vectorizeClassName", false);
+    text2vecContextionarySettings.put("properties", new String[]{ "title", "content" });
+    titleAndContent.put("text2vec-contextionary", text2vecContextionarySettings);
+    return getHNSWSQVectorConfig(titleAndContent);
+  }
+
+  private WeaviateClass.VectorConfig getTitle1VectorConfig() {
+    Map<String, Object> titleAndContent = new HashMap<>();
+    Map<String, Object> text2vecContextionarySettings = new HashMap<>();
+    text2vecContextionarySettings.put("vectorizeClassName", false);
+    text2vecContextionarySettings.put("properties", new String[]{ "title1" });
+    titleAndContent.put("text2vec-contextionary", text2vecContextionarySettings);
+    return getHNSWPQVectorConfig(titleAndContent);
+  }
+
+  private WeaviateClass.VectorConfig getTitle2VectorConfig() {
+    Map<String, Object> titleAndContent = new HashMap<>();
+    Map<String, Object> text2vecContextionarySettings = new HashMap<>();
+    text2vecContextionarySettings.put("vectorizeClassName", false);
+    text2vecContextionarySettings.put("properties", new String[]{ "title2" });
+    titleAndContent.put("text2vec-contextionary", text2vecContextionarySettings);
+    return getHNSWVectorConfig(titleAndContent);
+  }
+
+  private WeaviateClass.VectorConfig getBringYourOwnVectorVectorConfig() {
+    Map<String, Object> byov = new HashMap<>();
+    byov.put("none", new Object());
+    return getFlatBQVectorConfig(byov);
+  }
+
+  private WeaviateClass.VectorConfig getBringYourOwnVectorVectorConfig2() {
+    Map<String, Object> byov = new HashMap<>();
+    byov.put("none", new Object());
+    return getFlatVectorConfig(byov);
+  }
+
+  private WeaviateClass.VectorConfig getFlatBQVectorConfig(Map<String, Object> vectorizerConfig) {
+    return WeaviateClass.VectorConfig.builder()
+      .vectorIndexType("flat")
+      .vectorizer(vectorizerConfig)
+      .vectorIndexConfig(VectorIndexConfig.builder()
+        .bq(BQConfig.builder().enabled(true).build())
+        .build())
+      .build();
+  }
+
+  private WeaviateClass.VectorConfig getFlatVectorConfig(Map<String, Object> vectorizerConfig) {
+    return WeaviateClass.VectorConfig.builder()
+      .vectorIndexType("flat")
+      .vectorizer(vectorizerConfig)
+      .build();
+  }
+
+  private WeaviateClass.VectorConfig getHNSWVectorConfig(Map<String, Object> vectorizerConfig) {
+    return WeaviateClass.VectorConfig.builder()
+      .vectorIndexType("hnsw")
+      .vectorizer(vectorizerConfig)
+      .build();
+  }
+
+  private WeaviateClass.VectorConfig getHNSWPQVectorConfig(Map<String, Object> vectorizerConfig) {
+    return WeaviateClass.VectorConfig.builder()
+      .vectorIndexType("hnsw")
+      .vectorizer(vectorizerConfig)
+      .vectorIndexConfig(VectorIndexConfig.builder()
+        .pq(PQConfig.builder().enabled(true).build())
+        .build())
+      .build();
+  }
+
+  private WeaviateClass.VectorConfig getHNSWSQVectorConfig(Map<String, Object> vectorizerConfig) {
+    return WeaviateClass.VectorConfig.builder()
+      .vectorIndexType("hnsw")
+      .vectorizer(vectorizerConfig)
+      .vectorIndexConfig(VectorIndexConfig.builder()
+        .sq(SQConfig.builder().enabled(true).build())
+        .build())
+      .build();
+  }
+
+  private WeaviateObject createObject(String id, String className, Map<String, Object> props, Map<String, Float[]> vectors) {
+    WeaviateObject.WeaviateObjectBuilder obj = WeaviateObject.builder()
+      .id(id)
+      .className(className)
+      .properties(props);
+    if (vectors != null) {
+      obj = obj.vectors(vectors);
+    }
+    return obj.build();
+  }
+
+  private void assertGetContainsIds(Result<GraphQLResponse> response, String className, String... expectedIds) {
+    assertThat(response).isNotNull()
+      .returns(false, Result::hasErrors)
+      .extracting(Result::getResult).isNotNull()
+      .extracting(GraphQLResponse::getData).isInstanceOf(Map.class)
+      .extracting(data -> ((Map<String, Object>) data).get("Get")).isInstanceOf(Map.class)
+      .extracting(get -> ((Map<String, Object>) get).get(className)).isInstanceOf(List.class).asList()
+      .hasSize(expectedIds.length)
+      .extracting(obj -> ((Map<String, Object>) obj).get("_additional"))
+      .extracting(add -> ((Map<String, Object>) add).get("id"))
+      .containsExactlyInAnyOrder(expectedIds);
+  }
+}

--- a/src/test/java/io/weaviate/integration/client/schema/ClientSchemaTenantOffloadingTest.java
+++ b/src/test/java/io/weaviate/integration/client/schema/ClientSchemaTenantOffloadingTest.java
@@ -74,7 +74,7 @@ public class ClientSchemaTenantOffloadingTest {
     // update tenants to FROZEN
     updateTenantStatus(className, tenants, ActivityStatus.FROZEN);
     // verify tenant status FREEZING
-    verifyEventuallyTenantStatus(className, ActivityStatus.FREEZING);
+    verifyEventuallyTenantStatus(className, ActivityStatus.FROZEN);
     // verify tenants does not exist
     for (String tenant : tenants) {
       Result<List<WeaviateObject>> result = client.data().objectsGetter().withClassName(className).withTenant(tenant).run();


### PR DESCRIPTION
This PR adds multi target search capability to all `near<Media>` and `hybrid` arguments.