### PR TITLE
data-type: Add missing blob enum

### DIFF
--- a/src/main/java/io/weaviate/client/v1/schema/model/DataType.java
+++ b/src/main/java/io/weaviate/client/v1/schema/model/DataType.java
@@ -17,6 +17,7 @@ public interface DataType {
   String PHONE_NUMBER = "phoneNumber";
   String UUID = "uuid";
   String OBJECT = "object";
+  String BLOB = "blob";
 
   /**
    * As of Weaviate v1.19 'string[]' is deprecated and replaced by 'text[]'.<br>


### PR DESCRIPTION
This PR adds the missing enum for the blob data type. Using the [python](https://github.com/weaviate/weaviate-python-client/blob/bcdeb277167ad4a009084fb291012779b8d4c757/weaviate/collections/classes/config.py#L118) and [TS](https://github.com/weaviate/typescript-client/blob/d88f6d2fee1eb1f364785b10c364ded794390fca/src/collections/configure/index.ts#L36) clients as a reference.  

The blob type does not support arrays