### PR TITLE
Support dynamic backup location

### DIFF
--- a/src/main/java/io/weaviate/client/v1/async/backup/api/BackupCanceler.java
+++ b/src/main/java/io/weaviate/client/v1/async/backup/api/BackupCanceler.java
@@ -1,8 +1,7 @@
 package io.weaviate.client.v1.async.backup.api;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.Future;
 
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
@@ -27,7 +26,7 @@ public class BackupCanceler extends AsyncBaseClient<Void>
   private String backend;
   private String backupId;
   private String bucket;
-  private String path;
+  private String backupPath;
 
 
   public BackupCanceler(CloseableHttpAsyncClient client, Config config, AccessTokenProvider tokenProvider) {
@@ -50,7 +49,7 @@ public class BackupCanceler extends AsyncBaseClient<Void>
   }
 
   public BackupCanceler withPath(String path) {
-    this.path = path;
+    this.backupPath = path;
     return this;
   }
 
@@ -59,15 +58,17 @@ public class BackupCanceler extends AsyncBaseClient<Void>
   public Future<Result<Void>> run(FutureCallback<Result<Void>> callback) {
     String path = String.format("/backups/%s/%s", UrlEncoder.encodePathParam(backend), UrlEncoder.encodePathParam(backupId));
 
-    List<String> queryParams = Arrays.asList(
-      UrlEncoder.encodeQueryParam("bucket", this.bucket),
-      UrlEncoder.encodeQueryParam("path", this.path)
-    );
-    queryParams.removeIf(Objects::isNull);
-    if (!queryParams.isEmpty()) {
-      path = path + "?" + String.join("&", queryParams);
+    List<String> queryParams = new ArrayList<>();
+    if (this.bucket != null){
+      queryParams.add(UrlEncoder.encodeQueryParam("bucket", this.bucket));
+    }
+    if (this.backupPath != null){
+      queryParams.add(UrlEncoder.encodeQueryParam("path", this.backupPath));
     }
 
+    if (!queryParams.isEmpty()) {
+      path += "?" + String.join("&", queryParams);
+    }
     return sendDeleteRequest(path, null, Void.class, callback);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/async/backup/api/BackupCanceler.java
+++ b/src/main/java/io/weaviate/client/v1/async/backup/api/BackupCanceler.java
@@ -1,17 +1,19 @@
 package io.weaviate.client.v1.async.backup.api;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+
 import io.weaviate.client.Config;
 import io.weaviate.client.base.AsyncBaseClient;
 import io.weaviate.client.base.AsyncClientResult;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.base.util.UrlEncoder;
 import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
-import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
-import org.apache.hc.core5.concurrent.FutureCallback;
-import org.apache.hc.core5.net.URIBuilder;
-
-import java.net.URISyntaxException;
-import java.util.concurrent.Future;
 
 /**
  * BackupCanceler can cancel an in-progress backup by ID.
@@ -56,13 +58,16 @@ public class BackupCanceler extends AsyncBaseClient<Void>
   @Override
   public Future<Result<Void>> run(FutureCallback<Result<Void>> callback) {
     String path = String.format("/backups/%s/%s", UrlEncoder.encodePathParam(backend), UrlEncoder.encodePathParam(backupId));
-    try {
-      path = new URIBuilder(path)
-      .addParameter("bucket", bucket)
-      .addParameter("path", this.path)
-      .toString();
-    } catch (URISyntaxException e) {
+
+    List<String> queryParams = Arrays.asList(
+      UrlEncoder.encodeQueryParam("bucket", this.bucket),
+      UrlEncoder.encodeQueryParam("path", this.path)
+    );
+    queryParams.removeIf(Objects::isNull);
+    if (!queryParams.isEmpty()) {
+      path = path + "?" + String.join("&", queryParams);
     }
+
     return sendDeleteRequest(path, null, Void.class, callback);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/async/backup/api/BackupCanceler.java
+++ b/src/main/java/io/weaviate/client/v1/async/backup/api/BackupCanceler.java
@@ -59,10 +59,10 @@ public class BackupCanceler extends AsyncBaseClient<Void>
     String path = String.format("/backups/%s/%s", UrlEncoder.encodePathParam(backend), UrlEncoder.encodePathParam(backupId));
 
     List<String> queryParams = new ArrayList<>();
-    if (this.bucket != null){
+    if (this.bucket != null) {
       queryParams.add(UrlEncoder.encodeQueryParam("bucket", this.bucket));
     }
-    if (this.backupPath != null){
+    if (this.backupPath != null) {
       queryParams.add(UrlEncoder.encodeQueryParam("path", this.backupPath));
     }
 

--- a/src/main/java/io/weaviate/client/v1/async/backup/api/BackupCanceler.java
+++ b/src/main/java/io/weaviate/client/v1/async/backup/api/BackupCanceler.java
@@ -8,7 +8,9 @@ import io.weaviate.client.base.util.UrlEncoder;
 import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.net.URIBuilder;
 
+import java.net.URISyntaxException;
 import java.util.concurrent.Future;
 
 /**
@@ -22,12 +24,13 @@ public class BackupCanceler extends AsyncBaseClient<Void>
 
   private String backend;
   private String backupId;
+  private String bucket;
+  private String path;
 
 
   public BackupCanceler(CloseableHttpAsyncClient client, Config config, AccessTokenProvider tokenProvider) {
     super(client, config, tokenProvider);
   }
-
 
   public BackupCanceler withBackend(String backend) {
     this.backend = backend;
@@ -39,10 +42,27 @@ public class BackupCanceler extends AsyncBaseClient<Void>
     return this;
   }
 
+  public BackupCanceler withBucket(String bucket) {
+    this.bucket = bucket;
+    return this;
+  }
+
+  public BackupCanceler withPath(String path) {
+    this.path = path;
+    return this;
+  }
+
 
   @Override
   public Future<Result<Void>> run(FutureCallback<Result<Void>> callback) {
     String path = String.format("/backups/%s/%s", UrlEncoder.encodePathParam(backend), UrlEncoder.encodePathParam(backupId));
+    try {
+      path = new URIBuilder(path)
+      .addParameter("bucket", bucket)
+      .addParameter("path", this.path)
+      .toString();
+    } catch (URISyntaxException e) {
+    }
     return sendDeleteRequest(path, null, Void.class, callback);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/async/backup/api/BackupCreateStatusGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/backup/api/BackupCreateStatusGetter.java
@@ -1,11 +1,12 @@
 package io.weaviate.client.v1.async.backup.api;
 
-import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Future;
 
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.core5.concurrent.FutureCallback;
-import org.apache.hc.core5.net.URIBuilder;
 
 import io.weaviate.client.Config;
 import io.weaviate.client.base.AsyncBaseClient;
@@ -51,13 +52,16 @@ public class BackupCreateStatusGetter extends AsyncBaseClient<BackupCreateStatus
   @Override
   public Future<Result<BackupCreateStatusResponse>> run(FutureCallback<Result<BackupCreateStatusResponse>> callback) {
     String path = String.format("/backups/%s/%s", UrlEncoder.encodePathParam(backend), UrlEncoder.encodePathParam(backupId));
-    try {
-      path =  new URIBuilder(path)
-      .addParameter("bucket", bucket)
-      .addParameter("path", this.path)
-      .toString();
-    } catch (URISyntaxException e) {
+
+    List<String> queryParams = Arrays.asList(
+      UrlEncoder.encodeQueryParam("bucket", this.bucket),
+      UrlEncoder.encodeQueryParam("path", this.path)
+    );
+    queryParams.removeIf(Objects::isNull);
+    if (!queryParams.isEmpty()) {
+      path = path + "?" + String.join("&", queryParams);
     }
+
     return sendGetRequest(path, BackupCreateStatusResponse.class, callback);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/async/backup/api/BackupCreateStatusGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/backup/api/BackupCreateStatusGetter.java
@@ -53,10 +53,10 @@ public class BackupCreateStatusGetter extends AsyncBaseClient<BackupCreateStatus
     String path = String.format("/backups/%s/%s", UrlEncoder.encodePathParam(backend), UrlEncoder.encodePathParam(backupId));
 
     List<String> queryParams = new ArrayList<>();
-    if (this.bucket != null){
+    if (this.bucket != null) {
       queryParams.add(UrlEncoder.encodeQueryParam("bucket", this.bucket));
     }
-    if (this.backupPath != null){
+    if (this.backupPath != null) {
       queryParams.add(UrlEncoder.encodeQueryParam("path", this.backupPath));
     }
 

--- a/src/main/java/io/weaviate/client/v1/async/backup/api/BackupCreateStatusGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/backup/api/BackupCreateStatusGetter.java
@@ -1,5 +1,12 @@
 package io.weaviate.client.v1.async.backup.api;
 
+import java.net.URISyntaxException;
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.net.URIBuilder;
+
 import io.weaviate.client.Config;
 import io.weaviate.client.base.AsyncBaseClient;
 import io.weaviate.client.base.AsyncClientResult;
@@ -7,17 +14,14 @@ import io.weaviate.client.base.Result;
 import io.weaviate.client.base.util.UrlEncoder;
 import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 import io.weaviate.client.v1.backup.model.BackupCreateStatusResponse;
-import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
-import org.apache.hc.core5.concurrent.FutureCallback;
-
-import java.util.concurrent.Future;
 
 public class BackupCreateStatusGetter extends AsyncBaseClient<BackupCreateStatusResponse>
   implements AsyncClientResult<BackupCreateStatusResponse> {
 
   private String backend;
   private String backupId;
-
+  private String bucket;
+  private String path;
 
   public BackupCreateStatusGetter(CloseableHttpAsyncClient client, Config config, AccessTokenProvider tokenProvider) {
     super(client, config, tokenProvider);
@@ -34,9 +38,26 @@ public class BackupCreateStatusGetter extends AsyncBaseClient<BackupCreateStatus
     return this;
   }
 
+  public BackupCreateStatusGetter withBucket(String bucket) {
+    this.bucket = bucket;
+    return this;
+  }
+
+  public BackupCreateStatusGetter withPath(String path) {
+    this.path = path;
+    return this;
+  }
+
   @Override
   public Future<Result<BackupCreateStatusResponse>> run(FutureCallback<Result<BackupCreateStatusResponse>> callback) {
     String path = String.format("/backups/%s/%s", UrlEncoder.encodePathParam(backend), UrlEncoder.encodePathParam(backupId));
+    try {
+      path =  new URIBuilder(path)
+      .addParameter("bucket", bucket)
+      .addParameter("path", this.path)
+      .toString();
+    } catch (URISyntaxException e) {
+    }
     return sendGetRequest(path, BackupCreateStatusResponse.class, callback);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/async/backup/api/BackupCreateStatusGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/backup/api/BackupCreateStatusGetter.java
@@ -1,8 +1,7 @@
 package io.weaviate.client.v1.async.backup.api;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.Future;
 
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
@@ -22,7 +21,7 @@ public class BackupCreateStatusGetter extends AsyncBaseClient<BackupCreateStatus
   private String backend;
   private String backupId;
   private String bucket;
-  private String path;
+  private String backupPath;
 
   public BackupCreateStatusGetter(CloseableHttpAsyncClient client, Config config, AccessTokenProvider tokenProvider) {
     super(client, config, tokenProvider);
@@ -45,7 +44,7 @@ public class BackupCreateStatusGetter extends AsyncBaseClient<BackupCreateStatus
   }
 
   public BackupCreateStatusGetter withPath(String path) {
-    this.path = path;
+    this.backupPath = path;
     return this;
   }
 
@@ -53,15 +52,17 @@ public class BackupCreateStatusGetter extends AsyncBaseClient<BackupCreateStatus
   public Future<Result<BackupCreateStatusResponse>> run(FutureCallback<Result<BackupCreateStatusResponse>> callback) {
     String path = String.format("/backups/%s/%s", UrlEncoder.encodePathParam(backend), UrlEncoder.encodePathParam(backupId));
 
-    List<String> queryParams = Arrays.asList(
-      UrlEncoder.encodeQueryParam("bucket", this.bucket),
-      UrlEncoder.encodeQueryParam("path", this.path)
-    );
-    queryParams.removeIf(Objects::isNull);
-    if (!queryParams.isEmpty()) {
-      path = path + "?" + String.join("&", queryParams);
+    List<String> queryParams = new ArrayList<>();
+    if (this.bucket != null){
+      queryParams.add(UrlEncoder.encodeQueryParam("bucket", this.bucket));
+    }
+    if (this.backupPath != null){
+      queryParams.add(UrlEncoder.encodeQueryParam("path", this.backupPath));
     }
 
+    if (!queryParams.isEmpty()) {
+      path += "?" + String.join("&", queryParams);
+    }
     return sendGetRequest(path, BackupCreateStatusResponse.class, callback);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/async/backup/api/BackupCreator.java
+++ b/src/main/java/io/weaviate/client/v1/async/backup/api/BackupCreator.java
@@ -242,6 +242,10 @@ public class BackupCreator extends AsyncBaseClient<BackupCreateResponse>
     Integer chunkSize;
     @SerializedName("CompressionLevel")
     String compressionLevel;
+    @SerializedName("Bucket")
+    String bucket;
+    @SerializedName("Path")
+    String path;
   }
 
   public interface BackupCompression {

--- a/src/main/java/io/weaviate/client/v1/async/backup/api/BackupRestoreStatusGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/backup/api/BackupRestoreStatusGetter.java
@@ -53,10 +53,10 @@ public class BackupRestoreStatusGetter extends AsyncBaseClient<BackupRestoreStat
     String path = String.format("/backups/%s/%s/restore", UrlEncoder.encodePathParam(backend), UrlEncoder.encodePathParam(backupId));
 
     List<String> queryParams = new ArrayList<>();
-    if (this.bucket != null){
+    if (this.bucket != null) {
       queryParams.add(UrlEncoder.encodeQueryParam("bucket", this.bucket));
     }
-    if (this.backupPath != null){
+    if (this.backupPath != null) {
       queryParams.add(UrlEncoder.encodeQueryParam("path", this.backupPath));
     }
 

--- a/src/main/java/io/weaviate/client/v1/async/backup/api/BackupRestoreStatusGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/backup/api/BackupRestoreStatusGetter.java
@@ -1,5 +1,13 @@
 package io.weaviate.client.v1.async.backup.api;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+
 import io.weaviate.client.Config;
 import io.weaviate.client.base.AsyncBaseClient;
 import io.weaviate.client.base.AsyncClientResult;
@@ -7,12 +15,6 @@ import io.weaviate.client.base.Result;
 import io.weaviate.client.base.util.UrlEncoder;
 import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 import io.weaviate.client.v1.backup.model.BackupRestoreStatusResponse;
-import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
-import org.apache.hc.core5.concurrent.FutureCallback;
-import org.apache.hc.core5.net.URIBuilder;
-
-import java.net.URISyntaxException;
-import java.util.concurrent.Future;
 
 public class BackupRestoreStatusGetter extends AsyncBaseClient<BackupRestoreStatusResponse>
   implements AsyncClientResult<BackupRestoreStatusResponse> {
@@ -50,13 +52,16 @@ public class BackupRestoreStatusGetter extends AsyncBaseClient<BackupRestoreStat
   @Override
   public Future<Result<BackupRestoreStatusResponse>> run(FutureCallback<Result<BackupRestoreStatusResponse>> callback) {
     String path = String.format("/backups/%s/%s/restore", UrlEncoder.encodePathParam(backend), UrlEncoder.encodePathParam(backupId));
-     try {
-      path = new URIBuilder(path)
-      .addParameter("bucket", bucket)
-      .addParameter("path", this.path)
-      .toString();
-    } catch (URISyntaxException e) {
+
+    List<String> queryParams = Arrays.asList(
+      UrlEncoder.encodeQueryParam("bucket", this.bucket),
+      UrlEncoder.encodeQueryParam("path", this.path)
+    );
+    queryParams.removeIf(Objects::isNull);
+    if (!queryParams.isEmpty()) {
+      path = path + "?" + String.join("&", queryParams);
     }
+
     return sendGetRequest(path, BackupRestoreStatusResponse.class, callback);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/async/backup/api/BackupRestoreStatusGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/backup/api/BackupRestoreStatusGetter.java
@@ -9,7 +9,9 @@ import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 import io.weaviate.client.v1.backup.model.BackupRestoreStatusResponse;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.net.URIBuilder;
 
+import java.net.URISyntaxException;
 import java.util.concurrent.Future;
 
 public class BackupRestoreStatusGetter extends AsyncBaseClient<BackupRestoreStatusResponse>
@@ -17,7 +19,8 @@ public class BackupRestoreStatusGetter extends AsyncBaseClient<BackupRestoreStat
 
   private String backend;
   private String backupId;
-
+  private String bucket;
+  private String path;
 
   public BackupRestoreStatusGetter(CloseableHttpAsyncClient client, Config config, AccessTokenProvider tokenProvider) {
     super(client, config, tokenProvider);
@@ -34,10 +37,26 @@ public class BackupRestoreStatusGetter extends AsyncBaseClient<BackupRestoreStat
     return this;
   }
 
+  public BackupRestoreStatusGetter withBucket(String bucket) {
+    this.bucket = bucket;
+    return this;
+  }
+
+  public BackupRestoreStatusGetter withPath(String path) {
+    this.path = path;
+    return this;
+  }
 
   @Override
   public Future<Result<BackupRestoreStatusResponse>> run(FutureCallback<Result<BackupRestoreStatusResponse>> callback) {
     String path = String.format("/backups/%s/%s/restore", UrlEncoder.encodePathParam(backend), UrlEncoder.encodePathParam(backupId));
+     try {
+      path = new URIBuilder(path)
+      .addParameter("bucket", bucket)
+      .addParameter("path", this.path)
+      .toString();
+    } catch (URISyntaxException e) {
+    }
     return sendGetRequest(path, BackupRestoreStatusResponse.class, callback);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/async/backup/api/BackupRestoreStatusGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/backup/api/BackupRestoreStatusGetter.java
@@ -1,8 +1,7 @@
 package io.weaviate.client.v1.async.backup.api;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.Future;
 
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
@@ -22,7 +21,7 @@ public class BackupRestoreStatusGetter extends AsyncBaseClient<BackupRestoreStat
   private String backend;
   private String backupId;
   private String bucket;
-  private String path;
+  private String backupPath;
 
   public BackupRestoreStatusGetter(CloseableHttpAsyncClient client, Config config, AccessTokenProvider tokenProvider) {
     super(client, config, tokenProvider);
@@ -45,7 +44,7 @@ public class BackupRestoreStatusGetter extends AsyncBaseClient<BackupRestoreStat
   }
 
   public BackupRestoreStatusGetter withPath(String path) {
-    this.path = path;
+    this.backupPath = path;
     return this;
   }
 
@@ -53,15 +52,17 @@ public class BackupRestoreStatusGetter extends AsyncBaseClient<BackupRestoreStat
   public Future<Result<BackupRestoreStatusResponse>> run(FutureCallback<Result<BackupRestoreStatusResponse>> callback) {
     String path = String.format("/backups/%s/%s/restore", UrlEncoder.encodePathParam(backend), UrlEncoder.encodePathParam(backupId));
 
-    List<String> queryParams = Arrays.asList(
-      UrlEncoder.encodeQueryParam("bucket", this.bucket),
-      UrlEncoder.encodeQueryParam("path", this.path)
-    );
-    queryParams.removeIf(Objects::isNull);
-    if (!queryParams.isEmpty()) {
-      path = path + "?" + String.join("&", queryParams);
+    List<String> queryParams = new ArrayList<>();
+    if (this.bucket != null){
+      queryParams.add(UrlEncoder.encodeQueryParam("bucket", this.bucket));
+    }
+    if (this.backupPath != null){
+      queryParams.add(UrlEncoder.encodeQueryParam("path", this.backupPath));
     }
 
+    if (!queryParams.isEmpty()) {
+      path += "?" + String.join("&", queryParams);
+    }
     return sendGetRequest(path, BackupRestoreStatusResponse.class, callback);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/async/backup/api/BackupRestorer.java
+++ b/src/main/java/io/weaviate/client/v1/async/backup/api/BackupRestorer.java
@@ -237,5 +237,9 @@ public class BackupRestorer extends AsyncBaseClient<BackupRestoreResponse>
   public static class BackupRestoreConfig {
     @SerializedName("CPUPercentage")
     Integer cpuPercentage;
+    @SerializedName("Bucket")
+    String bucket;
+    @SerializedName("Path")
+    String path;
   }
 }

--- a/src/main/java/io/weaviate/client/v1/backup/api/BackupCanceler.java
+++ b/src/main/java/io/weaviate/client/v1/backup/api/BackupCanceler.java
@@ -1,8 +1,8 @@
 package io.weaviate.client.v1.backup.api;
 
-import java.net.URISyntaxException;
-
-import org.apache.hc.core5.net.URIBuilder;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 
 import io.weaviate.client.Config;
 import io.weaviate.client.base.BaseClient;
@@ -10,6 +10,7 @@ import io.weaviate.client.base.ClientResult;
 import io.weaviate.client.base.Response;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.base.util.UrlEncoder;
 
 /**
  * BackupCanceler can cancel an in-progress backup by ID.
@@ -55,14 +56,17 @@ public class BackupCanceler extends BaseClient<Void> implements ClientResult<Voi
 
   private String path() {
     String base = String.format("/backups/%s/%s", backend, backupId);
-    try {
-      return new URIBuilder(base)
-      .addParameter("bucket", bucket)
-      .addParameter("path", path)
-      .toString();
-    } catch (URISyntaxException e) {
-      return base;
+
+    List<String> queryParams = Arrays.asList(
+      UrlEncoder.encodeQueryParam("bucket", this.bucket),
+      UrlEncoder.encodeQueryParam("path", this.path)
+    );
+    queryParams.removeIf(Objects::isNull);
+    if (!queryParams.isEmpty()) {
+      base = base + "?" + String.join("&", queryParams);
     }
+
+    return base;
   }
 }
 

--- a/src/main/java/io/weaviate/client/v1/backup/api/BackupCanceler.java
+++ b/src/main/java/io/weaviate/client/v1/backup/api/BackupCanceler.java
@@ -1,8 +1,7 @@
 package io.weaviate.client.v1.backup.api;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import io.weaviate.client.Config;
 import io.weaviate.client.base.BaseClient;
@@ -22,7 +21,7 @@ public class BackupCanceler extends BaseClient<Void> implements ClientResult<Voi
   private String backend;
   private String backupId;
   private String bucket;
-  private String path;
+  private String backupPath;
 
   public BackupCanceler(HttpClient client, Config config) {
     super(client, config);
@@ -39,7 +38,7 @@ public class BackupCanceler extends BaseClient<Void> implements ClientResult<Voi
   }
 
   public BackupCanceler withPath(String path) {
-    this.path = path;
+    this.backupPath = path;
     return this;
   }
 
@@ -55,18 +54,20 @@ public class BackupCanceler extends BaseClient<Void> implements ClientResult<Voi
   }
 
   private String path() {
-    String base = String.format("/backups/%s/%s", backend, backupId);
+    String path = String.format("/backups/%s/%s", backend, backupId);
 
-    List<String> queryParams = Arrays.asList(
-      UrlEncoder.encodeQueryParam("bucket", this.bucket),
-      UrlEncoder.encodeQueryParam("path", this.path)
-    );
-    queryParams.removeIf(Objects::isNull);
-    if (!queryParams.isEmpty()) {
-      base = base + "?" + String.join("&", queryParams);
+    List<String> queryParams = new ArrayList<>();
+    if (this.bucket != null){
+      queryParams.add(UrlEncoder.encodeQueryParam("bucket", this.bucket));
+    }
+    if (this.backupPath != null){
+      queryParams.add(UrlEncoder.encodeQueryParam("path", this.backupPath));
     }
 
-    return base;
+    if (!queryParams.isEmpty()) {
+      path += "?" + String.join("&", queryParams);
+    }
+    return path;
   }
 }
 

--- a/src/main/java/io/weaviate/client/v1/backup/api/BackupCanceler.java
+++ b/src/main/java/io/weaviate/client/v1/backup/api/BackupCanceler.java
@@ -1,5 +1,9 @@
 package io.weaviate.client.v1.backup.api;
 
+import java.net.URISyntaxException;
+
+import org.apache.hc.core5.net.URIBuilder;
+
 import io.weaviate.client.Config;
 import io.weaviate.client.base.BaseClient;
 import io.weaviate.client.base.ClientResult;
@@ -16,6 +20,8 @@ import io.weaviate.client.base.http.HttpClient;
 public class BackupCanceler extends BaseClient<Void> implements ClientResult<Void> {
   private String backend;
   private String backupId;
+  private String bucket;
+  private String path;
 
   public BackupCanceler(HttpClient client, Config config) {
     super(client, config);
@@ -23,6 +29,16 @@ public class BackupCanceler extends BaseClient<Void> implements ClientResult<Voi
 
   public BackupCanceler withBackend(String backend) {
     this.backend = backend;
+    return this;
+  }
+
+  public BackupCanceler withBucket(String bucket) {
+    this.bucket = bucket;
+    return this;
+  }
+
+  public BackupCanceler withPath(String path) {
+    this.path = path;
     return this;
   }
 
@@ -38,7 +54,15 @@ public class BackupCanceler extends BaseClient<Void> implements ClientResult<Voi
   }
 
   private String path() {
-    return String.format("/backups/%s/%s", backend, backupId);
+    String base = String.format("/backups/%s/%s", backend, backupId);
+    try {
+      return new URIBuilder(base)
+      .addParameter("bucket", bucket)
+      .addParameter("path", path)
+      .toString();
+    } catch (URISyntaxException e) {
+      return base;
+    }
   }
 }
 

--- a/src/main/java/io/weaviate/client/v1/backup/api/BackupCanceler.java
+++ b/src/main/java/io/weaviate/client/v1/backup/api/BackupCanceler.java
@@ -57,10 +57,10 @@ public class BackupCanceler extends BaseClient<Void> implements ClientResult<Voi
     String path = String.format("/backups/%s/%s", backend, backupId);
 
     List<String> queryParams = new ArrayList<>();
-    if (this.bucket != null){
+    if (this.bucket != null) {
       queryParams.add(UrlEncoder.encodeQueryParam("bucket", this.bucket));
     }
-    if (this.backupPath != null){
+    if (this.backupPath != null) {
       queryParams.add(UrlEncoder.encodeQueryParam("path", this.backupPath));
     }
 

--- a/src/main/java/io/weaviate/client/v1/backup/api/BackupCreateStatusGetter.java
+++ b/src/main/java/io/weaviate/client/v1/backup/api/BackupCreateStatusGetter.java
@@ -1,7 +1,5 @@
 package io.weaviate.client.v1.backup.api;
 
-import io.weaviate.client.v1.backup.model.BackupCreateStatusResponse;
-
 import java.net.URISyntaxException;
 
 import org.apache.hc.core5.net.URIBuilder;
@@ -12,6 +10,7 @@ import io.weaviate.client.base.ClientResult;
 import io.weaviate.client.base.Response;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.backup.model.BackupCreateStatusResponse;
 
 public class BackupCreateStatusGetter extends BaseClient<BackupCreateStatusResponse> implements ClientResult<BackupCreateStatusResponse> {
 

--- a/src/main/java/io/weaviate/client/v1/backup/api/BackupCreateStatusGetter.java
+++ b/src/main/java/io/weaviate/client/v1/backup/api/BackupCreateStatusGetter.java
@@ -1,6 +1,11 @@
 package io.weaviate.client.v1.backup.api;
 
 import io.weaviate.client.v1.backup.model.BackupCreateStatusResponse;
+
+import java.net.URISyntaxException;
+
+import org.apache.hc.core5.net.URIBuilder;
+
 import io.weaviate.client.Config;
 import io.weaviate.client.base.BaseClient;
 import io.weaviate.client.base.ClientResult;
@@ -12,6 +17,8 @@ public class BackupCreateStatusGetter extends BaseClient<BackupCreateStatusRespo
 
   private String backend;
   private String backupId;
+  private String bucket;
+  private String path;
 
   public BackupCreateStatusGetter(HttpClient httpClient, Config config) {
     super(httpClient, config);
@@ -27,6 +34,16 @@ public class BackupCreateStatusGetter extends BaseClient<BackupCreateStatusRespo
     return this;
   }
 
+  public BackupCreateStatusGetter withBucket(String bucket) {
+    this.bucket = bucket;
+    return this;
+  }
+
+  public BackupCreateStatusGetter withPath(String path) {
+    this.path = path;
+    return this;
+  }
+
   @Override
   public Result<BackupCreateStatusResponse> run() {
     return new Result<>(statusCreate());
@@ -37,6 +54,14 @@ public class BackupCreateStatusGetter extends BaseClient<BackupCreateStatusRespo
   }
 
   private String path() {
-    return String.format("/backups/%s/%s", backend, backupId);
+    String base = String.format("/backups/%s/%s", backend, backupId);
+    try {
+      return new URIBuilder(base)
+      .addParameter("bucket", bucket)
+      .addParameter("path", path)
+      .toString();
+    } catch (URISyntaxException e) {
+      return base;
+    }
   }
 }

--- a/src/main/java/io/weaviate/client/v1/backup/api/BackupCreateStatusGetter.java
+++ b/src/main/java/io/weaviate/client/v1/backup/api/BackupCreateStatusGetter.java
@@ -1,8 +1,7 @@
 package io.weaviate.client.v1.backup.api;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import io.weaviate.client.Config;
 import io.weaviate.client.base.BaseClient;
@@ -18,7 +17,7 @@ public class BackupCreateStatusGetter extends BaseClient<BackupCreateStatusRespo
   private String backend;
   private String backupId;
   private String bucket;
-  private String path;
+  private String backupPath;
 
   public BackupCreateStatusGetter(HttpClient httpClient, Config config) {
     super(httpClient, config);
@@ -40,7 +39,7 @@ public class BackupCreateStatusGetter extends BaseClient<BackupCreateStatusRespo
   }
 
   public BackupCreateStatusGetter withPath(String path) {
-    this.path = path;
+    this.backupPath = path;
     return this;
   }
 
@@ -54,17 +53,19 @@ public class BackupCreateStatusGetter extends BaseClient<BackupCreateStatusRespo
   }
 
   private String path() {
-    String base = String.format("/backups/%s/%s", backend, backupId);
+    String path = String.format("/backups/%s/%s", backend, backupId);
 
-    List<String> queryParams = Arrays.asList(
-      UrlEncoder.encodeQueryParam("bucket", this.bucket),
-      UrlEncoder.encodeQueryParam("path", this.path)
-    );
-    queryParams.removeIf(Objects::isNull);
-    if (!queryParams.isEmpty()) {
-      base = base + "?" + String.join("&", queryParams);
+    List<String> queryParams = new ArrayList<>();
+    if (this.bucket != null){
+      queryParams.add(UrlEncoder.encodeQueryParam("bucket", this.bucket));
+    }
+    if (this.backupPath != null){
+      queryParams.add(UrlEncoder.encodeQueryParam("path", this.backupPath));
     }
 
-    return base;
+    if (!queryParams.isEmpty()) {
+      path += "?" + String.join("&", queryParams);
+    }
+    return path;
   }
 }

--- a/src/main/java/io/weaviate/client/v1/backup/api/BackupCreateStatusGetter.java
+++ b/src/main/java/io/weaviate/client/v1/backup/api/BackupCreateStatusGetter.java
@@ -1,8 +1,8 @@
 package io.weaviate.client.v1.backup.api;
 
-import java.net.URISyntaxException;
-
-import org.apache.hc.core5.net.URIBuilder;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 
 import io.weaviate.client.Config;
 import io.weaviate.client.base.BaseClient;
@@ -10,6 +10,7 @@ import io.weaviate.client.base.ClientResult;
 import io.weaviate.client.base.Response;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.base.util.UrlEncoder;
 import io.weaviate.client.v1.backup.model.BackupCreateStatusResponse;
 
 public class BackupCreateStatusGetter extends BaseClient<BackupCreateStatusResponse> implements ClientResult<BackupCreateStatusResponse> {
@@ -54,13 +55,16 @@ public class BackupCreateStatusGetter extends BaseClient<BackupCreateStatusRespo
 
   private String path() {
     String base = String.format("/backups/%s/%s", backend, backupId);
-    try {
-      return new URIBuilder(base)
-      .addParameter("bucket", bucket)
-      .addParameter("path", path)
-      .toString();
-    } catch (URISyntaxException e) {
-      return base;
+
+    List<String> queryParams = Arrays.asList(
+      UrlEncoder.encodeQueryParam("bucket", this.bucket),
+      UrlEncoder.encodeQueryParam("path", this.path)
+    );
+    queryParams.removeIf(Objects::isNull);
+    if (!queryParams.isEmpty()) {
+      base = base + "?" + String.join("&", queryParams);
     }
+
+    return base;
   }
 }

--- a/src/main/java/io/weaviate/client/v1/backup/api/BackupCreateStatusGetter.java
+++ b/src/main/java/io/weaviate/client/v1/backup/api/BackupCreateStatusGetter.java
@@ -56,10 +56,10 @@ public class BackupCreateStatusGetter extends BaseClient<BackupCreateStatusRespo
     String path = String.format("/backups/%s/%s", backend, backupId);
 
     List<String> queryParams = new ArrayList<>();
-    if (this.bucket != null){
+    if (this.bucket != null) {
       queryParams.add(UrlEncoder.encodeQueryParam("bucket", this.bucket));
     }
-    if (this.backupPath != null){
+    if (this.backupPath != null) {
       queryParams.add(UrlEncoder.encodeQueryParam("path", this.backupPath));
     }
 

--- a/src/main/java/io/weaviate/client/v1/backup/api/BackupCreator.java
+++ b/src/main/java/io/weaviate/client/v1/backup/api/BackupCreator.java
@@ -150,6 +150,10 @@ public class BackupCreator extends BaseClient<BackupCreateResponse> implements C
     Integer chunkSize;
     @SerializedName("CompressionLevel")
     String compressionLevel;
+    @SerializedName("Bucket")
+    String bucket;
+    @SerializedName("Path")
+    String path;
   }
 
   public interface BackupCompression {

--- a/src/main/java/io/weaviate/client/v1/backup/api/BackupRestoreStatusGetter.java
+++ b/src/main/java/io/weaviate/client/v1/backup/api/BackupRestoreStatusGetter.java
@@ -56,10 +56,10 @@ public class BackupRestoreStatusGetter extends BaseClient<BackupRestoreStatusRes
     String path = String.format("/backups/%s/%s/restore", backend, backupId);
 
     List<String> queryParams = new ArrayList<>();
-    if (this.bucket != null){
+    if (this.bucket != null) {
       queryParams.add(UrlEncoder.encodeQueryParam("bucket", this.bucket));
     }
-    if (this.backupPath != null){
+    if (this.backupPath != null) {
       queryParams.add(UrlEncoder.encodeQueryParam("path", this.backupPath));
     }
 

--- a/src/main/java/io/weaviate/client/v1/backup/api/BackupRestoreStatusGetter.java
+++ b/src/main/java/io/weaviate/client/v1/backup/api/BackupRestoreStatusGetter.java
@@ -1,7 +1,5 @@
 package io.weaviate.client.v1.backup.api;
 
-import io.weaviate.client.v1.backup.model.BackupRestoreStatusResponse;
-
 import java.net.URISyntaxException;
 
 import org.apache.hc.core5.net.URIBuilder;
@@ -12,6 +10,7 @@ import io.weaviate.client.base.ClientResult;
 import io.weaviate.client.base.Response;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.backup.model.BackupRestoreStatusResponse;
 
 public class BackupRestoreStatusGetter extends BaseClient<BackupRestoreStatusResponse> implements ClientResult<BackupRestoreStatusResponse> {
 

--- a/src/main/java/io/weaviate/client/v1/backup/api/BackupRestoreStatusGetter.java
+++ b/src/main/java/io/weaviate/client/v1/backup/api/BackupRestoreStatusGetter.java
@@ -1,6 +1,11 @@
 package io.weaviate.client.v1.backup.api;
 
 import io.weaviate.client.v1.backup.model.BackupRestoreStatusResponse;
+
+import java.net.URISyntaxException;
+
+import org.apache.hc.core5.net.URIBuilder;
+
 import io.weaviate.client.Config;
 import io.weaviate.client.base.BaseClient;
 import io.weaviate.client.base.ClientResult;
@@ -12,6 +17,8 @@ public class BackupRestoreStatusGetter extends BaseClient<BackupRestoreStatusRes
 
   private String backend;
   private String backupId;
+  private String bucket;
+  private String path;
 
   public BackupRestoreStatusGetter(HttpClient httpClient, Config config) {
     super(httpClient, config);
@@ -27,6 +34,16 @@ public class BackupRestoreStatusGetter extends BaseClient<BackupRestoreStatusRes
     return this;
   }
 
+  public BackupRestoreStatusGetter withBucket(String bucket) {
+    this.bucket = bucket;
+    return this;
+  }
+
+  public BackupRestoreStatusGetter withPath(String path) {
+    this.path = path;
+    return this;
+  }
+
   @Override
   public Result<BackupRestoreStatusResponse> run() {
     return new Result<>(statusRestore());
@@ -37,6 +54,14 @@ public class BackupRestoreStatusGetter extends BaseClient<BackupRestoreStatusRes
   }
 
   private String path() {
-    return String.format("/backups/%s/%s/restore", backend, backupId);
+    String base = String.format("/backups/%s/%s/restore", backend, backupId);
+    try {
+      return new URIBuilder(base)
+      .addParameter("bucket", bucket)
+      .addParameter("path", path)
+      .toString();
+    } catch (URISyntaxException e) {
+      return base;
+    }
   }
 }

--- a/src/main/java/io/weaviate/client/v1/backup/api/BackupRestoreStatusGetter.java
+++ b/src/main/java/io/weaviate/client/v1/backup/api/BackupRestoreStatusGetter.java
@@ -1,8 +1,7 @@
 package io.weaviate.client.v1.backup.api;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import io.weaviate.client.Config;
 import io.weaviate.client.base.BaseClient;
@@ -18,7 +17,7 @@ public class BackupRestoreStatusGetter extends BaseClient<BackupRestoreStatusRes
   private String backend;
   private String backupId;
   private String bucket;
-  private String path;
+  private String backupPath;
 
   public BackupRestoreStatusGetter(HttpClient httpClient, Config config) {
     super(httpClient, config);
@@ -40,7 +39,7 @@ public class BackupRestoreStatusGetter extends BaseClient<BackupRestoreStatusRes
   }
 
   public BackupRestoreStatusGetter withPath(String path) {
-    this.path = path;
+    this.backupPath = path;
     return this;
   }
 
@@ -54,17 +53,19 @@ public class BackupRestoreStatusGetter extends BaseClient<BackupRestoreStatusRes
   }
 
   private String path() {
-    String base = String.format("/backups/%s/%s/restore", backend, backupId);
+    String path = String.format("/backups/%s/%s/restore", backend, backupId);
 
-    List<String> queryParams = Arrays.asList(
-      UrlEncoder.encodeQueryParam("bucket", this.bucket),
-      UrlEncoder.encodeQueryParam("path", this.path)
-    );
-    queryParams.removeIf(Objects::isNull);
-    if (!queryParams.isEmpty()) {
-      base = base + "?" + String.join("&", queryParams);
+    List<String> queryParams = new ArrayList<>();
+    if (this.bucket != null){
+      queryParams.add(UrlEncoder.encodeQueryParam("bucket", this.bucket));
+    }
+    if (this.backupPath != null){
+      queryParams.add(UrlEncoder.encodeQueryParam("path", this.backupPath));
     }
 
-    return base;
+    if (!queryParams.isEmpty()) {
+      path += "?" + String.join("&", queryParams);
+    }
+    return path;
   }
 }

--- a/src/main/java/io/weaviate/client/v1/backup/api/BackupRestoreStatusGetter.java
+++ b/src/main/java/io/weaviate/client/v1/backup/api/BackupRestoreStatusGetter.java
@@ -1,8 +1,8 @@
 package io.weaviate.client.v1.backup.api;
 
-import java.net.URISyntaxException;
-
-import org.apache.hc.core5.net.URIBuilder;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 
 import io.weaviate.client.Config;
 import io.weaviate.client.base.BaseClient;
@@ -10,6 +10,7 @@ import io.weaviate.client.base.ClientResult;
 import io.weaviate.client.base.Response;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.base.util.UrlEncoder;
 import io.weaviate.client.v1.backup.model.BackupRestoreStatusResponse;
 
 public class BackupRestoreStatusGetter extends BaseClient<BackupRestoreStatusResponse> implements ClientResult<BackupRestoreStatusResponse> {
@@ -54,13 +55,16 @@ public class BackupRestoreStatusGetter extends BaseClient<BackupRestoreStatusRes
 
   private String path() {
     String base = String.format("/backups/%s/%s/restore", backend, backupId);
-    try {
-      return new URIBuilder(base)
-      .addParameter("bucket", bucket)
-      .addParameter("path", path)
-      .toString();
-    } catch (URISyntaxException e) {
-      return base;
+
+    List<String> queryParams = Arrays.asList(
+      UrlEncoder.encodeQueryParam("bucket", this.bucket),
+      UrlEncoder.encodeQueryParam("path", this.path)
+    );
+    queryParams.removeIf(Objects::isNull);
+    if (!queryParams.isEmpty()) {
+      base = base + "?" + String.join("&", queryParams);
     }
+
+    return base;
   }
 }

--- a/src/main/java/io/weaviate/client/v1/backup/api/BackupRestorer.java
+++ b/src/main/java/io/weaviate/client/v1/backup/api/BackupRestorer.java
@@ -150,5 +150,9 @@ public class BackupRestorer extends BaseClient<BackupRestoreResponse> implements
   public static class BackupRestoreConfig {
     @SerializedName("CPUPercentage")
     Integer cpuPercentage;
+    @SerializedName("Bucket")
+    String bucket;
+    @SerializedName("Path")
+    String path;
   }
 }

--- a/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
@@ -3,12 +3,12 @@ package io.weaviate.integration.client;
 public class WeaviateVersion {
 
   // docker image version
-  public static final String WEAVIATE_IMAGE = "stable-v1.28-ac93b01";
+  public static final String WEAVIATE_IMAGE = "stable-v1.27.7";
 
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_VERSION = "1.28.0-rc.0";
+  public static final String EXPECTED_WEAVIATE_VERSION = "1.27.7";
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_GIT_HASH = "ac93b01";
+  public static final String EXPECTED_WEAVIATE_GIT_HASH = "a6d7f16";
 
   private WeaviateVersion() {
   }

--- a/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
@@ -6,7 +6,7 @@ public class WeaviateVersion {
   public static final String WEAVIATE_IMAGE = "stable-v1.28-ac93b01";
 
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_VERSION = "1.28.0";
+  public static final String EXPECTED_WEAVIATE_VERSION = "1.28.0-rc.0";
   // to be set according to weaviate docker image
   public static final String EXPECTED_WEAVIATE_GIT_HASH = "ac93b01";
 

--- a/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
@@ -3,12 +3,12 @@ package io.weaviate.integration.client;
 public class WeaviateVersion {
 
   // docker image version
-  public static final String WEAVIATE_IMAGE = "1.27.0";
+  public static final String WEAVIATE_IMAGE = "stable-v1.28-ac93b01";
 
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_VERSION = "1.27.0";
+  public static final String EXPECTED_WEAVIATE_VERSION = "1.28.0";
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_GIT_HASH = "6c571ff";
+  public static final String EXPECTED_WEAVIATE_GIT_HASH = "ac93b01";
 
   private WeaviateVersion() {
   }

--- a/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
@@ -3,12 +3,12 @@ package io.weaviate.integration.client;
 public class WeaviateVersion {
 
   // docker image version
-  public static final String WEAVIATE_IMAGE = "stable-v1.27.7";
+  public static final String WEAVIATE_IMAGE = "1.27.7-8f0e033";
 
   // to be set according to weaviate docker image
   public static final String EXPECTED_WEAVIATE_VERSION = "1.27.7";
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_GIT_HASH = "a6d7f16";
+  public static final String EXPECTED_WEAVIATE_GIT_HASH = "8f0e033";
 
   private WeaviateVersion() {
   }

--- a/src/test/java/io/weaviate/integration/client/async/backup/ClientBackupTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/backup/ClientBackupTest.java
@@ -134,6 +134,47 @@ public class ClientBackupTest {
   }
 
   @Test
+  public void shouldCreateAndRestoreBackupWithDynamicLocation() throws InterruptedException {
+    String bucket = "test-bucket"; // irrelevant for "filesystem" backend, here only to illustrate
+    String path = "/custom/backup/location";
+
+    try (WeaviateAsyncClient asyncClient = client.async()) {
+      Supplier<Result<BackupCreateResponse>> supplierCreateResult = createSupplierCreate(
+        asyncClient, creator -> creator
+          .withIncludeClassNames(BackupTestSuite.CLASS_NAME_PIZZA)
+          .withBackend(BackupTestSuite.BACKEND)
+          .withBackupId(backupId)
+          .withConfig(BackupCreator.BackupCreateConfig.builder().bucket(bucket).path(path).build())
+      );
+      Supplier<Result<BackupCreateStatusResponse>> supplierCreateStatusResult = createSupplierCreateStatus(
+        asyncClient, createStatusGetter -> createStatusGetter
+          .withBackend(BackupTestSuite.BACKEND)
+          .withBackupId(backupId)
+          .withBucket(bucket)
+          .withPath(path)
+      );
+      Supplier<Result<BackupRestoreResponse>> supplierRestoreResult = createSupplierRestore(
+        asyncClient, restorer -> restorer
+          .withIncludeClassNames(BackupTestSuite.CLASS_NAME_PIZZA)
+          .withBackend(BackupTestSuite.BACKEND)
+          .withBackupId(backupId)
+          .withConfig(BackupRestorer.BackupRestoreConfig.builder().bucket(bucket).path(path).build())
+      );
+      Supplier<Result<BackupRestoreStatusResponse>> supplierRestoreStatusResult = createSupplierRestoreStatus(
+        asyncClient, restoreStatusGetter -> restoreStatusGetter
+          .withBackend(BackupTestSuite.BACKEND)
+          .withBackupId(backupId)
+          .withBucket(bucket)
+          .withPath(path)
+      );
+
+      BackupTestSuite.testCreateWithDynamicLocation(supplierCreateResult, supplierCreateStatusResult,
+        supplierRestoreResult, supplierRestoreStatusResult,
+        createSupplierDeletePizza(), createSupplierGQLOfClass(), backupId, bucket, path);
+    }
+  }
+
+  @Test
   public void shouldCreateAndRestore1Of2Classes() {
     try (WeaviateAsyncClient asyncClient = client.async()) {
       Supplier<Result<BackupCreateResponse>> supplierCreateResult = createSupplierCreate(


### PR DESCRIPTION
This PR extends sync/async clients to accept `bucket` and `path` parameters in backup operations.

As query parameters: create status, restore status, cancel.
As request body parameters: create, restore.


## How is this tested?

New tests case in `BackupTestSuite`. It's only limitation is that it doesn't verify that the bucket was set correctly, because `bucket` is irrelevant for `"filesystem"` backend, which we use in the tests.

We do pass this parameter in all requests.