### PR TITLE
gql: Support maxVectorDistance parameter in hybrid search

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,12 +139,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-params</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-  </dependency>
-    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>weaviate</artifactId>
       <version>${testcontainers.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+  </dependency>
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>weaviate</artifactId>
       <version>${testcontainers.version}</version>

--- a/src/main/java/io/weaviate/client/v1/graphql/query/argument/HybridArgument.java
+++ b/src/main/java/io/weaviate/client/v1/graphql/query/argument/HybridArgument.java
@@ -3,16 +3,16 @@ package io.weaviate.client.v1.graphql.query.argument;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+
 import io.weaviate.client.v1.graphql.query.util.Serializer;
-import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.experimental.FieldDefaults;
-import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.lang3.StringUtils;
 
 @Getter
 @Builder
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 public class HybridArgument implements Argument {
   String query;
   Float alpha;
+  Float maxVectorDistance;
   Float[] vector;
   String fusionType;
   String[] properties;
@@ -40,6 +41,9 @@ public class HybridArgument implements Argument {
     if (alpha != null) {
       arg.add(String.format("alpha:%s", alpha));
     }
+    if (maxVectorDistance != null) {
+      arg.add(String.format("maxVectorDistance:%s", maxVectorDistance));
+    }
     if (ArrayUtils.isNotEmpty(properties)) {
       arg.add(String.format("properties:%s", Serializer.arrayWithQuotes(properties)));
     }
@@ -47,7 +51,7 @@ public class HybridArgument implements Argument {
       arg.add(String.format("fusionType:%s", fusionType));
     }
     if (ArrayUtils.isNotEmpty(targetVectors)) {
-      arg.add(String.format("targetVectors:%s",  Serializer.arrayWithQuotes(targetVectors)));
+      arg.add(String.format("targetVectors:%s", Serializer.arrayWithQuotes(targetVectors)));
     }
     if (searches != null && (searches.nearVector != null || searches.nearText != null)) {
       Set<String> searchesArgs = new LinkedHashSet<>();

--- a/src/test/java/io/weaviate/client/v1/graphql/query/argument/HybridArgumentTest.java
+++ b/src/test/java/io/weaviate/client/v1/graphql/query/argument/HybridArgumentTest.java
@@ -12,128 +12,120 @@ import com.jparams.junit4.data.DataMethod;
 
 @RunWith(JParamsTestRunner.class)
 public class HybridArgumentTest {
-        public static Object[][] provideTestCases() {
-                return new Object[][] {
-                                {
-                                                "simple query",
-                                                HybridArgument.builder()
-                                                                .query("I'm a simple string")
-                                                                .build(),
-                                                "hybrid:{query:\"I'm a simple string\"}"
-                                },
-                                {
-                                                "vector and alpha",
-                                                HybridArgument.builder()
-                                                                .query("I'm a simple string")
-                                                                .vector(new Float[] { .1f, .2f, .3f })
-                                                                .alpha(.567f)
-                                                                .build(),
-                                                "hybrid:{query:\"I'm a simple string\" vector:[0.1,0.2,0.3] alpha:0.567}"
-                                },
-                                {
-                                                "vector and target vectors",
-                                                HybridArgument.builder()
-                                                                .query("I'm a simple string")
-                                                                .vector(new Float[] { .1f, .2f, .3f })
-                                                                .targetVectors(new String[] { "vector1" })
-                                                                .build(),
-                                                "hybrid:{query:\"I'm a simple string\" vector:[0.1,0.2,0.3] targetVectors:[\"vector1\"]}"
-                                },
-                                {
-                                                "with escaped characters",
-                                                HybridArgument.builder()
-                                                                .query("\"I'm a complex string\" says the {'`:string:`'}")
-                                                                .build(),
-                                                "hybrid:{query:\"\\\"I'm a complex string\\\" says the {'`:string:`'}\"}"
-                                },
-                                {
-                                                "fusion type ranked",
-                                                HybridArgument.builder()
-                                                                .query("I'm a simple string")
-                                                                .fusionType(FusionType.RANKED)
-                                                                .build(),
-                                                "hybrid:{query:\"I'm a simple string\" fusionType:rankedFusion}"
-                                },
-                                {
-                                                "fusion type relative score",
-                                                HybridArgument.builder()
-                                                                .query("I'm a simple string")
-                                                                .fusionType(FusionType.RELATIVE_SCORE)
-                                                                .build(),
-                                                "hybrid:{query:\"I'm a simple string\" fusionType:relativeScoreFusion}"
-                                },
-                                {
-                                                "specify properties to search on",
-                                                HybridArgument.builder()
-                                                                .query("I'm a simple string")
-                                                                .properties(new String[] { "prop1", "prop2" })
-                                                                .build(),
-                                                "hybrid:{query:\"I'm a simple string\" properties:[\"prop1\",\"prop2\"]}"
-                                },
-                                {
-                                                "nearVector search",
-                                                HybridArgument.builder().query("I'm a simple string")
-                                                // @formatter:off
-                                                        .searches(HybridArgument.Searches.builder()
-                                                                .nearVector(NearVectorArgument.builder()
-                                                                        .vector(new Float[] {.1f, .2f, .3f })
-                                                                        .certainty(0.9f)
-                                                                        .build())
-                                                                .build())
-                                                // @formatter:on
-                                                                .build(),
-                                                "hybrid:{query:\"I'm a simple string\" searches:{nearVector:{vector:[0.1,0.2,0.3] certainty:0.9}}}"
-                                },
-                                {
-                                                "nearText search",
-                                                HybridArgument.builder().query("I'm a simple string")
-                                                // @formatter:off
-                                                        .searches(
-                                                                HybridArgument.Searches.builder().nearText(
-                                                                        NearTextArgument.builder()
-                                                                                .concepts(new String[] { "concept" })
-                                                                                .certainty(0.9f)
-                                                                                .build())
-                                                                        .build())
-                                                // @formatter:on
-                                                                .build(),
-                                                "hybrid:{query:\"I'm a simple string\" searches:{nearText:{concepts:[\"concept\"] certainty:0.9}}}"
-                                },
-                                {
-                                                "target vectors",
-                                                HybridArgument.builder().query("I'm a simple string")
-                                                                .targets(Targets.builder()
-                                                                // @formatter:off
-                                                                        .targetVectors(new String[] { "t1", "t2" })
-                                                                        .combinationMethod(Targets.CombinationMethod.minimum)
-                                                                        .weights(new LinkedHashMap<String, Float>() {{
-                                                                                put("t1", 0.8f);
-                                                                                put("t2", 0.2f);
-                                                                        }})
-                                                                        .build())
-                                                                // @formatter:on
-                                                                .build(),
-                                                "hybrid:{query:\"I'm a simple string\" targets:{combinationMethod:minimum targetVectors:[\"t1\",\"t2\"] weights:{t1:0.8 t2:0.2}}}"
-                                },
-                                {
-                                                "max vector distance",
-                                                HybridArgument.builder().query("I'm a simple string")
-                                                // @formatter:off
-                                                .searches(HybridArgument.Searches.builder().nearText(
-                                                        NearTextArgument.builder().concepts(new String[]{"concept"}).build()).build()
-                                                )
-                                                .maxVectorDistance(.5f)
-                                                // @formatter:on
-                                                                .build(),
-                                                "hybrid:{query:\"I'm a simple string\" maxVectorDistance:0.5 searches:{nearText:{concepts:[\"concept\"]}}}"
-                                }
-                };
-        }
+  public static Object[][] provideTestCases() {
+    return new Object[][]{
+      {
+        "simple query",
+        HybridArgument.builder()
+          .query("I'm a simple string")
+          .build(),
+        "hybrid:{query:\"I'm a simple string\"}"
+      },
+      {
+        "vector and alpha",
+        HybridArgument.builder()
+          .query("I'm a simple string")
+          .vector(new Float[]{ .1f, .2f, .3f })
+          .alpha(.567f)
+          .build(),
+        "hybrid:{query:\"I'm a simple string\" vector:[0.1,0.2,0.3] alpha:0.567}"
+      },
+      {
+        "vector and target vectors",
+        HybridArgument.builder()
+          .query("I'm a simple string")
+          .vector(new Float[]{ .1f, .2f, .3f })
+          .targetVectors(new String[]{ "vector1" })
+          .build(),
+        "hybrid:{query:\"I'm a simple string\" vector:[0.1,0.2,0.3] targetVectors:[\"vector1\"]}"
+      },
+      {
+        "with escaped characters",
+        HybridArgument.builder()
+          .query("\"I'm a complex string\" says the {'`:string:`'}")
+          .build(),
+        "hybrid:{query:\"\\\"I'm a complex string\\\" says the {'`:string:`'}\"}"
+      },
+      {
+        "fusion type ranked",
+        HybridArgument.builder()
+          .query("I'm a simple string")
+          .fusionType(FusionType.RANKED)
+          .build(),
+        "hybrid:{query:\"I'm a simple string\" fusionType:rankedFusion}"
+      },
+      {
+        "fusion type relative score",
+        HybridArgument.builder()
+          .query("I'm a simple string")
+          .fusionType(FusionType.RELATIVE_SCORE)
+          .build(),
+        "hybrid:{query:\"I'm a simple string\" fusionType:relativeScoreFusion}"
+      },
+      {
+        "specify properties to search on",
+        HybridArgument.builder()
+          .query("I'm a simple string")
+          .properties(new String[]{ "prop1", "prop2" })
+          .build(),
+        "hybrid:{query:\"I'm a simple string\" properties:[\"prop1\",\"prop2\"]}"
+      },
+      {
+        "nearVector search",
+        HybridArgument.builder().query("I'm a simple string")
+          .searches(HybridArgument.Searches.builder()
+            .nearVector(NearVectorArgument.builder()
+              .vector(new Float[]{ .1f, .2f, .3f })
+              .certainty(0.9f)
+              .build())
+            .build())
+          .build(),
+        "hybrid:{query:\"I'm a simple string\" searches:{nearVector:{vector:[0.1,0.2,0.3] certainty:0.9}}}"
+      },
+      {
+        "nearText search",
+        HybridArgument.builder().query("I'm a simple string")
+          .searches(
+            HybridArgument.Searches.builder().nearText(
+                NearTextArgument.builder()
+                  .concepts(new String[]{ "concept" })
+                  .certainty(0.9f)
+                  .build())
+              .build())
+          .build(),
+        "hybrid:{query:\"I'm a simple string\" searches:{nearText:{concepts:[\"concept\"] certainty:0.9}}}"
+      },
+      {
+        "target vectors",
+        HybridArgument.builder().query("I'm a simple string")
+          .targets(Targets.builder()
+            .targetVectors(new String[]{ "t1", "t2" })
+            .combinationMethod(Targets.CombinationMethod.minimum)
+            .weights(new LinkedHashMap<String, Float>() {{
+              put("t1", 0.8f);
+              put("t2", 0.2f);
+            }})
+            .build())
+          .build(),
+        "hybrid:{query:\"I'm a simple string\" targets:{combinationMethod:minimum targetVectors:[\"t1\",\"t2\"] weights:{t1:0.8 t2:0.2}}}"
+      },
+      {
+        "max vector distance",
+        HybridArgument.builder().query("I'm a simple string")
+          .searches(HybridArgument.Searches.builder().nearText(
+            NearTextArgument.builder().concepts(new String[]{ "concept" }).build()).build()
+          )
+          .maxVectorDistance(.5f)
+          .build(),
+        "hybrid:{query:\"I'm a simple string\" maxVectorDistance:0.5 searches:{nearText:{concepts:[\"concept\"]}}}"
+      }
+    };
+  }
 
-        @DataMethod(source = HybridArgumentTest.class, method = "provideTestCases")
-        @Test
-        public void test(String name, HybridArgument hybrid, String expected) throws Exception {
-                String actual = hybrid.build();
-                assertThat(actual).as(name).isEqualTo(expected);
-        }
+  @DataMethod(source = HybridArgumentTest.class, method = "provideTestCases")
+  @Test
+  public void test(String name, HybridArgument hybrid, String expected) throws Exception {
+    String actual = hybrid.build();
+    assertThat(actual).as(name).isEqualTo(expected);
+  }
 }

--- a/src/test/java/io/weaviate/client/v1/graphql/query/argument/HybridArgumentTest.java
+++ b/src/test/java/io/weaviate/client/v1/graphql/query/argument/HybridArgumentTest.java
@@ -3,79 +3,88 @@ package io.weaviate.client.v1.graphql.query.argument;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.LinkedHashMap;
-import java.util.stream.Stream;
 
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
+import com.jparams.junit4.JParamsTestRunner;
+import com.jparams.junit4.data.DataMethod;
+
+@RunWith(JParamsTestRunner.class)
 public class HybridArgumentTest {
-        static Stream<Arguments> testCases() {
-                return Stream.of(
-                                Arguments.of(
+        public static Object[][] provideTestCases() {
+                return new Object[][] {
+                                {
                                                 "simple query",
                                                 HybridArgument.builder()
                                                                 .query("I'm a simple string")
                                                                 .build(),
-                                                "hybrid:{query:\"I'm a simple string\"}"),
-                                Arguments.of(
+                                                "hybrid:{query:\"I'm a simple string\"}"
+                                },
+                                {
                                                 "vector and alpha",
                                                 HybridArgument.builder()
                                                                 .query("I'm a simple string")
                                                                 .vector(new Float[] { .1f, .2f, .3f })
                                                                 .alpha(.567f)
                                                                 .build(),
-                                                "hybrid:{query:\"I'm a simple string\" vector:[0.1,0.2,0.3] alpha:0.567}"),
-                                Arguments.of(
+                                                "hybrid:{query:\"I'm a simple string\" vector:[0.1,0.2,0.3] alpha:0.567}"
+                                },
+                                {
                                                 "vector and target vectors",
                                                 HybridArgument.builder()
                                                                 .query("I'm a simple string")
                                                                 .vector(new Float[] { .1f, .2f, .3f })
                                                                 .targetVectors(new String[] { "vector1" })
                                                                 .build(),
-                                                "hybrid:{query:\"I'm a simple string\" vector:[0.1,0.2,0.3] targetVectors:[\"vector1\"]}"),
-                                Arguments.of(
+                                                "hybrid:{query:\"I'm a simple string\" vector:[0.1,0.2,0.3] targetVectors:[\"vector1\"]}"
+                                },
+                                {
                                                 "with escaped characters",
                                                 HybridArgument.builder()
                                                                 .query("\"I'm a complex string\" says the {'`:string:`'}")
                                                                 .build(),
-                                                "hybrid:{query:\"\\\"I'm a complex string\\\" says the {'`:string:`'}\"}"),
-                                Arguments.of(
+                                                "hybrid:{query:\"\\\"I'm a complex string\\\" says the {'`:string:`'}\"}"
+                                },
+                                {
                                                 "fusion type ranked",
                                                 HybridArgument.builder()
                                                                 .query("I'm a simple string")
                                                                 .fusionType(FusionType.RANKED)
                                                                 .build(),
-                                                "hybrid:{query:\"I'm a simple string\" fusionType:rankedFusion}"),
-                                Arguments.of(
+                                                "hybrid:{query:\"I'm a simple string\" fusionType:rankedFusion}"
+                                },
+                                {
                                                 "fusion type relative score",
                                                 HybridArgument.builder()
                                                                 .query("I'm a simple string")
                                                                 .fusionType(FusionType.RELATIVE_SCORE)
                                                                 .build(),
-                                                "hybrid:{query:\"I'm a simple string\" fusionType:relativeScoreFusion}"),
-                                Arguments.of(
+                                                "hybrid:{query:\"I'm a simple string\" fusionType:relativeScoreFusion}"
+                                },
+                                {
                                                 "specify properties to search on",
                                                 HybridArgument.builder()
                                                                 .query("I'm a simple string")
                                                                 .properties(new String[] { "prop1", "prop2" })
                                                                 .build(),
-                                                "hybrid:{query:\"I'm a simple string\" properties:[\"prop1\",\"prop2\"]}"),
-                                Arguments.of(
+                                                "hybrid:{query:\"I'm a simple string\" properties:[\"prop1\",\"prop2\"]}"
+                                },
+                                {
                                                 "nearVector search",
                                                 HybridArgument.builder().query("I'm a simple string")
-                                                                .searches(HybridArgument.Searches.builder()
-                                                                                .nearVector(NearVectorArgument
-                                                                                                .builder()
-                                                                                                // @formatter:off
-                                                                                                .vector(new Float[] {.1f, .2f, .3f })
-                                                                                                // @formatter:on
-                                                                                                .certainty(0.9f)
-                                                                                                .build())
-                                                                                .build())
+                                                // @formatter:off
+                                                        .searches(HybridArgument.Searches.builder()
+                                                                .nearVector(NearVectorArgument.builder()
+                                                                        .vector(new Float[] {.1f, .2f, .3f })
+                                                                        .certainty(0.9f)
+                                                                        .build())
+                                                                .build())
+                                                // @formatter:on
                                                                 .build(),
-                                                "hybrid:{query:\"I'm a simple string\" searches:{nearVector:{vector:[0.1,0.2,0.3] certainty:0.9}}}"),
-                                Arguments.of(
+                                                "hybrid:{query:\"I'm a simple string\" searches:{nearVector:{vector:[0.1,0.2,0.3] certainty:0.9}}}"
+                                },
+                                {
                                                 "nearText search",
                                                 HybridArgument.builder().query("I'm a simple string")
                                                 // @formatter:off
@@ -88,8 +97,9 @@ public class HybridArgumentTest {
                                                                         .build())
                                                 // @formatter:on
                                                                 .build(),
-                                                "hybrid:{query:\"I'm a simple string\" searches:{nearText:{concepts:[\"concept\"] certainty:0.9}}}"),
-                                Arguments.of(
+                                                "hybrid:{query:\"I'm a simple string\" searches:{nearText:{concepts:[\"concept\"] certainty:0.9}}}"
+                                },
+                                {
                                                 "target vectors",
                                                 HybridArgument.builder().query("I'm a simple string")
                                                                 .targets(Targets.builder()
@@ -103,8 +113,9 @@ public class HybridArgumentTest {
                                                                         .build())
                                                                 // @formatter:on
                                                                 .build(),
-                                                "hybrid:{query:\"I'm a simple string\" targets:{combinationMethod:minimum targetVectors:[\"t1\",\"t2\"] weights:{t1:0.8 t2:0.2}}}"),
-                                Arguments.of(
+                                                "hybrid:{query:\"I'm a simple string\" targets:{combinationMethod:minimum targetVectors:[\"t1\",\"t2\"] weights:{t1:0.8 t2:0.2}}}"
+                                },
+                                {
                                                 "max vector distance",
                                                 HybridArgument.builder().query("I'm a simple string")
                                                 // @formatter:off
@@ -114,12 +125,14 @@ public class HybridArgumentTest {
                                                 .maxVectorDistance(.5f)
                                                 // @formatter:on
                                                                 .build(),
-                                                "hybrid:{query:\"I'm a simple string\" maxVectorDistance:0.5 searches:{nearText:{concepts:[\"concept\"]}}}"));
+                                                "hybrid:{query:\"I'm a simple string\" maxVectorDistance:0.5 searches:{nearText:{concepts:[\"concept\"]}}}"
+                                }
+                };
         }
 
-        @ParameterizedTest
-        @MethodSource("testCases")
-        void test(String name, HybridArgument hybrid, String expected) {
+        @DataMethod(source = HybridArgumentTest.class, method = "provideData")
+        @Test
+        public void test(String name, HybridArgument hybrid, String expected) throws Exception {
                 String actual = hybrid.build();
                 assertThat(actual).as(name).isEqualTo(expected);
         }

--- a/src/test/java/io/weaviate/client/v1/graphql/query/argument/HybridArgumentTest.java
+++ b/src/test/java/io/weaviate/client/v1/graphql/query/argument/HybridArgumentTest.java
@@ -103,7 +103,18 @@ public class HybridArgumentTest {
                                                                         .build())
                                                                 // @formatter:on
                                                                 .build(),
-                                                "hybrid:{query:\"I'm a simple string\" targets:{combinationMethod:minimum targetVectors:[\"t1\",\"t2\"] weights:{t1:0.8 t2:0.2}}}"));
+                                                "hybrid:{query:\"I'm a simple string\" targets:{combinationMethod:minimum targetVectors:[\"t1\",\"t2\"] weights:{t1:0.8 t2:0.2}}}"),
+                                Arguments.of(
+                                                "max vector distance",
+                                                HybridArgument.builder().query("I'm a simple string")
+                                                // @formatter:off
+                                                .searches(HybridArgument.Searches.builder().nearText(
+                                                        NearTextArgument.builder().concepts(new String[]{"concept"}).build()).build()
+                                                )
+                                                .maxVectorDistance(.5f)
+                                                // @formatter:on
+                                                                .build(),
+                                                "hybrid:{query:\"I'm a simple string\" maxVectorDistance:0.5 searches:{nearText:{concepts:[\"concept\"]}}}"));
         }
 
         @ParameterizedTest

--- a/src/test/java/io/weaviate/client/v1/graphql/query/argument/HybridArgumentTest.java
+++ b/src/test/java/io/weaviate/client/v1/graphql/query/argument/HybridArgumentTest.java
@@ -130,7 +130,7 @@ public class HybridArgumentTest {
                 };
         }
 
-        @DataMethod(source = HybridArgumentTest.class, method = "provideData")
+        @DataMethod(source = HybridArgumentTest.class, method = "provideTestCases")
         @Test
         public void test(String name, HybridArgument hybrid, String expected) throws Exception {
                 String actual = hybrid.build();

--- a/src/test/java/io/weaviate/client/v1/graphql/query/argument/HybridArgumentTest.java
+++ b/src/test/java/io/weaviate/client/v1/graphql/query/argument/HybridArgumentTest.java
@@ -1,154 +1,115 @@
 package io.weaviate.client.v1.graphql.query.argument;
 
-import java.util.LinkedHashMap;
-import org.junit.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.LinkedHashMap;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
 public class HybridArgumentTest {
+        static Stream<Arguments> testCases() {
+                return Stream.of(
+                                Arguments.of(
+                                                "simple query",
+                                                HybridArgument.builder()
+                                                                .query("I'm a simple string")
+                                                                .build(),
+                                                "hybrid:{query:\"I'm a simple string\"}"),
+                                Arguments.of(
+                                                "vector and alpha",
+                                                HybridArgument.builder()
+                                                                .query("I'm a simple string")
+                                                                .vector(new Float[] { .1f, .2f, .3f })
+                                                                .alpha(.567f)
+                                                                .build(),
+                                                "hybrid:{query:\"I'm a simple string\" vector:[0.1,0.2,0.3] alpha:0.567}"),
+                                Arguments.of(
+                                                "vector and target vectors",
+                                                HybridArgument.builder()
+                                                                .query("I'm a simple string")
+                                                                .vector(new Float[] { .1f, .2f, .3f })
+                                                                .targetVectors(new String[] { "vector1" })
+                                                                .build(),
+                                                "hybrid:{query:\"I'm a simple string\" vector:[0.1,0.2,0.3] targetVectors:[\"vector1\"]}"),
+                                Arguments.of(
+                                                "with escaped characters",
+                                                HybridArgument.builder()
+                                                                .query("\"I'm a complex string\" says the {'`:string:`'}")
+                                                                .build(),
+                                                "hybrid:{query:\"\\\"I'm a complex string\\\" says the {'`:string:`'}\"}"),
+                                Arguments.of(
+                                                "fusion type ranked",
+                                                HybridArgument.builder()
+                                                                .query("I'm a simple string")
+                                                                .fusionType(FusionType.RANKED)
+                                                                .build(),
+                                                "hybrid:{query:\"I'm a simple string\" fusionType:rankedFusion}"),
+                                Arguments.of(
+                                                "fusion type relative score",
+                                                HybridArgument.builder()
+                                                                .query("I'm a simple string")
+                                                                .fusionType(FusionType.RELATIVE_SCORE)
+                                                                .build(),
+                                                "hybrid:{query:\"I'm a simple string\" fusionType:relativeScoreFusion}"),
+                                Arguments.of(
+                                                "specify properties to search on",
+                                                HybridArgument.builder()
+                                                                .query("I'm a simple string")
+                                                                .properties(new String[] { "prop1", "prop2" })
+                                                                .build(),
+                                                "hybrid:{query:\"I'm a simple string\" properties:[\"prop1\",\"prop2\"]}"),
+                                Arguments.of(
+                                                "nearVector search",
+                                                HybridArgument.builder().query("I'm a simple string")
+                                                                .searches(HybridArgument.Searches.builder()
+                                                                                .nearVector(NearVectorArgument
+                                                                                                .builder()
+                                                                                                // @formatter:off
+                                                                                                .vector(new Float[] {.1f, .2f, .3f })
+                                                                                                // @formatter:on
+                                                                                                .certainty(0.9f)
+                                                                                                .build())
+                                                                                .build())
+                                                                .build(),
+                                                "hybrid:{query:\"I'm a simple string\" searches:{nearVector:{vector:[0.1,0.2,0.3] certainty:0.9}}}"),
+                                Arguments.of(
+                                                "nearText search",
+                                                HybridArgument.builder().query("I'm a simple string")
+                                                // @formatter:off
+                                                        .searches(
+                                                                HybridArgument.Searches.builder().nearText(
+                                                                        NearTextArgument.builder()
+                                                                                .concepts(new String[] { "concept" })
+                                                                                .certainty(0.9f)
+                                                                                .build())
+                                                                        .build())
+                                                // @formatter:on
+                                                                .build(),
+                                                "hybrid:{query:\"I'm a simple string\" searches:{nearText:{concepts:[\"concept\"] certainty:0.9}}}"),
+                                Arguments.of(
+                                                "target vectors",
+                                                HybridArgument.builder().query("I'm a simple string")
+                                                                .targets(Targets.builder()
+                                                                // @formatter:off
+                                                                        .targetVectors(new String[] { "t1", "t2" })
+                                                                        .combinationMethod(Targets.CombinationMethod.minimum)
+                                                                        .weights(new LinkedHashMap<String, Float>() {{
+                                                                                put("t1", 0.8f);
+                                                                                put("t2", 0.2f);
+                                                                        }})
+                                                                        .build())
+                                                                // @formatter:on
+                                                                .build(),
+                                                "hybrid:{query:\"I'm a simple string\" targets:{combinationMethod:minimum targetVectors:[\"t1\",\"t2\"] weights:{t1:0.8 t2:0.2}}}"));
+        }
 
-  @Test
-  public void shouldCreateArgument() {
-    HybridArgument hybrid = HybridArgument.builder()
-      .query("I'm a simple string")
-      .build();
-
-    String str = hybrid.build();
-
-    assertThat(str).isEqualTo("hybrid:{query:\"I'm a simple string\"}");
-  }
-
-  @Test
-  public void shouldCreateArgumentWithVectorAndAlpha() {
-    HybridArgument hybrid = HybridArgument.builder()
-      .query("I'm a simple string")
-      .vector(new Float[]{.1f, .2f, .3f})
-      .alpha(.567f)
-      .build();
-
-    String str = hybrid.build();
-
-    assertThat(str).isEqualTo("hybrid:{query:\"I'm a simple string\" " +
-      "vector:[0.1,0.2,0.3] " +
-      "alpha:0.567}");
-  }
-
-  @Test
-  public void shouldCreateArgumentWithVectorAndTargetVectors() {
-    HybridArgument hybrid = HybridArgument.builder()
-      .query("I'm a simple string")
-      .vector(new Float[]{.1f, .2f, .3f})
-      .targetVectors(new String[]{"vector1"})
-      .build();
-
-    String str = hybrid.build();
-
-    assertThat(str).isEqualTo("hybrid:{query:\"I'm a simple string\" " +
-      "vector:[0.1,0.2,0.3] " +
-      "targetVectors:[\"vector1\"]}");
-  }
-
-  @Test
-  public void shouldCreateArgumentWithChars() {
-    HybridArgument hybrid = HybridArgument.builder()
-      .query("\"I'm a complex string\" says the {'`:string:`'}")
-      .build();
-
-    String str = hybrid.build();
-
-    assertThat(str).isEqualTo("hybrid:{query:\"\\\"I'm a complex string\\\" says the {'`:string:`'}\"}");
-  }
-
-  @Test
-  public void shouldCreateArgumentWithFusionTypeRanked() {
-    HybridArgument hybrid = HybridArgument.builder()
-      .query("I'm a simple string")
-      .fusionType(FusionType.RANKED)
-      .build();
-
-    String str = hybrid.build();
-
-    assertThat(str).isEqualTo("hybrid:{query:\"I'm a simple string\" " +
-      "fusionType:rankedFusion}");
-  }
-
-  @Test
-  public void shouldCreateArgumentWithFusionTypeRelativeScore() {
-    HybridArgument hybrid = HybridArgument.builder()
-      .query("I'm a simple string")
-      .fusionType(FusionType.RELATIVE_SCORE)
-      .build();
-
-    String str = hybrid.build();
-
-    assertThat(str).isEqualTo("hybrid:{query:\"I'm a simple string\" " +
-      "fusionType:relativeScoreFusion}");
-  }
-
-  @Test
-  public void shouldCreateArgumentWithProperties() {
-    HybridArgument hybrid = HybridArgument.builder()
-      .query("I'm a simple string")
-      .properties(new String[]{"prop1", "prop2"})
-      .build();
-
-    String str = hybrid.build();
-
-    assertThat(str).isEqualTo("hybrid:{query:\"I'm a simple string\" " +
-      "properties:[\"prop1\",\"prop2\"]}");
-  }
-
-  @Test
-  public void shouldCreateArgumentWithNearVectorSearches() {
-    NearVectorArgument nearVector = NearVectorArgument.builder()
-      .vector(new Float[]{ .1f, .2f, .3f })
-      .certainty(0.9f)
-      .build();
-
-    HybridArgument hybrid = HybridArgument.builder()
-      .query("I'm a simple string")
-      .searches(HybridArgument.Searches.builder().nearVector(nearVector).build())
-      .build();
-
-    String str = hybrid.build();
-
-    assertThat(str).isEqualTo("hybrid:{query:\"I'm a simple string\" searches:{nearVector:{vector:[0.1,0.2,0.3] certainty:0.9}}}");
-  }
-
-  @Test
-  public void shouldCreateArgumentWithNearTextSearches() {
-    NearTextArgument nearText = NearTextArgument.builder()
-      .concepts(new String[]{"concept"})
-      .certainty(0.9f)
-      .build();
-
-    HybridArgument hybrid = HybridArgument.builder()
-      .query("I'm a simple string")
-      .searches(HybridArgument.Searches.builder().nearText(nearText).build())
-      .build();
-
-    String str = hybrid.build();
-
-    assertThat(str).isEqualTo("hybrid:{query:\"I'm a simple string\" searches:{nearText:{concepts:[\"concept\"] certainty:0.9}}}");
-  }
-
-  @Test
-  public void shouldCreateArgumentWithTargets() {
-    // given
-    LinkedHashMap<String, Float> weights = new LinkedHashMap<>();
-    weights.put("t1", 0.8f);
-    weights.put("t2", 0.2f);
-    Targets targets = Targets.builder()
-      .targetVectors(new String[]{ "t1", "t2" })
-      .combinationMethod(Targets.CombinationMethod.minimum)
-      .weights(weights)
-      .build();
-    HybridArgument hybrid = HybridArgument.builder()
-      .query("I'm a simple string").targets(targets)
-      .build();
-    // when
-    String str = hybrid.build();
-    // then
-    assertThat(str).isEqualTo("hybrid:{query:\"I'm a simple string\" targets:{combinationMethod:minimum targetVectors:[\"t1\",\"t2\"] weights:{t1:0.8 t2:0.2}}}");
-  }
+        @ParameterizedTest
+        @MethodSource("testCases")
+        void test(String name, HybridArgument hybrid, String expected) {
+                String actual = hybrid.build();
+                assertThat(actual).as(name).isEqualTo(expected);
+        }
 }


### PR DESCRIPTION
Closes #303

## What is changed?
- GraphQL query builder allows specifying `maxVectorDistance` parameter for hybrid search
- Rewrote `HybridArgumentTest.java` tests in the table-driven format

## How is this tested?
- New test case in `HybridArgumentTest.java`