### PR TITLE
Add RBAC support (sync client only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 *.iml
 # Maven
 target/
+# maven-lombok-plugin
+.factorypath

--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.1</version>
+          <version>3.13.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
@@ -273,6 +273,13 @@
               </configuration>
             </execution>
           </executions>
+          <dependencies>
+            <dependency>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>${lombok.version}</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/io/weaviate/client/WeaviateClient.java
+++ b/src/main/java/io/weaviate/client/WeaviateClient.java
@@ -17,6 +17,7 @@ import io.weaviate.client.v1.data.Data;
 import io.weaviate.client.v1.graphql.GraphQL;
 import io.weaviate.client.v1.misc.Misc;
 import io.weaviate.client.v1.misc.api.MetaGetter;
+import io.weaviate.client.v1.rbac.Roles;
 import io.weaviate.client.v1.schema.Schema;
 import java.util.Optional;
 
@@ -33,7 +34,8 @@ public class WeaviateClient {
   }
 
   public WeaviateClient(Config config, AccessTokenProvider tokenProvider) {
-    this(config, new CommonsHttpClientImpl(config.getHeaders(), tokenProvider, HttpApacheClientBuilder.build(config)), tokenProvider);
+    this(config, new CommonsHttpClientImpl(config.getHeaders(), tokenProvider, HttpApacheClientBuilder.build(config)),
+        tokenProvider);
   }
 
   public WeaviateClient(Config config, HttpClient httpClient, AccessTokenProvider tokenProvider) {
@@ -87,10 +89,13 @@ public class WeaviateClient {
     return new GraphQL(httpClient, config);
   }
 
+  public Roles roles() {
+    return new Roles(httpClient, config);
+  }
+
   private DbVersionProvider initDbVersionProvider() {
     MetaGetter metaGetter = new Misc(httpClient, config, null).metaGetter();
-    DbVersionProvider.VersionGetter getter = () ->
-      Optional.ofNullable(metaGetter.run())
+    DbVersionProvider.VersionGetter getter = () -> Optional.ofNullable(metaGetter.run())
         .filter(result -> !result.hasErrors())
         .map(result -> result.getResult().getVersion());
 

--- a/src/main/java/io/weaviate/client/base/BaseClient.java
+++ b/src/main/java/io/weaviate/client/base/BaseClient.java
@@ -45,9 +45,6 @@ public abstract class BaseClient<T> {
       HttpResponse response = this.sendHttpRequest(endpoint, payload, method);
       int statusCode = response.getStatusCode();
       String responseBody = response.getBody();
-      System.out.println("response: " + responseBody);
-      System.out.println("Status Code: " + String.valueOf(response.getStatusCode()));
-
       if (statusCode < 399) {
         T body = toResponse(responseBody, classOfT);
         return new Response<>(statusCode, body, null);
@@ -63,9 +60,7 @@ public abstract class BaseClient<T> {
 
   protected HttpResponse sendHttpRequest(String endpoint, Object payload, String method) throws Exception {
     String address = config.getBaseURL() + endpoint;
-    System.out.println(method + " request: " + address);
     String json = toJsonString(payload);
-    System.out.println("with body: " + json);
     if (method.equals("POST")) {
       return client.sendPostRequest(address, json);
     }

--- a/src/main/java/io/weaviate/client/base/BaseClient.java
+++ b/src/main/java/io/weaviate/client/base/BaseClient.java
@@ -45,6 +45,8 @@ public abstract class BaseClient<T> {
       HttpResponse response = this.sendHttpRequest(endpoint, payload, method);
       int statusCode = response.getStatusCode();
       String responseBody = response.getBody();
+      System.out.println("response: " + responseBody);
+      System.out.println("Status Code: " + String.valueOf(response.getStatusCode()));
 
       if (statusCode < 399) {
         T body = toResponse(responseBody, classOfT);
@@ -61,7 +63,9 @@ public abstract class BaseClient<T> {
 
   protected HttpResponse sendHttpRequest(String endpoint, Object payload, String method) throws Exception {
     String address = config.getBaseURL() + endpoint;
+    System.out.println(method + " request: " + address);
     String json = toJsonString(payload);
+    System.out.println("with body: " + json);
     if (method.equals("POST")) {
       return client.sendPostRequest(address, json);
     }

--- a/src/main/java/io/weaviate/client/v1/backup/api/BackupCanceler.java
+++ b/src/main/java/io/weaviate/client/v1/backup/api/BackupCanceler.java
@@ -15,7 +15,8 @@ import io.weaviate.client.base.util.UrlEncoder;
  * BackupCanceler can cancel an in-progress backup by ID.
  *
  * <p>
- * Canceling backups which have successfully completed before being interrupted is not supported and will result in an error.
+ * Canceling backups which have successfully completed before being interrupted
+ * is not supported and will result in an error.
  */
 public class BackupCanceler extends BaseClient<Void> implements ClientResult<Void> {
   private String backend;
@@ -70,4 +71,3 @@ public class BackupCanceler extends BaseClient<Void> implements ClientResult<Voi
     return path;
   }
 }
-

--- a/src/main/java/io/weaviate/client/v1/rbac/Roles.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/Roles.java
@@ -1,57 +1,90 @@
 package io.weaviate.client.v1.rbac;
 
+import io.weaviate.client.Config;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.rbac.api.AssignedUsersGetter;
+import io.weaviate.client.v1.rbac.api.PermissionAdder;
+import io.weaviate.client.v1.rbac.api.PermissionChecker;
+import io.weaviate.client.v1.rbac.api.PermissionRemover;
+import io.weaviate.client.v1.rbac.api.RoleAllGetter;
+import io.weaviate.client.v1.rbac.api.RoleAssigner;
+import io.weaviate.client.v1.rbac.api.RoleCreator;
+import io.weaviate.client.v1.rbac.api.RoleDeleter;
+import io.weaviate.client.v1.rbac.api.RoleExists;
+import io.weaviate.client.v1.rbac.api.RoleGetter;
+import io.weaviate.client.v1.rbac.api.RoleRevoker;
+import io.weaviate.client.v1.rbac.api.UserRolesGetter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 public class Roles {
-  public Roles() {
+
+  private final HttpClient httpClient;
+  private final Config config;
+
+  public RoleCreator creator() {
+    return new RoleCreator(httpClient, config);
   }
 
-  // public Role create(String name, Permission... permissions) {
-  // }
-  //
-  /// ** Get all existing roles. */
-  // public void delete(String role) {
-  // }
-  //
-  /// **
-  // * Add permissions to an existing role.
-  // * Note: This method is an upsert operation. If the permission already exists,
-  // * it will be updated. If it does not exist, it will be created.
-  // */
-  // public void addPermissions(String role, Permission... permissions) {
-  // }
-  //
-  /// **
-  // * Remove permissions from a role.
-  // * Note: This method is a downsert operation. If the permission does not
-  // exist,
-  // * it will be ignored. If these permissions are the only permissions of the
-  // * role, the role will be deleted.
-  // */
-  // public void removePermissions(String role, Permission... permissions) {
-  // }
-  //
-  /// ** Get all existing roles. */
-  // public void getAll() {
-  // };
-  //
-  /// ** Get permissions associated with a role. */
-  // public List<Permission> getRolePermissions(String role) {
-  // };
-  //
-  /// ** Get roles assigned to the current user. */
-  // public List<Role> getUserRoles() {
-  // };
-  //
-  /// ** Get roles assigned to a user. */
-  // public List<Role> getUserRoles(String user) {
-  // };
-  //
-  /// ** Check if a role exists. */
-  // public boolean exists(String role) {
-  // }
-  //
-  // public void assign(String user, String... roles) {
-  // }
-  //
-  // public void revoke(String user, String... roles) {
-  // }
+  /** Get all existing roles. */
+  public RoleDeleter deleter() {
+    return new RoleDeleter(httpClient, config);
+  }
+
+  /**
+   * Add permissions to an existing role.
+   * Note: This method is an upsert operation. If the permission already exists,
+   * it will be updated. If it does not exist, it will be created.
+   */
+  public PermissionAdder permissionAdder() {
+    return new PermissionAdder(httpClient, config);
+  }
+
+  /**
+   * Remove permissions from a role.
+   * Note: This method is a downsert operation. If the permission does not
+   * exist, it will be ignored. If these permissions are the only permissions of
+   * the role, the role will be deleted.
+   */
+  public PermissionRemover permissionRemover() {
+    return new PermissionRemover(httpClient, config);
+  }
+
+  /** Check if a role has a permission. */
+  public PermissionChecker permissionChecker() {
+    return new PermissionChecker(httpClient, config);
+  }
+
+  /** Get all existing roles. */
+  public RoleAllGetter allGetter() {
+    return new RoleAllGetter(httpClient, config);
+  };
+
+  /** Get role and its assiciated permissions. */
+  public RoleGetter getter() {
+    return new RoleGetter(httpClient, config);
+  };
+
+  /** Get roles assigned to a user. */
+  public UserRolesGetter userRolesGetter() {
+    return new UserRolesGetter(httpClient, config);
+  };
+
+  /** Get users assigned to a role. */
+  public AssignedUsersGetter assignedUsersGetter() {
+    return new AssignedUsersGetter(httpClient, config);
+  };
+
+  /** Check if a role exists. */
+  public RoleExists exists() {
+    return new RoleExists(httpClient, config);
+  }
+
+  public RoleAssigner assigner() {
+    return new RoleAssigner(httpClient, config);
+  }
+
+  public RoleRevoker revoker() {
+    return new RoleRevoker(httpClient, config);
+  }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/Roles.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/Roles.java
@@ -1,0 +1,57 @@
+package io.weaviate.client.v1.rbac;
+
+public class Roles {
+  public Roles() {
+  }
+
+  // public Role create(String name, Permission... permissions) {
+  // }
+  //
+  /// ** Get all existing roles. */
+  // public void delete(String role) {
+  // }
+  //
+  /// **
+  // * Add permissions to an existing role.
+  // * Note: This method is an upsert operation. If the permission already exists,
+  // * it will be updated. If it does not exist, it will be created.
+  // */
+  // public void addPermissions(String role, Permission... permissions) {
+  // }
+  //
+  /// **
+  // * Remove permissions from a role.
+  // * Note: This method is a downsert operation. If the permission does not
+  // exist,
+  // * it will be ignored. If these permissions are the only permissions of the
+  // * role, the role will be deleted.
+  // */
+  // public void removePermissions(String role, Permission... permissions) {
+  // }
+  //
+  /// ** Get all existing roles. */
+  // public void getAll() {
+  // };
+  //
+  /// ** Get permissions associated with a role. */
+  // public List<Permission> getRolePermissions(String role) {
+  // };
+  //
+  /// ** Get roles assigned to the current user. */
+  // public List<Role> getUserRoles() {
+  // };
+  //
+  /// ** Get roles assigned to a user. */
+  // public List<Role> getUserRoles(String user) {
+  // };
+  //
+  /// ** Check if a role exists. */
+  // public boolean exists(String role) {
+  // }
+  //
+  // public void assign(String user, String... roles) {
+  // }
+  //
+  // public void revoke(String user, String... roles) {
+  // }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/Roles.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/Roles.java
@@ -22,11 +22,12 @@ public class Roles {
   private final HttpClient httpClient;
   private final Config config;
 
+  /** Create a new role. */
   public RoleCreator creator() {
     return new RoleCreator(httpClient, config);
   }
 
-  /** Get all existing roles. */
+  /** Delete a role. */
   public RoleDeleter deleter() {
     return new RoleDeleter(httpClient, config);
   }
@@ -60,7 +61,7 @@ public class Roles {
     return new RoleAllGetter(httpClient, config);
   };
 
-  /** Get role and its assiciated permissions. */
+  /** Get role and its associated permissions. */
   public RoleGetter getter() {
     return new RoleGetter(httpClient, config);
   };
@@ -80,10 +81,12 @@ public class Roles {
     return new RoleExists(httpClient, config);
   }
 
+  /** Assign a role to a user. Note that 'root' cannot be assigned. */
   public RoleAssigner assigner() {
     return new RoleAssigner(httpClient, config);
   }
 
+  /** Revoke a role from a user. Note that 'root' cannot be revoked. */
   public RoleRevoker revoker() {
     return new RoleRevoker(httpClient, config);
   }

--- a/src/main/java/io/weaviate/client/v1/rbac/api/AssignedUsersGetter.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/AssignedUsersGetter.java
@@ -13,14 +13,14 @@ import io.weaviate.client.base.Result;
 import io.weaviate.client.base.http.HttpClient;
 
 public class AssignedUsersGetter extends BaseClient<String[]> implements ClientResult<List<String>> {
-  private String name;
+  private String role;
 
   public AssignedUsersGetter(HttpClient httpClient, Config config) {
     super(httpClient, config);
   }
 
-  public AssignedUsersGetter withName(String name) {
-    this.name = name;
+  public AssignedUsersGetter withRole(String role) {
+    this.role = role;
     return this;
   }
 
@@ -34,6 +34,6 @@ public class AssignedUsersGetter extends BaseClient<String[]> implements ClientR
   }
 
   private String path() {
-    return String.format("/authz/roles/%s/users", this.name);
+    return String.format("/authz/roles/%s/users", this.role);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/api/AssignedUsersGetter.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/AssignedUsersGetter.java
@@ -1,0 +1,39 @@
+package io.weaviate.client.v1.rbac.api;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Response;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+
+public class AssignedUsersGetter extends BaseClient<String[]> implements ClientResult<List<String>> {
+  private String name;
+
+  public AssignedUsersGetter(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public AssignedUsersGetter withName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  @Override
+  public Result<List<String>> run() {
+    Response<String[]> resp = sendGetRequest(path(), String[].class);
+    List<String> roles = Optional.ofNullable(resp.getBody())
+        .map(Arrays::asList)
+        .orElse(new ArrayList<>());
+    return new Result<>(resp.getStatusCode(), roles, resp.getErrors());
+  }
+
+  private String path() {
+    return String.format("/authz/roles/%s/users", this.name);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/PermissionAdder.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/PermissionAdder.java
@@ -1,0 +1,41 @@
+package io.weaviate.client.v1.rbac.api;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.rbac.model.Permission;
+
+public class PermissionAdder extends BaseClient<Void> implements ClientResult<Void> {
+  private String name;
+  private List<Permission<?>> permissions = new ArrayList<>();
+
+  public PermissionAdder(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public PermissionAdder withName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public PermissionAdder withPermissions(Permission<?>... permissions) {
+    this.permissions = Arrays.asList(permissions);
+    return this;
+  }
+
+  @Override
+  public Result<Void> run() {
+    List<WeaviatePermission> permissions = WeaviatePermission.mergePermissions(this.permissions);
+    return new Result<Void>(sendPostRequest(path(), permissions, Void.class));
+  }
+
+  private String path() {
+    return String.format("/authz/roles/%s/add-permissions", this.name);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/PermissionAdder.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/PermissionAdder.java
@@ -10,17 +10,18 @@ import io.weaviate.client.base.ClientResult;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.base.http.HttpClient;
 import io.weaviate.client.v1.rbac.model.Permission;
+import lombok.AllArgsConstructor;
 
 public class PermissionAdder extends BaseClient<Void> implements ClientResult<Void> {
-  private String name;
+  private String role;
   private List<Permission<?>> permissions = new ArrayList<>();
 
   public PermissionAdder(HttpClient httpClient, Config config) {
     super(httpClient, config);
   }
 
-  public PermissionAdder withName(String name) {
-    this.name = name;
+  public PermissionAdder withRole(String name) {
+    this.role = name;
     return this;
   }
 
@@ -29,13 +30,18 @@ public class PermissionAdder extends BaseClient<Void> implements ClientResult<Vo
     return this;
   }
 
+  @AllArgsConstructor
+  private static class Body {
+    public final List<?> permissions;
+  }
+
   @Override
   public Result<Void> run() {
     List<WeaviatePermission> permissions = WeaviatePermission.mergePermissions(this.permissions);
-    return new Result<Void>(sendPostRequest(path(), permissions, Void.class));
+    return new Result<Void>(sendPostRequest(path(), new Body(permissions), Void.class));
   }
 
   private String path() {
-    return String.format("/authz/roles/%s/add-permissions", this.name);
+    return String.format("/authz/roles/%s/add-permissions", this.role);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/api/PermissionChecker.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/PermissionChecker.java
@@ -8,15 +8,15 @@ import io.weaviate.client.base.http.HttpClient;
 import io.weaviate.client.v1.rbac.model.Permission;
 
 public class PermissionChecker extends BaseClient<Boolean> implements ClientResult<Boolean> {
-  private String name;
+  private String role;
   private Permission<?> permission;
 
   public PermissionChecker(HttpClient httpClient, Config config) {
     super(httpClient, config);
   }
 
-  public PermissionChecker withName(String name) {
-    this.name = name;
+  public PermissionChecker withRole(String role) {
+    this.role = role;
     return this;
   }
 
@@ -27,10 +27,10 @@ public class PermissionChecker extends BaseClient<Boolean> implements ClientResu
 
   @Override
   public Result<Boolean> run() {
-    return new Result<Boolean>(sendPostRequest(path(), permission, Boolean.class));
+    return new Result<Boolean>(sendPostRequest(path(), permission.toWeaviate(), Boolean.class));
   }
 
   private String path() {
-    return String.format("/authz/roles/%s/has-permission", this.name);
+    return String.format("/authz/roles/%s/has-permission", this.role);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/api/PermissionChecker.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/PermissionChecker.java
@@ -1,0 +1,36 @@
+package io.weaviate.client.v1.rbac.api;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.rbac.model.Permission;
+
+public class PermissionChecker extends BaseClient<Boolean> implements ClientResult<Boolean> {
+  private String name;
+  private Permission<?> permission;
+
+  public PermissionChecker(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public PermissionChecker withName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public PermissionChecker withPermission(Permission<?> permission) {
+    this.permission = permission;
+    return this;
+  }
+
+  @Override
+  public Result<Boolean> run() {
+    return new Result<Boolean>(sendPostRequest(path(), permission, Boolean.class));
+  }
+
+  private String path() {
+    return String.format("/authz/roles/%s/has-permission", this.name);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/PermissionRemover.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/PermissionRemover.java
@@ -10,17 +10,18 @@ import io.weaviate.client.base.ClientResult;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.base.http.HttpClient;
 import io.weaviate.client.v1.rbac.model.Permission;
+import lombok.AllArgsConstructor;
 
 public class PermissionRemover extends BaseClient<Void> implements ClientResult<Void> {
-  private String name;
+  private String role;
   private List<Permission<?>> permissions = new ArrayList<>();
 
   public PermissionRemover(HttpClient httpClient, Config config) {
     super(httpClient, config);
   }
 
-  public PermissionRemover withName(String name) {
-    this.name = name;
+  public PermissionRemover withRole(String role) {
+    this.role = role;
     return this;
   }
 
@@ -29,13 +30,18 @@ public class PermissionRemover extends BaseClient<Void> implements ClientResult<
     return this;
   }
 
+  @AllArgsConstructor
+  private static class Body {
+    public final List<?> permissions;
+  }
+
   @Override
   public Result<Void> run() {
     List<WeaviatePermission> permissions = WeaviatePermission.mergePermissions(this.permissions);
-    return new Result<Void>(sendPostRequest(path(), permissions, Void.class));
+    return new Result<Void>(sendPostRequest(path(), new Body(permissions), Void.class));
   }
 
   private String path() {
-    return String.format("/authz/roles/%s/remove-permissions", this.name);
+    return String.format("/authz/roles/%s/remove-permissions", this.role);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/api/PermissionRemover.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/PermissionRemover.java
@@ -1,0 +1,41 @@
+package io.weaviate.client.v1.rbac.api;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.rbac.model.Permission;
+
+public class PermissionRemover extends BaseClient<Void> implements ClientResult<Void> {
+  private String name;
+  private List<Permission<?>> permissions = new ArrayList<>();
+
+  public PermissionRemover(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public PermissionRemover withName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public PermissionRemover withPermissions(Permission<?>... permissions) {
+    this.permissions = Arrays.asList(permissions);
+    return this;
+  }
+
+  @Override
+  public Result<Void> run() {
+    List<WeaviatePermission> permissions = WeaviatePermission.mergePermissions(this.permissions);
+    return new Result<Void>(sendPostRequest(path(), permissions, Void.class));
+  }
+
+  private String path() {
+    return String.format("/authz/roles/%s/remove-permissions", this.name);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/RoleAllGetter.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/RoleAllGetter.java
@@ -1,0 +1,33 @@
+package io.weaviate.client.v1.rbac.api;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Response;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.rbac.model.Role;
+
+public class RoleAllGetter extends BaseClient<WeaviateRole[]> implements ClientResult<List<Role>> {
+
+  public RoleAllGetter(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  @Override
+  public Result<List<Role>> run() {
+    Response<WeaviateRole[]> resp = sendGetRequest("/authz/roles", WeaviateRole[].class);
+    List<Role> roles = Optional.ofNullable(resp.getBody())
+        .map(Arrays::asList)
+        .orElse(new ArrayList<>())
+        .stream()
+        .map(w -> w.toRole())
+        .toList();
+    return new Result<>(resp.getStatusCode(), roles, resp.getErrors());
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/RoleAssigner.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/RoleAssigner.java
@@ -1,0 +1,46 @@
+package io.weaviate.client.v1.rbac.api;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import lombok.AllArgsConstructor;
+
+public class RoleAssigner extends BaseClient<Void> implements ClientResult<Void> {
+  private String user;
+  private List<String> roles = new ArrayList<>();
+
+  public RoleAssigner(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public RoleAssigner withUser(String user) {
+    this.user = user;
+    return this;
+  }
+
+  public RoleAssigner witRoles(String... roles) {
+    this.roles = Arrays.asList(roles);
+    return this;
+  }
+
+  /** The API signature for this method is { "roles": [...] } */
+  @AllArgsConstructor
+  private static class Body {
+    public final List<String> roles;
+  }
+
+  @Override
+  public Result<Void> run() {
+    return new Result<Void>(sendPostRequest(path(), new Body(this.roles), Void.class));
+  }
+
+  private String path() {
+    return String.format("/authz/users/%s/assign", this.user);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/RoleCreator.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/RoleCreator.java
@@ -1,0 +1,37 @@
+package io.weaviate.client.v1.rbac.api;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.rbac.model.Permission;
+
+public class RoleCreator extends BaseClient<Void> implements ClientResult<Void> {
+  private String name;
+  private List<Permission<?>> permissions = new ArrayList<>();
+
+  public RoleCreator(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public RoleCreator withName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public RoleCreator withPermissions(Permission<?>... permissions) {
+    this.permissions = Arrays.asList(permissions);
+    return this;
+  }
+
+  @Override
+  public Result<Void> run() {
+    WeaviateRole role = new WeaviateRole(this.name, this.permissions);
+    return new Result<Void>(sendPostRequest("/authz/roles", role, Void.class));
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/RoleDeleter.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/RoleDeleter.java
@@ -1,0 +1,25 @@
+package io.weaviate.client.v1.rbac.api;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+
+public class RoleDeleter extends BaseClient<Void> implements ClientResult<Void> {
+  private String name;
+
+  public RoleDeleter(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public RoleDeleter withName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  @Override
+  public Result<Void> run() {
+    return new Result<Void>(sendDeleteRequest("/authz/roles/" + this.name, null, Void.class));
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/RoleExists.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/RoleExists.java
@@ -1,0 +1,38 @@
+package io.weaviate.client.v1.rbac.api;
+
+import org.apache.hc.core5.http.HttpStatus;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.WeaviateError;
+import io.weaviate.client.base.WeaviateErrorResponse;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.rbac.model.Role;
+
+public class RoleExists extends BaseClient<Boolean> implements ClientResult<Boolean> {
+  private RoleGetter getter;
+
+  public RoleExists(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+    this.getter = new RoleGetter(httpClient, config);
+  }
+
+  public RoleExists withName(String name) {
+    this.getter.withName(name);
+    return this;
+  }
+
+  @Override
+  public Result<Boolean> run() {
+    Result<Role> resp = this.getter.run();
+    if (resp.hasErrors()) {
+      WeaviateError error = resp.getError();
+      return new Result<>(error.getStatusCode(), null,
+          WeaviateErrorResponse.builder().error(error.getMessages()).build());
+
+    }
+    return new Result<Boolean>(HttpStatus.SC_OK, resp.getResult() != null, null);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/RoleGetter.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/RoleGetter.java
@@ -25,7 +25,7 @@ public class RoleGetter extends BaseClient<WeaviateRole> implements ClientResult
   @Override
   public Result<Role> run() {
     Response<WeaviateRole> resp = sendGetRequest("/authz/roles/" + this.name, WeaviateRole.class);
-    WeaviateRole role = Optional.ofNullable(resp.getBody()).orElse(null);
-    return new Result<Role>(resp.getStatusCode(), role.toRole(), resp.getErrors());
+    Role role = Optional.ofNullable(resp.getBody()).map(WeaviateRole::toRole).orElse(null);
+    return new Result<Role>(resp.getStatusCode(), role, resp.getErrors());
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/api/RoleGetter.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/RoleGetter.java
@@ -1,0 +1,31 @@
+package io.weaviate.client.v1.rbac.api;
+
+import java.util.Optional;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Response;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.rbac.model.Role;
+
+public class RoleGetter extends BaseClient<WeaviateRole> implements ClientResult<Role> {
+  private String name;
+
+  public RoleGetter(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public RoleGetter withName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  @Override
+  public Result<Role> run() {
+    Response<WeaviateRole> resp = sendGetRequest("/authz/roles/" + this.name, WeaviateRole.class);
+    WeaviateRole role = Optional.ofNullable(resp.getBody()).orElse(null);
+    return new Result<Role>(resp.getStatusCode(), role.toRole(), resp.getErrors());
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/RoleRevoker.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/RoleRevoker.java
@@ -1,0 +1,47 @@
+package io.weaviate.client.v1.rbac.api;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import lombok.AllArgsConstructor;
+
+public class RoleRevoker extends BaseClient<Void> implements ClientResult<Void> {
+  private String user;
+  private List<String> roles = new ArrayList<>();
+
+  public RoleRevoker(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public RoleRevoker withUser(String user) {
+    this.user = user;
+    return this;
+  }
+
+  public RoleRevoker witRoles(String... roles) {
+    this.roles = Collections.unmodifiableList(Arrays.asList(roles));
+    return this;
+  }
+
+  /** The API signature for this method is { "roles": [...] } */
+  @AllArgsConstructor
+  private static class Body {
+    public final List<String> roles;
+  }
+
+  @Override
+  public Result<Void> run() {
+    return new Result<Void>(sendPostRequest(path(), new Body(this.roles), Void.class));
+  }
+
+  private String path() {
+    return String.format("/authz/users/%s/revoke", this.user);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/UserRolesGetter.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/UserRolesGetter.java
@@ -1,0 +1,49 @@
+package io.weaviate.client.v1.rbac.api;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Response;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.rbac.model.Role;
+
+public class UserRolesGetter extends BaseClient<WeaviateRole[]> implements ClientResult<List<Role>> {
+  private String user;
+
+  public UserRolesGetter(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  /** Leave unset to fetch roles assigned to the current user. */
+  public UserRolesGetter withUser(String user) {
+    this.user = user;
+    return this;
+  }
+
+  @Override
+  public Result<List<Role>> run() {
+    Response<WeaviateRole[]> resp;
+    if (this.user == null) {
+      resp = sendGetRequest("/authz/users/own-roles", WeaviateRole[].class);
+    } else {
+      resp = sendGetRequest(path(), WeaviateRole[].class);
+    }
+    List<Role> roles = Optional.ofNullable(resp.getBody())
+        .map(Arrays::asList)
+        .orElse(new ArrayList<>())
+        .stream()
+        .map(w -> w.toRole())
+        .toList();
+    return new Result<>(resp.getStatusCode(), roles, resp.getErrors());
+  }
+
+  private String path() {
+    return String.format("/authz/users/%s/roles", this.user);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/WeaviatePermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/WeaviatePermission.java
@@ -1,0 +1,54 @@
+package io.weaviate.client.v1.rbac.api;
+
+import io.weaviate.client.v1.rbac.model.BackupsPermission;
+import io.weaviate.client.v1.rbac.model.ClusterPermission;
+import io.weaviate.client.v1.rbac.model.CollectionsPermission;
+import io.weaviate.client.v1.rbac.model.DataPermission;
+import io.weaviate.client.v1.rbac.model.NodesPermission;
+import io.weaviate.client.v1.rbac.model.Permission;
+import io.weaviate.client.v1.rbac.model.RolesPermission;
+import io.weaviate.client.v1.rbac.model.TenantsPermission;
+import io.weaviate.client.v1.rbac.model.UsersPermission;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class WeaviatePermission {
+  String action;
+  BackupsPermission backups;
+  ClusterPermission cluster;
+  CollectionsPermission collections;
+  DataPermission data;
+  NodesPermission nodes;
+  RolesPermission roles;
+  TenantsPermission tenants;
+  UsersPermission users;
+
+  public WeaviatePermission(String action) {
+    this.action = action;
+  }
+
+  public <P extends Permission<P>> WeaviatePermission(String action, Permission<P> perm) {
+    this.action = action;
+    if (perm instanceof BackupsPermission) {
+      this.backups = (BackupsPermission) perm;
+    } else if (perm instanceof ClusterPermission) {
+      this.cluster = (ClusterPermission) perm;
+    } else if (perm instanceof CollectionsPermission) {
+      this.collections = (CollectionsPermission) perm;
+    } else if (perm instanceof DataPermission) {
+      this.data = (DataPermission) perm;
+    } else if (perm instanceof NodesPermission) {
+      this.nodes = (NodesPermission) perm;
+    } else if (perm instanceof RolesPermission) {
+      this.roles = (RolesPermission) perm;
+    } else if (perm instanceof TenantsPermission) {
+      this.tenants = (TenantsPermission) perm;
+    } else if (perm instanceof UsersPermission) {
+      this.users = (UsersPermission) perm;
+    }
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/WeaviatePermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/WeaviatePermission.java
@@ -8,7 +8,6 @@ import io.weaviate.client.v1.rbac.model.NodesPermission;
 import io.weaviate.client.v1.rbac.model.Permission;
 import io.weaviate.client.v1.rbac.model.RolesPermission;
 import io.weaviate.client.v1.rbac.model.TenantsPermission;
-import io.weaviate.client.v1.rbac.model.UsersPermission;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,13 +18,11 @@ import lombok.Getter;
 public class WeaviatePermission {
   String action;
   BackupsPermission backups;
-  ClusterPermission cluster;
   CollectionsPermission collections;
   DataPermission data;
   NodesPermission nodes;
   RolesPermission roles;
   TenantsPermission tenants;
-  UsersPermission users;
 
   public WeaviatePermission(String action) {
     this.action = action;
@@ -35,8 +32,6 @@ public class WeaviatePermission {
     this.action = action;
     if (perm instanceof BackupsPermission) {
       this.backups = (BackupsPermission) perm;
-    } else if (perm instanceof ClusterPermission) {
-      this.cluster = (ClusterPermission) perm;
     } else if (perm instanceof CollectionsPermission) {
       this.collections = (CollectionsPermission) perm;
     } else if (perm instanceof DataPermission) {
@@ -47,8 +42,6 @@ public class WeaviatePermission {
       this.roles = (RolesPermission) perm;
     } else if (perm instanceof TenantsPermission) {
       this.tenants = (TenantsPermission) perm;
-    } else if (perm instanceof UsersPermission) {
-      this.users = (UsersPermission) perm;
     }
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/api/WeaviatePermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/WeaviatePermission.java
@@ -1,7 +1,8 @@
 package io.weaviate.client.v1.rbac.api;
 
+import java.util.List;
+
 import io.weaviate.client.v1.rbac.model.BackupsPermission;
-import io.weaviate.client.v1.rbac.model.ClusterPermission;
 import io.weaviate.client.v1.rbac.model.CollectionsPermission;
 import io.weaviate.client.v1.rbac.model.DataPermission;
 import io.weaviate.client.v1.rbac.model.NodesPermission;
@@ -43,5 +44,9 @@ public class WeaviatePermission {
     } else if (perm instanceof TenantsPermission) {
       this.tenants = (TenantsPermission) perm;
     }
+  }
+
+  public static List<WeaviatePermission> mergePermissions(List<Permission<?>> permissions) {
+    return permissions.stream().map(perm -> perm.toWeaviate()).toList();
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/api/WeaviateRole.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/WeaviateRole.java
@@ -1,32 +1,24 @@
 package io.weaviate.client.v1.rbac.api;
 
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import io.weaviate.client.v1.rbac.model.Permission;
 import io.weaviate.client.v1.rbac.model.Role;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder
-@AllArgsConstructor
 public class WeaviateRole {
   String name;
-  List<Map<String, Map<String, ?>>> permissions;
+  List<WeaviatePermission> permissions;
 
-  public WeaviateRole(Role role) {
-    this.name = role.name;
-    this.permissions = mergePermissions(role.permissions);
-  }
-
-  private static List<Map<String, Map<String, ?>>> mergePermissions(List<Permission<?>> permissions) {
-    return null;
+  public WeaviateRole(String name, List<Permission<?>> permissions) {
+    this.name = name;
+    this.permissions = WeaviatePermission.mergePermissions(permissions);
   }
 
   public Role toRole() {
-    return null;
+    List<Permission<?>> permissions = this.permissions.stream()
+        .<Permission<?>>map(perm -> Permission.fromWeaviate(perm)).toList();
+    return new Role(this.name, permissions);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/api/WeaviateRole.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/WeaviateRole.java
@@ -1,0 +1,32 @@
+package io.weaviate.client.v1.rbac.api;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import io.weaviate.client.v1.rbac.model.Permission;
+import io.weaviate.client.v1.rbac.model.Role;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class WeaviateRole {
+  String name;
+  List<Map<String, Map<String, ?>>> permissions;
+
+  public WeaviateRole(Role role) {
+    this.name = role.name;
+    this.permissions = mergePermissions(role.permissions);
+  }
+
+  private static List<Map<String, Map<String, ?>>> mergePermissions(List<Permission<?>> permissions) {
+    return null;
+  }
+
+  public Role toRole() {
+    return null;
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/model/BackupsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/BackupsPermission.java
@@ -2,9 +2,11 @@ package io.weaviate.client.v1.rbac.model;
 
 import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
+@EqualsAndHashCode(callSuper = true)
 public class BackupsPermission extends Permission<BackupsPermission> {
   final String collection;
 

--- a/src/main/java/io/weaviate/client/v1/rbac/model/BackupsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/BackupsPermission.java
@@ -5,12 +5,11 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-public class BackupsPermission implements Permission<BackupsPermission> {
-  final transient String action;
+public class BackupsPermission extends Permission<BackupsPermission> {
   final String collection;
 
   public BackupsPermission(Action action, String collection) {
-    this.action = action.getValue();
+    super(action);
     this.collection = collection;
   }
 

--- a/src/main/java/io/weaviate/client/v1/rbac/model/BackupsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/BackupsPermission.java
@@ -1,0 +1,33 @@
+package io.weaviate.client.v1.rbac.model;
+
+import io.weaviate.client.v1.rbac.api.WeaviatePermission;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class BackupsPermission implements Permission<BackupsPermission> {
+  final transient String action;
+  final String collection;
+
+  public BackupsPermission(Action action, String collection) {
+    this.action = action.getValue();
+    this.collection = collection;
+  }
+
+  @Override
+  public WeaviatePermission toWeaviate() {
+    return new WeaviatePermission(this.action, this);
+  }
+
+  @Override
+  public BackupsPermission fromWeaviate(WeaviatePermission perm) {
+    return null;
+  }
+
+  @AllArgsConstructor
+  public enum Action {
+    MANAGE("manage_backups");
+
+    @Getter
+    private final String value;
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/model/BackupsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/BackupsPermission.java
@@ -4,6 +4,7 @@ import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@Getter
 public class BackupsPermission implements Permission<BackupsPermission> {
   final transient String action;
   final String collection;
@@ -13,18 +14,17 @@ public class BackupsPermission implements Permission<BackupsPermission> {
     this.collection = collection;
   }
 
+  BackupsPermission(String action, String collection) {
+    this(CustomAction.fromString(Action.class, action), collection);
+  }
+
   @Override
   public WeaviatePermission toWeaviate() {
     return new WeaviatePermission(this.action, this);
   }
 
-  @Override
-  public BackupsPermission fromWeaviate(WeaviatePermission perm) {
-    return null;
-  }
-
   @AllArgsConstructor
-  public enum Action {
+  public enum Action implements CustomAction {
     MANAGE("manage_backups");
 
     @Getter

--- a/src/main/java/io/weaviate/client/v1/rbac/model/ClusterPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/ClusterPermission.java
@@ -1,0 +1,31 @@
+package io.weaviate.client.v1.rbac.model;
+
+import io.weaviate.client.v1.rbac.api.WeaviatePermission;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class ClusterPermission implements Permission<ClusterPermission> {
+  final String action;
+
+  public ClusterPermission(Action action) {
+    this.action = action.getValue();
+  }
+
+  @Override
+  public WeaviatePermission toWeaviate() {
+    return new WeaviatePermission(this.action);
+  }
+
+  @Override
+  public ClusterPermission fromWeaviate(WeaviatePermission perm) {
+    return null;
+  }
+
+  @AllArgsConstructor
+  public enum Action {
+    READ("read_cluster");
+
+    @Getter
+    private final String value;
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/model/ClusterPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/ClusterPermission.java
@@ -4,6 +4,7 @@ import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@Getter
 public class ClusterPermission implements Permission<ClusterPermission> {
   final String action;
 
@@ -11,18 +12,17 @@ public class ClusterPermission implements Permission<ClusterPermission> {
     this.action = action.getValue();
   }
 
+  ClusterPermission(String action) {
+    this(CustomAction.fromString(Action.class, action));
+  }
+
   @Override
   public WeaviatePermission toWeaviate() {
     return new WeaviatePermission(this.action);
   }
 
-  @Override
-  public ClusterPermission fromWeaviate(WeaviatePermission perm) {
-    return null;
-  }
-
   @AllArgsConstructor
-  public enum Action {
+  public enum Action implements CustomAction {
     READ("read_cluster");
 
     @Getter

--- a/src/main/java/io/weaviate/client/v1/rbac/model/ClusterPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/ClusterPermission.java
@@ -2,9 +2,11 @@ package io.weaviate.client.v1.rbac.model;
 
 import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
+@EqualsAndHashCode(callSuper = true)
 public class ClusterPermission extends Permission<ClusterPermission> {
   public ClusterPermission(Action action) {
     super(action);

--- a/src/main/java/io/weaviate/client/v1/rbac/model/ClusterPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/ClusterPermission.java
@@ -5,11 +5,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-public class ClusterPermission implements Permission<ClusterPermission> {
-  final String action;
-
+public class ClusterPermission extends Permission<ClusterPermission> {
   public ClusterPermission(Action action) {
-    this.action = action.getValue();
+    super(action);
   }
 
   ClusterPermission(String action) {

--- a/src/main/java/io/weaviate/client/v1/rbac/model/CollectionsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/CollectionsPermission.java
@@ -5,8 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-public class CollectionsPermission implements Permission<CollectionsPermission> {
-  final transient String action;
+public class CollectionsPermission extends Permission<CollectionsPermission> {
   final String collection;
   final String tenant;
 
@@ -19,7 +18,7 @@ public class CollectionsPermission implements Permission<CollectionsPermission> 
   }
 
   private CollectionsPermission(Action action, String collection, String tenant) {
-    this.action = action.getValue();
+    super(action);
     this.collection = collection;
     this.tenant = tenant;
   }
@@ -34,8 +33,10 @@ public class CollectionsPermission implements Permission<CollectionsPermission> 
     CREATE("create_collections"),
     READ("read_collections"),
     UPDATE("update_collections"),
-    DELETE("delete_collections"),
-    MANAGE("manage_collections");
+    DELETE("delete_collections");
+
+    // Not part of the public API yet.
+    // MANAGE("manage_collections");
 
     @Getter
     private final String value;

--- a/src/main/java/io/weaviate/client/v1/rbac/model/CollectionsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/CollectionsPermission.java
@@ -2,9 +2,11 @@ package io.weaviate.client.v1.rbac.model;
 
 import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
+@EqualsAndHashCode(callSuper = true)
 public class CollectionsPermission extends Permission<CollectionsPermission> {
   final String collection;
   final String tenant;

--- a/src/main/java/io/weaviate/client/v1/rbac/model/CollectionsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/CollectionsPermission.java
@@ -1,0 +1,44 @@
+package io.weaviate.client.v1.rbac.model;
+
+import io.weaviate.client.v1.rbac.api.WeaviatePermission;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+public class CollectionsPermission implements Permission<CollectionsPermission> {
+  final transient String action;
+  final String collection;
+  final String tenant;
+
+  public CollectionsPermission(Action action, String collection) {
+    this(action, collection, "*");
+  }
+
+  private CollectionsPermission(Action action, String collection, String tenant) {
+    this.action = action.getValue();
+    this.collection = collection;
+    this.tenant = tenant;
+  }
+
+  @Override
+  public WeaviatePermission toWeaviate() {
+    return new WeaviatePermission(this.action, this);
+  }
+
+  @Override
+  public CollectionsPermission fromWeaviate(WeaviatePermission perm) {
+    return null;
+  }
+
+  @AllArgsConstructor
+  public enum Action {
+    CREATE("create_collections"),
+    READ("read_collections"),
+    UPDATE("update_collections"),
+    DELETE("delete_collections"),
+    MANAGE("manage_collections");
+
+    @Getter
+    private final String value;
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/model/CollectionsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/CollectionsPermission.java
@@ -14,6 +14,10 @@ public class CollectionsPermission implements Permission<CollectionsPermission> 
     this(action, collection, "*");
   }
 
+  CollectionsPermission(String action, String collection) {
+    this(CustomAction.fromString(Action.class, action), collection);
+  }
+
   private CollectionsPermission(Action action, String collection, String tenant) {
     this.action = action.getValue();
     this.collection = collection;
@@ -25,13 +29,8 @@ public class CollectionsPermission implements Permission<CollectionsPermission> 
     return new WeaviatePermission(this.action, this);
   }
 
-  @Override
-  public CollectionsPermission fromWeaviate(WeaviatePermission perm) {
-    return null;
-  }
-
   @AllArgsConstructor
-  public enum Action {
+  public enum Action implements CustomAction {
     CREATE("create_collections"),
     READ("read_collections"),
     UPDATE("update_collections"),

--- a/src/main/java/io/weaviate/client/v1/rbac/model/DataPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/DataPermission.java
@@ -15,6 +15,10 @@ public class DataPermission implements Permission<DataPermission> {
     this(action, collection, "*", "*");
   }
 
+  DataPermission(String action, String collection) {
+    this(CustomAction.fromString(Action.class, action), collection);
+  }
+
   private DataPermission(Action action, String collection, String object, String tenant) {
     this.action = action.getValue();
     this.collection = collection;
@@ -27,13 +31,8 @@ public class DataPermission implements Permission<DataPermission> {
     return new WeaviatePermission(this.action, this);
   }
 
-  @Override
-  public DataPermission fromWeaviate(WeaviatePermission perm) {
-    return null;
-  }
-
   @AllArgsConstructor
-  public enum Action {
+  public enum Action implements CustomAction {
     CREATE("create_data"),
     READ("read_data"),
     UPDATE("update_data"),

--- a/src/main/java/io/weaviate/client/v1/rbac/model/DataPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/DataPermission.java
@@ -1,0 +1,46 @@
+package io.weaviate.client.v1.rbac.model;
+
+import io.weaviate.client.v1.rbac.api.WeaviatePermission;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+public class DataPermission implements Permission<DataPermission> {
+  final transient String action;
+  final String collection;
+  final String object;
+  final String tenant;
+
+  public DataPermission(Action action, String collection) {
+    this(action, collection, "*", "*");
+  }
+
+  private DataPermission(Action action, String collection, String object, String tenant) {
+    this.action = action.getValue();
+    this.collection = collection;
+    this.object = object;
+    this.tenant = tenant;
+  }
+
+  @Override
+  public WeaviatePermission toWeaviate() {
+    return new WeaviatePermission(this.action, this);
+  }
+
+  @Override
+  public DataPermission fromWeaviate(WeaviatePermission perm) {
+    return null;
+  }
+
+  @AllArgsConstructor
+  public enum Action {
+    CREATE("create_data"),
+    READ("read_data"),
+    UPDATE("update_data"),
+    DELETE("delete_data"),
+    MANAGE("manage_data");
+
+    @Getter
+    private final String value;
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/model/DataPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/DataPermission.java
@@ -2,9 +2,11 @@ package io.weaviate.client.v1.rbac.model;
 
 import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
+@EqualsAndHashCode(callSuper = true)
 public class DataPermission extends Permission<DataPermission> {
   final String collection;
   final String object;

--- a/src/main/java/io/weaviate/client/v1/rbac/model/DataPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/DataPermission.java
@@ -5,8 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-public class DataPermission implements Permission<DataPermission> {
-  final transient String action;
+public class DataPermission extends Permission<DataPermission> {
   final String collection;
   final String object;
   final String tenant;
@@ -20,7 +19,7 @@ public class DataPermission implements Permission<DataPermission> {
   }
 
   private DataPermission(Action action, String collection, String object, String tenant) {
-    this.action = action.getValue();
+    super(action);
     this.collection = collection;
     this.object = object;
     this.tenant = tenant;

--- a/src/main/java/io/weaviate/client/v1/rbac/model/NodesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/NodesPermission.java
@@ -4,9 +4,11 @@ import com.google.gson.annotations.SerializedName;
 
 import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
+@EqualsAndHashCode(callSuper = true)
 public class NodesPermission extends Permission<NodesPermission> {
   final String collection;
   final Verbosity verbosity;

--- a/src/main/java/io/weaviate/client/v1/rbac/model/NodesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/NodesPermission.java
@@ -1,0 +1,50 @@
+package io.weaviate.client.v1.rbac.model;
+
+import io.weaviate.client.v1.rbac.api.WeaviatePermission;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+public class NodesPermission implements Permission<NodesPermission> {
+  final transient String action;
+  final String collection;
+  final Verbosity verbosity;
+
+  public NodesPermission(Action action, Verbosity verbosity) {
+    this(action, verbosity, "*");
+  }
+
+  public NodesPermission(Action action, Verbosity verbosity, String collection) {
+    this.action = action.getValue();
+    this.collection = collection;
+    this.verbosity = verbosity;
+  }
+
+  @Override
+  public WeaviatePermission toWeaviate() {
+    return new WeaviatePermission(this.action, this);
+  }
+
+  @Override
+  public NodesPermission fromWeaviate(WeaviatePermission perm) {
+    return null;
+  }
+
+  @AllArgsConstructor
+  public enum Action {
+    READ("read_nodes");
+
+    @Getter
+    private final String value;
+  }
+
+  @AllArgsConstructor
+  public enum Verbosity {
+    MINIMAL("minimal"),
+    VERBOSE("verbose");
+
+    @Getter
+    private final String value;
+  }
+
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/model/NodesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/NodesPermission.java
@@ -7,8 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-public class NodesPermission implements Permission<NodesPermission> {
-  final transient String action;
+public class NodesPermission extends Permission<NodesPermission> {
   final String collection;
   final Verbosity verbosity;
 
@@ -25,7 +24,7 @@ public class NodesPermission implements Permission<NodesPermission> {
   }
 
   public NodesPermission(Action action, Verbosity verbosity, String collection) {
-    this.action = action.getValue();
+    super(action);
     this.collection = collection;
     this.verbosity = verbosity;
   }

--- a/src/main/java/io/weaviate/client/v1/rbac/model/NodesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/NodesPermission.java
@@ -1,5 +1,7 @@
 package io.weaviate.client.v1.rbac.model;
 
+import com.google.gson.annotations.SerializedName;
+
 import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,6 +16,14 @@ public class NodesPermission implements Permission<NodesPermission> {
     this(action, verbosity, "*");
   }
 
+  NodesPermission(String action, Verbosity verbosity) {
+    this(CustomAction.fromString(Action.class, action), verbosity);
+  }
+
+  NodesPermission(String action, Verbosity verbosity, String collection) {
+    this(CustomAction.fromString(Action.class, action), verbosity, collection);
+  }
+
   public NodesPermission(Action action, Verbosity verbosity, String collection) {
     this.action = action.getValue();
     this.collection = collection;
@@ -25,13 +35,8 @@ public class NodesPermission implements Permission<NodesPermission> {
     return new WeaviatePermission(this.action, this);
   }
 
-  @Override
-  public NodesPermission fromWeaviate(WeaviatePermission perm) {
-    return null;
-  }
-
   @AllArgsConstructor
-  public enum Action {
+  public enum Action implements CustomAction {
     READ("read_nodes");
 
     @Getter
@@ -40,11 +45,10 @@ public class NodesPermission implements Permission<NodesPermission> {
 
   @AllArgsConstructor
   public enum Verbosity {
-    MINIMAL("minimal"),
-    VERBOSE("verbose");
-
-    @Getter
-    private final String value;
+    @SerializedName("minimal")
+    MINIMAL,
+    @SerializedName("verbose")
+    VERBOSE;
   }
 
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
@@ -1,0 +1,45 @@
+package io.weaviate.client.v1.rbac.model;
+
+import io.weaviate.client.v1.rbac.api.WeaviatePermission;
+
+public interface Permission<P extends Permission<P>> {
+  WeaviatePermission toWeaviate();
+
+  P fromWeaviate(WeaviatePermission perm);
+
+  static ClusterPermission backups(ClusterPermission.Action action) {
+    return new ClusterPermission(action);
+  }
+
+  static BackupsPermission backups(BackupsPermission.Action action, String collection) {
+    return new BackupsPermission(action, collection);
+  }
+
+  static CollectionsPermission collections(CollectionsPermission.Action action, String collection) {
+    return new CollectionsPermission(action, collection);
+  }
+
+  static DataPermission data(DataPermission.Action action, String collection) {
+    return new DataPermission(action, collection);
+  }
+
+  static NodesPermission nodes(NodesPermission.Action action, NodesPermission.Verbosity verbosity) {
+    return new NodesPermission(action, verbosity);
+  }
+
+  static NodesPermission nodes(NodesPermission.Action action, NodesPermission.Verbosity verbosity, String collection) {
+    return new NodesPermission(action, verbosity, collection);
+  }
+
+  static RolesPermission roles(RolesPermission.Action action, String role) {
+    return new RolesPermission(action, role);
+  }
+
+  static TenantsPermission tenants(TenantsPermission.Action action) {
+    return new TenantsPermission(action);
+  }
+
+  static UsersPermission users(UsersPermission.Action action) {
+    return new UsersPermission(action);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
@@ -37,7 +37,7 @@ public abstract class Permission<P extends Permission<P>> {
       return new UsersPermission(action);
     }
     return null;
-  };
+  }
 
   public static BackupsPermission backups(BackupsPermission.Action action, String collection) {
     return new BackupsPermission(action, collection);
@@ -75,6 +75,11 @@ public abstract class Permission<P extends Permission<P>> {
   // public static UsersPermission users(UsersPermission.Action action) {
   // return new UsersPermission(action);
   // }
+
+  public String toString() {
+    return String.format("Permission<action=%s>", this.action);
+  }
+
 }
 
 interface CustomAction {

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
@@ -1,8 +1,10 @@
 package io.weaviate.client.v1.rbac.model;
 
 import io.weaviate.client.v1.rbac.api.WeaviatePermission;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+@EqualsAndHashCode
 public abstract class Permission<P extends Permission<P>> {
   @Getter
   final transient String action;
@@ -79,7 +81,6 @@ public abstract class Permission<P extends Permission<P>> {
   public String toString() {
     return String.format("Permission<action=%s>", this.action);
   }
-
 }
 
 interface CustomAction {

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
@@ -5,14 +5,43 @@ import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 public interface Permission<P extends Permission<P>> {
   WeaviatePermission toWeaviate();
 
-  P fromWeaviate(WeaviatePermission perm);
-
-  static ClusterPermission backups(ClusterPermission.Action action) {
-    return new ClusterPermission(action);
-  }
+  @SuppressWarnings("unchecked")
+  static <P extends Permission<P>> P fromWeaviate(WeaviatePermission perm) {
+    String action = perm.getAction();
+    if (perm.getBackups() != null) {
+      return (P) new BackupsPermission(action, perm.getBackups().getCollection());
+    } else if (perm.getCollections() != null) {
+      return (P) new CollectionsPermission(action, perm.getCollections().getCollection());
+    } else if (perm.getData() != null) {
+      return (P) new DataPermission(action, perm.getData().getCollection());
+    } else if (perm.getNodes() != null) {
+      NodesPermission out;
+      NodesPermission nodes = perm.getNodes();
+      if (nodes.getCollection() != null) {
+        out = new NodesPermission(action, perm.getNodes().getVerbosity(), nodes.getCollection());
+      } else {
+        out = new NodesPermission(action, perm.getNodes().getVerbosity());
+      }
+      return (P) out;
+    } else if (perm.getRoles() != null) {
+      return (P) new RolesPermission(action, perm.getRoles().getRole());
+    } else if (perm.getTenants() != null) {
+      return (P) new TenantsPermission(action);
+    } else if (CustomAction.isValid(ClusterPermission.Action.class, action)) {
+      System.out.println("cluster:" + action);
+      return (P) new ClusterPermission(action);
+    } else if (CustomAction.isValid(UsersPermission.Action.class, action)) {
+      return (P) new UsersPermission(action);
+    }
+    return null;
+  };
 
   static BackupsPermission backups(BackupsPermission.Action action, String collection) {
     return new BackupsPermission(action, collection);
+  }
+
+  static ClusterPermission cluster(ClusterPermission.Action action) {
+    return new ClusterPermission(action);
   }
 
   static CollectionsPermission collections(CollectionsPermission.Action action, String collection) {
@@ -41,5 +70,27 @@ public interface Permission<P extends Permission<P>> {
 
   static UsersPermission users(UsersPermission.Action action) {
     return new UsersPermission(action);
+  }
+}
+
+interface CustomAction {
+  String getValue();
+
+  static <E extends Enum<E> & CustomAction> E fromString(Class<E> enumClass, String value) {
+    for (E action : enumClass.getEnumConstants()) {
+      if (action.getValue().equals(value)) {
+        return action;
+      }
+    }
+    throw new IllegalArgumentException("No enum constant for value: " + value);
+  }
+
+  static <A extends CustomAction> boolean isValid(Class<A> enumClass, String value) {
+    for (CustomAction action : enumClass.getEnumConstants()) {
+      if (action.getValue().equals(value)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
@@ -1,76 +1,80 @@
 package io.weaviate.client.v1.rbac.model;
 
 import io.weaviate.client.v1.rbac.api.WeaviatePermission;
+import lombok.Getter;
 
-public interface Permission<P extends Permission<P>> {
-  WeaviatePermission toWeaviate();
+public abstract class Permission<P extends Permission<P>> {
+  @Getter
+  final transient String action;
 
-  @SuppressWarnings("unchecked")
-  static <P extends Permission<P>> P fromWeaviate(WeaviatePermission perm) {
+  Permission(CustomAction action) {
+    this.action = action.getValue();
+  }
+
+  public abstract WeaviatePermission toWeaviate();
+
+  public static Permission<?> fromWeaviate(WeaviatePermission perm) {
     String action = perm.getAction();
     if (perm.getBackups() != null) {
-      return (P) new BackupsPermission(action, perm.getBackups().getCollection());
+      return new BackupsPermission(action, perm.getBackups().getCollection());
     } else if (perm.getCollections() != null) {
-      return (P) new CollectionsPermission(action, perm.getCollections().getCollection());
+      return new CollectionsPermission(action, perm.getCollections().getCollection());
     } else if (perm.getData() != null) {
-      return (P) new DataPermission(action, perm.getData().getCollection());
+      return new DataPermission(action, perm.getData().getCollection());
     } else if (perm.getNodes() != null) {
-      NodesPermission out;
       NodesPermission nodes = perm.getNodes();
       if (nodes.getCollection() != null) {
-        out = new NodesPermission(action, perm.getNodes().getVerbosity(), nodes.getCollection());
-      } else {
-        out = new NodesPermission(action, perm.getNodes().getVerbosity());
+        return new NodesPermission(action, perm.getNodes().getVerbosity(), nodes.getCollection());
       }
-      return (P) out;
+      return new NodesPermission(action, perm.getNodes().getVerbosity());
     } else if (perm.getRoles() != null) {
-      return (P) new RolesPermission(action, perm.getRoles().getRole());
+      return new RolesPermission(action, perm.getRoles().getRole());
     } else if (perm.getTenants() != null) {
-      return (P) new TenantsPermission(action);
+      return new TenantsPermission(action);
     } else if (CustomAction.isValid(ClusterPermission.Action.class, action)) {
-      System.out.println("cluster:" + action);
-      return (P) new ClusterPermission(action);
+      return new ClusterPermission(action);
     } else if (CustomAction.isValid(UsersPermission.Action.class, action)) {
-      return (P) new UsersPermission(action);
+      return new UsersPermission(action);
     }
     return null;
   };
 
-  static BackupsPermission backups(BackupsPermission.Action action, String collection) {
+  public static BackupsPermission backups(BackupsPermission.Action action, String collection) {
     return new BackupsPermission(action, collection);
   }
 
-  static ClusterPermission cluster(ClusterPermission.Action action) {
+  public static ClusterPermission cluster(ClusterPermission.Action action) {
     return new ClusterPermission(action);
   }
 
-  static CollectionsPermission collections(CollectionsPermission.Action action, String collection) {
+  public static CollectionsPermission collections(CollectionsPermission.Action action, String collection) {
     return new CollectionsPermission(action, collection);
   }
 
-  static DataPermission data(DataPermission.Action action, String collection) {
+  public static DataPermission data(DataPermission.Action action, String collection) {
     return new DataPermission(action, collection);
   }
 
-  static NodesPermission nodes(NodesPermission.Action action, NodesPermission.Verbosity verbosity) {
+  public static NodesPermission nodes(NodesPermission.Action action, NodesPermission.Verbosity verbosity) {
     return new NodesPermission(action, verbosity);
   }
 
-  static NodesPermission nodes(NodesPermission.Action action, NodesPermission.Verbosity verbosity, String collection) {
+  public static NodesPermission nodes(NodesPermission.Action action, NodesPermission.Verbosity verbosity,
+      String collection) {
     return new NodesPermission(action, verbosity, collection);
   }
 
-  static RolesPermission roles(RolesPermission.Action action, String role) {
+  public static RolesPermission roles(RolesPermission.Action action, String role) {
     return new RolesPermission(action, role);
   }
 
-  static TenantsPermission tenants(TenantsPermission.Action action) {
+  public static TenantsPermission tenants(TenantsPermission.Action action) {
     return new TenantsPermission(action);
   }
 
-  static UsersPermission users(UsersPermission.Action action) {
-    return new UsersPermission(action);
-  }
+  // public static UsersPermission users(UsersPermission.Action action) {
+  // return new UsersPermission(action);
+  // }
 }
 
 interface CustomAction {

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Role.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Role.java
@@ -1,15 +1,22 @@
 package io.weaviate.client.v1.rbac.model;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public class Role {
   public final String name;
-  public final List<Permission<?>> permissions;
+  public List<? extends Permission<?>> permissions = new ArrayList<>();
 
-  public Role(String name, Permission<?>... permissions) {
-    this.name = name;
-    this.permissions = Arrays.asList(permissions);
+  public String toString() {
+    return String.format(
+        "Role<name='%s', permissions=[%s]>",
+        this.name, permissions.isEmpty()
+            ? "none"
+            : String.join(", ", permissions.stream().map(Permission::getAction).toList()));
   }
-
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Role.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Role.java
@@ -4,10 +4,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@EqualsAndHashCode
 public class Role {
   public final String name;
   public List<? extends Permission<?>> permissions = new ArrayList<>();

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Role.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Role.java
@@ -1,0 +1,15 @@
+package io.weaviate.client.v1.rbac.model;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class Role {
+  public final String name;
+  public final List<Permission<?>> permissions;
+
+  public Role(String name, Permission<?>... permissions) {
+    this.name = name;
+    this.permissions = Arrays.asList(permissions);
+  }
+
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
@@ -4,6 +4,7 @@ import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@Getter
 public class RolesPermission implements Permission<RolesPermission> {
   final transient String action;
   final String role;
@@ -13,18 +14,17 @@ public class RolesPermission implements Permission<RolesPermission> {
     this.role = role;
   }
 
+  RolesPermission(String action, String role) {
+    this(CustomAction.fromString(Action.class, action), role);
+  }
+
   @Override
   public WeaviatePermission toWeaviate() {
     return new WeaviatePermission(this.action, this);
   }
 
-  @Override
-  public RolesPermission fromWeaviate(WeaviatePermission perm) {
-    return null;
-  }
-
   @AllArgsConstructor
-  public enum Action {
+  public enum Action implements CustomAction {
     READ("read_roles"),
     MANAGE("manage_roles");
 

--- a/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
@@ -1,0 +1,34 @@
+package io.weaviate.client.v1.rbac.model;
+
+import io.weaviate.client.v1.rbac.api.WeaviatePermission;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class RolesPermission implements Permission<RolesPermission> {
+  final transient String action;
+  final String role;
+
+  public RolesPermission(Action action, String role) {
+    this.action = action.getValue();
+    this.role = role;
+  }
+
+  @Override
+  public WeaviatePermission toWeaviate() {
+    return new WeaviatePermission(this.action, this);
+  }
+
+  @Override
+  public RolesPermission fromWeaviate(WeaviatePermission perm) {
+    return null;
+  }
+
+  @AllArgsConstructor
+  public enum Action {
+    READ("read_roles"),
+    MANAGE("manage_roles");
+
+    @Getter
+    private final String value;
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
@@ -2,9 +2,11 @@ package io.weaviate.client.v1.rbac.model;
 
 import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
+@EqualsAndHashCode(callSuper = true)
 public class RolesPermission extends Permission<RolesPermission> {
   final String role;
 

--- a/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
@@ -5,12 +5,11 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-public class RolesPermission implements Permission<RolesPermission> {
-  final transient String action;
+public class RolesPermission extends Permission<RolesPermission> {
   final String role;
 
   public RolesPermission(Action action, String role) {
-    this.action = action.getValue();
+    super(action);
     this.role = role;
   }
 

--- a/src/main/java/io/weaviate/client/v1/rbac/model/TenantsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/TenantsPermission.java
@@ -13,6 +13,10 @@ public class TenantsPermission implements Permission<TenantsPermission> {
     this(action, "*");
   }
 
+  TenantsPermission(String action) {
+    this(CustomAction.fromString(Action.class, action));
+  }
+
   private TenantsPermission(Action action, String tenant) {
     this.action = action.getValue();
     this.tenant = tenant;
@@ -23,13 +27,8 @@ public class TenantsPermission implements Permission<TenantsPermission> {
     return new WeaviatePermission(this.action, this);
   }
 
-  @Override
-  public TenantsPermission fromWeaviate(WeaviatePermission perm) {
-    return null;
-  }
-
   @AllArgsConstructor
-  public enum Action {
+  public enum Action implements CustomAction {
     CREATE("create_tenants"),
     READ("read_tenants"),
     UPDATE("update_tenants"),

--- a/src/main/java/io/weaviate/client/v1/rbac/model/TenantsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/TenantsPermission.java
@@ -5,8 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-public class TenantsPermission implements Permission<TenantsPermission> {
-  final transient String action;
+public class TenantsPermission extends Permission<TenantsPermission> {
   final String tenant;
 
   public TenantsPermission(Action action) {
@@ -18,7 +17,7 @@ public class TenantsPermission implements Permission<TenantsPermission> {
   }
 
   private TenantsPermission(Action action, String tenant) {
-    this.action = action.getValue();
+    super(action);
     this.tenant = tenant;
   }
 

--- a/src/main/java/io/weaviate/client/v1/rbac/model/TenantsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/TenantsPermission.java
@@ -1,0 +1,41 @@
+package io.weaviate.client.v1.rbac.model;
+
+import io.weaviate.client.v1.rbac.api.WeaviatePermission;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+public class TenantsPermission implements Permission<TenantsPermission> {
+  final transient String action;
+  final String tenant;
+
+  public TenantsPermission(Action action) {
+    this(action, "*");
+  }
+
+  private TenantsPermission(Action action, String tenant) {
+    this.action = action.getValue();
+    this.tenant = tenant;
+  }
+
+  @Override
+  public WeaviatePermission toWeaviate() {
+    return new WeaviatePermission(this.action, this);
+  }
+
+  @Override
+  public TenantsPermission fromWeaviate(WeaviatePermission perm) {
+    return null;
+  }
+
+  @AllArgsConstructor
+  public enum Action {
+    CREATE("create_tenants"),
+    READ("read_tenants"),
+    UPDATE("update_tenants"),
+    DELETE("delete_tenants");
+
+    @Getter
+    private final String value;
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/model/TenantsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/TenantsPermission.java
@@ -2,9 +2,11 @@ package io.weaviate.client.v1.rbac.model;
 
 import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
+@EqualsAndHashCode(callSuper = true)
 public class TenantsPermission extends Permission<TenantsPermission> {
   final String tenant;
 

--- a/src/main/java/io/weaviate/client/v1/rbac/model/UsersPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/UsersPermission.java
@@ -1,0 +1,32 @@
+
+package io.weaviate.client.v1.rbac.model;
+
+import io.weaviate.client.v1.rbac.api.WeaviatePermission;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class UsersPermission implements Permission<UsersPermission> {
+  final String action;
+
+  public UsersPermission(Action action) {
+    this.action = action.getValue();
+  }
+
+  @Override
+  public WeaviatePermission toWeaviate() {
+    return new WeaviatePermission(this.action);
+  }
+
+  @Override
+  public UsersPermission fromWeaviate(WeaviatePermission perm) {
+    return null;
+  }
+
+  @AllArgsConstructor
+  public enum Action {
+    MANAGE("manage_users");
+
+    @Getter
+    private final String value;
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/model/UsersPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/UsersPermission.java
@@ -5,11 +5,14 @@ import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-public class UsersPermission implements Permission<UsersPermission> {
-  final String action;
-
+/**
+ * UsersPermission controls access to dynamic user management capabilities.
+ * These will be introduced in v1.30. Until then the class will remain
+ * package-private.
+ */
+class UsersPermission extends Permission<UsersPermission> {
   public UsersPermission(Action action) {
-    this.action = action.getValue();
+    super(action);
   }
 
   UsersPermission(String action) {

--- a/src/main/java/io/weaviate/client/v1/rbac/model/UsersPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/UsersPermission.java
@@ -12,18 +12,17 @@ public class UsersPermission implements Permission<UsersPermission> {
     this.action = action.getValue();
   }
 
+  UsersPermission(String action) {
+    this(CustomAction.fromString(Action.class, action));
+  }
+
   @Override
   public WeaviatePermission toWeaviate() {
     return new WeaviatePermission(this.action);
   }
 
-  @Override
-  public UsersPermission fromWeaviate(WeaviatePermission perm) {
-    return null;
-  }
-
   @AllArgsConstructor
-  public enum Action {
+  public enum Action implements CustomAction {
     MANAGE("manage_users");
 
     @Getter

--- a/src/test/java/io/weaviate/client/v1/rbac/model/PermissionTest.java
+++ b/src/test/java/io/weaviate/client/v1/rbac/model/PermissionTest.java
@@ -1,10 +1,8 @@
 package io.weaviate.client.v1.rbac.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.junit.Test;
@@ -13,7 +11,6 @@ import org.testcontainers.shaded.org.hamcrest.Matcher;
 import org.testcontainers.shaded.org.hamcrest.MatcherAssert;
 import org.testcontainers.shaded.org.hamcrest.beans.SamePropertyValuesAs;
 
-import com.google.gson.Gson;
 import com.jparams.junit4.JParamsTestRunner;
 import com.jparams.junit4.data.DataMethod;
 
@@ -28,7 +25,7 @@ public class PermissionTest {
     DataPermission data = new DataPermission(DataPermission.Action.MANAGE, "Pizza");
     NodesPermission nodes = new NodesPermission(NodesPermission.Action.READ, Verbosity.MINIMAL, "Pizza");
     RolesPermission roles = new RolesPermission(RolesPermission.Action.MANAGE, "TestWriter");
-    CollectionsPermission collections = new CollectionsPermission(CollectionsPermission.Action.MANAGE, "Pizza");
+    CollectionsPermission collections = new CollectionsPermission(CollectionsPermission.Action.CREATE, "Pizza");
     ClusterPermission cluster = new ClusterPermission(ClusterPermission.Action.READ);
     TenantsPermission tenants = new TenantsPermission(TenantsPermission.Action.READ);
 
@@ -98,7 +95,7 @@ public class PermissionTest {
 
   @Test
   public void testDefaultCollectionsPermission() {
-    CollectionsPermission perm = new CollectionsPermission(CollectionsPermission.Action.MANAGE, "Pizza");
+    CollectionsPermission perm = new CollectionsPermission(CollectionsPermission.Action.CREATE, "Pizza");
     assertThat(perm).as("collection permission must have tenant=*")
         .returns("*", CollectionsPermission::getTenant);
   }

--- a/src/test/java/io/weaviate/client/v1/rbac/model/PermissionTest.java
+++ b/src/test/java/io/weaviate/client/v1/rbac/model/PermissionTest.java
@@ -58,7 +58,7 @@ public class PermissionTest {
         {
             "collections permission",
             (Supplier<Permission<?>>) () -> collections,
-            new WeaviatePermission("manage_collections", collections),
+            new WeaviatePermission("create_collections", collections),
         },
         {
             "cluster permission",

--- a/src/test/java/io/weaviate/integration/client/WeaviateDockerCompose.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateDockerCompose.java
@@ -2,6 +2,7 @@ package io.weaviate.integration.client;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -84,7 +85,6 @@ public class WeaviateDockerCompose implements TestRule {
       withEnv("AUTHORIZATION_RBAC_ENABLED", "true");
       withEnv("AUTHENTICATION_APIKEY_USERS", adminUser);
       withEnv("AUTHENTICATION_APIKEY_ALLOWED_KEYS", makeSecret(adminUser));
-      withEnv("AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED", "false");
       withEnv("AUTHORIZATION_ADMIN_USERS", adminUser);
     }
 

--- a/src/test/java/io/weaviate/integration/client/WeaviateDockerCompose.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateDockerCompose.java
@@ -13,32 +13,40 @@ import org.testcontainers.weaviate.WeaviateContainer;
 
 public class WeaviateDockerCompose implements TestRule {
 
+  /** Weaviate Docker image to create a container from. */
   private final String weaviateVersion;
   private final boolean withOffloadS3;
-  private final boolean localServer;
+
+  /** Username of the admin user for instances using RBAC. */
+  private final String adminUser;
 
   public WeaviateDockerCompose() {
     this.weaviateVersion = WeaviateDockerImage.WEAVIATE_DOCKER_IMAGE;
     this.withOffloadS3 = false;
-    this.localServer = false;
-  }
-
-  public WeaviateDockerCompose(boolean localServer) {
-    this.weaviateVersion = WeaviateDockerImage.WEAVIATE_DOCKER_IMAGE;
-    this.withOffloadS3 = false;
-    this.localServer = localServer;
+    this.adminUser = null;
   }
 
   public WeaviateDockerCompose(String version) {
     this.weaviateVersion = String.format("semitechnologies/weaviate:%s", version);
     this.withOffloadS3 = false;
-    this.localServer = false;
+    this.adminUser = null;
   }
 
   public WeaviateDockerCompose(String version, boolean withOffloadS3) {
     this.weaviateVersion = String.format("semitechnologies/weaviate:%s", version);
     this.withOffloadS3 = withOffloadS3;
-    this.localServer = false;
+    this.adminUser = null;
+  }
+
+  public WeaviateDockerCompose(String version, String adminUser) {
+    this.weaviateVersion = WeaviateDockerImage.WEAVIATE_DOCKER_IMAGE;
+    this.withOffloadS3 = false;
+    this.adminUser = adminUser;
+  }
+
+  /** Create docker-compose deployment with auth and RBAC-authz enabled. */
+  public static WeaviateDockerCompose rbac(String adminUser) {
+    return new WeaviateDockerCompose(WeaviateDockerImage.WEAVIATE_DOCKER_IMAGE, adminUser);
   }
 
   public static class Weaviate extends WeaviateContainer {
@@ -66,6 +74,28 @@ public class WeaviateDockerCompose implements TestRule {
       withEnv("PERSISTENCE_FLUSH_IDLE_MEMTABLES_AFTER", "1");
       withEnv("ENABLE_MODULES", String.join(",", enableModules));
       withCreateContainerCmdModifier(cmd -> cmd.withHostName("weaviate"));
+    }
+
+    /** Create Weaviate container with RBAC authz and an admin user. */
+    public Weaviate(String dockerImageName, boolean withOffloadS3, String adminUser) {
+      this(dockerImageName, withOffloadS3);
+      withEnv("AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED", "false");
+      withEnv("AUTHENTICATION_APIKEY_ENABLED", "true");
+      withEnv("AUTHORIZATION_RBAC_ENABLED", "true");
+      withEnv("AUTHENTICATION_APIKEY_USERS", adminUser);
+      withEnv("AUTHENTICATION_APIKEY_ALLOWED_KEYS", makeSecret(adminUser));
+      withEnv("AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED", "false");
+      withEnv("AUTHORIZATION_ADMIN_USERS", adminUser);
+    }
+
+    /**
+     * Generate API secret for a username. When running an instance with
+     * authentication enabled, {@link Weaviate} will use this method to generate
+     * secrets for all users.
+     * Use this method to get a valid API key for a test client.
+     */
+    public static String makeSecret(String user) {
+      return user + "-secret";
     }
   }
 
@@ -108,30 +138,24 @@ public class WeaviateDockerCompose implements TestRule {
     }
     contextionary = new Contextionary();
     contextionary.start();
-    weaviate = new Weaviate(this.weaviateVersion, withOffloadS3);
-    if (!localServer) {
-      weaviate.start();
+    if (adminUser == null) {
+      weaviate = new Weaviate(this.weaviateVersion, this.withOffloadS3);
+    } else {
+      weaviate = new Weaviate(this.weaviateVersion, this.withOffloadS3, this.adminUser);
     }
+    weaviate.start();
   }
 
   public String getHttpHostAddress() {
-    if (localServer) {
-      return "127.0.0.1:8080";
-    }
     return weaviate.getHttpHostAddress();
   }
 
   public String getGrpcHostAddress() {
-    if (localServer) {
-      return "127.0.0.1:50051";
-    }
     return weaviate.getGrpcHostAddress();
   }
 
   public void stop() {
-    if (!localServer) {
-      weaviate.stop();
-    }
+    weaviate.stop();
     contextionary.stop();
     if (withOffloadS3) {
       minio.stop();

--- a/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
@@ -3,12 +3,12 @@ package io.weaviate.integration.client;
 public class WeaviateVersion {
 
   // docker image version
-  public static final String WEAVIATE_IMAGE = "1.27.7-8f0e033";
+  public static final String WEAVIATE_IMAGE = "1.28.3-f73fcee";
 
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_VERSION = "1.27.7";
+  public static final String EXPECTED_WEAVIATE_VERSION = "1.28.3-f73fcee";
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_GIT_HASH = "8f0e033";
+  public static final String EXPECTED_WEAVIATE_GIT_HASH = "34bb9ae";
 
   private WeaviateVersion() {
   }

--- a/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
@@ -8,7 +8,7 @@ public class WeaviateVersion {
   // to be set according to weaviate docker image
   public static final String EXPECTED_WEAVIATE_VERSION = "1.28.3";
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_GIT_HASH = "34bb9ae";
+  public static final String EXPECTED_WEAVIATE_GIT_HASH = "f73fcee";
 
   private WeaviateVersion() {
   }

--- a/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
@@ -6,7 +6,7 @@ public class WeaviateVersion {
   public static final String WEAVIATE_IMAGE = "1.28.3-f73fcee";
 
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_VERSION = "1.28.3-f73fcee";
+  public static final String EXPECTED_WEAVIATE_VERSION = "1.28.3";
   // to be set according to weaviate docker image
   public static final String EXPECTED_WEAVIATE_GIT_HASH = "34bb9ae";
 

--- a/src/test/java/io/weaviate/integration/client/async/schema/ClientSchemaTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/schema/ClientSchemaTest.java
@@ -468,7 +468,7 @@ public class ClientSchemaTest {
       //then
       assertResultTrue(createStatus);
 
-      assertResultError("tokenization in body should be one of [word lowercase whitespace field trigram gse kagome_kr]", notExistingTokenizationCreateStatus);
+      assertResultError("tokenization in body should be one of [word lowercase whitespace field trigram gse kagome_kr kagome_ja]", notExistingTokenizationCreateStatus);
       assertResultError("Tokenization is not allowed for data type 'int'", notSupportedTokenizationForIntCreateStatus);
     }
   }

--- a/src/test/java/io/weaviate/integration/client/rbac/ClientRbacTest.java
+++ b/src/test/java/io/weaviate/integration/client/rbac/ClientRbacTest.java
@@ -28,10 +28,12 @@ import io.weaviate.client.v1.rbac.model.Role;
 import io.weaviate.client.v1.rbac.model.RolesPermission;
 import io.weaviate.client.v1.rbac.model.TenantsPermission;
 import io.weaviate.integration.client.WeaviateDockerCompose;
+import io.weaviate.integration.client.WeaviateDockerCompose.Weaviate;
 
 public class ClientRbacTest {
   private static final String adminRole = "admin";
   private static final String viewerRole = "viewer";
+  private static final String adminUser = "john-doe";
 
   private Roles roles;
 
@@ -39,12 +41,12 @@ public class ClientRbacTest {
   public TestName currentTest = new TestName();
 
   @ClassRule
-  public static WeaviateDockerCompose compose = new WeaviateDockerCompose(true);
+  public static WeaviateDockerCompose compose = WeaviateDockerCompose.rbac(adminUser);
 
   @Before
   public void before() throws AuthException {
     Config config = new Config("http", compose.getHttpHostAddress());
-    roles = WeaviateAuthClient.apiKey(config, "jp-secret-key").roles();
+    roles = WeaviateAuthClient.apiKey(config, Weaviate.makeSecret(adminUser)).roles();
   }
 
   public static Object[][] rolesToCreate() {
@@ -78,7 +80,6 @@ public class ClientRbacTest {
     try {
       // Arrange
       roles.deleter().withName(myRole).run();
-
       roles.creator().withName(myRole)
           .withPermissions(
               Permission.backups(BackupsPermission.Action.MANAGE, myCollection),

--- a/src/test/java/io/weaviate/integration/client/rbac/ClientRbacTest.java
+++ b/src/test/java/io/weaviate/integration/client/rbac/ClientRbacTest.java
@@ -1,0 +1,121 @@
+package io.weaviate.integration.client.rbac;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.list;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.WeaviateAuthClient;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.auth.exception.AuthException;
+import io.weaviate.client.v1.rbac.Roles;
+import io.weaviate.client.v1.rbac.model.BackupsPermission;
+import io.weaviate.client.v1.rbac.model.ClusterPermission;
+import io.weaviate.client.v1.rbac.model.CollectionsPermission;
+import io.weaviate.client.v1.rbac.model.DataPermission;
+import io.weaviate.client.v1.rbac.model.NodesPermission;
+import io.weaviate.client.v1.rbac.model.NodesPermission.Verbosity;
+import io.weaviate.client.v1.rbac.model.Permission;
+import io.weaviate.client.v1.rbac.model.Role;
+import io.weaviate.client.v1.rbac.model.RolesPermission;
+import io.weaviate.client.v1.rbac.model.TenantsPermission;
+import io.weaviate.integration.client.WeaviateDockerCompose;
+
+public class ClientRbacTest {
+  private static final String adminRole = "admin";
+  private static final String viewerRole = "viewer";
+
+  private Roles roles;
+
+  @Rule
+  public TestName currentTest = new TestName();
+
+  @ClassRule
+  public static WeaviateDockerCompose compose = new WeaviateDockerCompose(true);
+
+  @Before
+  public void before() throws AuthException {
+    Config config = new Config("http", compose.getHttpHostAddress());
+    roles = WeaviateAuthClient.apiKey(config, "jp-secret-key").roles();
+  }
+
+  public static Object[][] rolesToCreate() {
+    return new Object[][] {
+    };
+  }
+
+  /**
+   * By default the admin user which we use to run the tests
+   * will have 'admin' and 'viewer' roles.
+   */
+  @Test
+  public void testGetAll() {
+    Result<List<Role>> response = roles.allGetter().run();
+    List<Role> all = response.getResult();
+
+    assertThat(response.getError()).as("result had errors").isNull();
+    assertThat(all).hasSize(2).as("wrong number of roles");
+    assertThat(all.get(0)).returns(adminRole, Role::getName);
+    assertThat(all.get(1)).returns(viewerRole, Role::getName);
+  }
+
+  // TODO: check if I can create a role with a name that's not a valid URL
+  // paramter
+
+  @Test
+  public void testCreateAndList() {
+    String myRole = roleName("VectorOwner");
+    String myCollection = "Pizza";
+
+    try {
+      // Arrange
+      roles.deleter().withName(myRole).run();
+
+      roles.creator().withName(myRole)
+          .withPermissions(
+              Permission.backups(BackupsPermission.Action.MANAGE, myCollection),
+              Permission.cluster(ClusterPermission.Action.READ),
+              Permission.nodes(NodesPermission.Action.READ, Verbosity.MINIMAL, myCollection),
+              Permission.roles(RolesPermission.Action.MANAGE, viewerRole),
+              Permission.collections(CollectionsPermission.Action.CREATE, myCollection),
+              Permission.data(DataPermission.Action.UPDATE, myCollection),
+              Permission.tenants(TenantsPermission.Action.DELETE))
+          .run();
+
+      Result<Role> response = roles.getter().withName(myRole).run();
+      Role role = response.getResult();
+      assertThat(response.getError()).as("result had errors").isNull();
+      assertThat(role).as("wrong role name").returns(myRole, Role::getName);
+
+      List<? extends Permission<?>> permissions = role.getPermissions();
+      assertTrue(hasPermissionWithAction(permissions, BackupsPermission.Action.MANAGE.getValue()));
+      assertTrue(hasPermissionWithAction(permissions, ClusterPermission.Action.READ.getValue()));
+      assertTrue(hasPermissionWithAction(permissions, NodesPermission.Action.READ.getValue()));
+      assertTrue(hasPermissionWithAction(permissions, RolesPermission.Action.MANAGE.getValue()));
+      assertTrue(hasPermissionWithAction(permissions, CollectionsPermission.Action.CREATE.getValue()));
+      assertTrue(hasPermissionWithAction(permissions, DataPermission.Action.UPDATE.getValue()));
+      assertTrue(hasPermissionWithAction(permissions, TenantsPermission.Action.DELETE.getValue()));
+    } finally {
+      roles.deleter().withName(myRole).run();
+    }
+  }
+
+  /** Prefix the role with the name of the current test for easier debugging */
+  private String roleName(String name) {
+    return String.format("%s-%s", currentTest.getMethodName(), name);
+  }
+
+  private boolean hasPermissionWithAction(List<? extends Permission<?>> permissions, String action) {
+    return permissions.stream()
+        .filter(perm -> perm.getAction().equals(action))
+        .findFirst().isPresent();
+  }
+}

--- a/src/test/java/io/weaviate/integration/client/rbac/ClientRbacTest.java
+++ b/src/test/java/io/weaviate/integration/client/rbac/ClientRbacTest.java
@@ -1,11 +1,11 @@
 package io.weaviate.integration.client.rbac;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.InstanceOfAssertFactories.list;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.util.List;
@@ -19,7 +19,6 @@ import org.junit.rules.TestName;
 
 import io.weaviate.client.Config;
 import io.weaviate.client.WeaviateAuthClient;
-import io.weaviate.client.WeaviateClient;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.v1.auth.exception.AuthException;
 import io.weaviate.client.v1.rbac.Roles;
@@ -69,7 +68,7 @@ public class ClientRbacTest {
     Result<List<Role>> response = roles.allGetter().run();
     List<Role> all = response.getResult();
 
-    assertThat(response.getError()).as("result had errors").isNull();
+    assertThat(response.getError()).as("get all roles error").isNull();
     assertThat(all).hasSize(2).as("wrong number of roles");
     assertThat(all.get(0)).returns(adminRole, Role::getName);
     assertThat(all.get(1)).returns(viewerRole, Role::getName);
@@ -78,14 +77,23 @@ public class ClientRbacTest {
   @Test
   public void testGetUserRoles() {
     Result<List<Role>> responseCurrent = roles.userRolesGetter().run();
-    assertThat(responseCurrent.getError()).as("result had errors").isNull();
+    assertThat(responseCurrent.getError()).as("get roles for current user error").isNull();
     Result<List<Role>> responseAdminUser = roles.userRolesGetter().withUser(adminUser).run();
-    assertThat(responseAdminUser.getError()).as("result had errors").isNull();
+    assertThat(responseAdminUser.getError()).as("get roles for user error").isNull();
 
     List<Role> currentRoles = responseCurrent.getResult();
     List<Role> adminRoles = responseAdminUser.getResult();
 
     Assertions.assertArrayEquals(currentRoles.toArray(), adminRoles.toArray(), "expect same set of roles");
+  }
+
+  public void testGetAssignedUsers() {
+    Result<List<String>> response = roles.assignedUsersGetter().withRole(adminRole).run();
+    assertThat(response.getError()).as("get assigned users error").isNull();
+
+    List<String> users = response.getResult();
+    assertThat(users).as("users assigned to " + adminRole + " role").hasSize(1);
+    assertEquals(adminUser, users.get(0), "wrong user assinged to " + adminRole + " role");
   }
 
   // TODO: check if I can create a role with a name that's not a valid URL
@@ -127,7 +135,7 @@ public class ClientRbacTest {
       }
     } finally {
       roles.deleter().withName(myRole).run();
-      assertFalse("should not exist after deletion", checkRoleExists(myRole));
+      assertFalse("role should not exist after deletion", checkRoleExists(myRole));
     }
   }
 
@@ -143,16 +151,16 @@ public class ClientRbacTest {
       assumeTrue(checkRoleExists(myRole), "role should exist after creation");
 
       // Act
-      Result<?> addResult = roles.permissionAdder().withRole(myRole)
+      Result<?> response = roles.permissionAdder().withRole(myRole)
           .withPermissions(toAdd)
           .run();
-      assertNull("add-permissions operation error", addResult.getError());
+      assertNull("add-permissions operation error", response.getError());
 
       // Assert
       assertTrue("should have permission " + toAdd, checkHasPermission(myRole, toAdd));
     } finally {
       roles.deleter().withName(myRole).run();
-      assertFalse("should not exist after deletion", checkRoleExists(myRole));
+      assertFalse("role should not exist after deletion", checkRoleExists(myRole));
     }
   }
 
@@ -170,16 +178,64 @@ public class ClientRbacTest {
       assumeTrue(checkRoleExists(myRole), "role should exist after creation");
 
       // Act
-      Result<?> addResult = roles.permissionRemover().withRole(myRole)
+      Result<?> response = roles.permissionRemover().withRole(myRole)
           .withPermissions(toRemove)
           .run();
-      assertNull("remove-permissions operation error", addResult.getError());
+      assertNull("remove-permissions operation error", response.getError());
 
       // Assert
       assertFalse("should not have permission " + toRemove, checkHasPermission(myRole, toRemove));
     } finally {
       roles.deleter().withName(myRole).run();
-      assertFalse("should not exist after deletion", checkRoleExists(myRole));
+      assertFalse("role should not exist after deletion", checkRoleExists(myRole));
+    }
+  }
+
+  @Test
+  public void testRevokeRole() {
+    String myRole = roleName("VectorOwner");
+    try {
+      // Arrange
+      roles.creator().withName(myRole)
+          .withPermissions(Permission.tenants(TenantsPermission.Action.DELETE))
+          .run();
+      assumeTrue(checkRoleExists(myRole), "role should exist after creation");
+
+      roles.assigner().withUser(adminUser).witRoles(myRole).run();
+      assumeTrue(checkHasRole(adminUser, myRole), adminUser + " should have the assigned role");
+
+      // Act
+      Result<?> response = roles.revoker().withUser(adminUser).witRoles(myRole).run();
+      assertNull("revoke operation error", response.getError());
+
+      // Assert
+      assertFalse("should not have " + myRole + "role", checkHasRole(adminUser, myRole));
+    } finally {
+      roles.deleter().withName(myRole).run();
+      assertFalse("role should not exist after deletion", checkRoleExists(myRole));
+    }
+  }
+
+  @Test
+  public void testAssignRole() {
+    String myRole = roleName("VectorOwner");
+    try {
+      // Arrange
+      roles.creator().withName(myRole)
+          .withPermissions(Permission.tenants(TenantsPermission.Action.DELETE))
+          .run();
+      assumeTrue(checkRoleExists(myRole), "role should exist after creation");
+      assumeFalse(checkHasRole(adminUser, myRole), adminUser + " should not have the new role");
+
+      // Act
+      Result<?> response = roles.assigner().withUser(adminUser).witRoles(myRole).run();
+      assertNull("assign operation error", response.getError());
+
+      // Assert
+      assertTrue("should have " + myRole + "role", checkHasRole(adminUser, myRole));
+    } finally {
+      roles.deleter().withName(myRole).run();
+      assertFalse("role should not exist after deletion", checkRoleExists(myRole));
     }
   }
 
@@ -194,5 +250,9 @@ public class ClientRbacTest {
 
   private boolean checkRoleExists(String role) {
     return roles.exists().withName(role).run().getResult();
+  }
+
+  private boolean checkHasRole(String user, String role) {
+    return roles.assignedUsersGetter().withRole(role).run().getResult().contains(user);
   }
 }

--- a/src/test/java/io/weaviate/integration/client/schema/ClientSchemaTest.java
+++ b/src/test/java/io/weaviate/integration/client/schema/ClientSchemaTest.java
@@ -361,7 +361,7 @@ public class ClientSchemaTest {
     //then
     assertResultTrue(createStatus);
 
-    assertResultError("tokenization in body should be one of [word lowercase whitespace field trigram gse kagome_kr]", notExistingTokenizationCreateStatus);
+    assertResultError("tokenization in body should be one of [word lowercase whitespace field trigram gse kagome_kr kagome_ja]", notExistingTokenizationCreateStatus);
     assertResultError("Tokenization is not allowed for data type 'int'", notSupportedTokenizationForIntCreateStatus);
   }
 


### PR DESCRIPTION
Related to #343.

This PR is the first iteration of that story, adding RBAC support to the sync client.
Initially it drew a lot on the Python's client, but I ended up re-organizing things to be consistent with the current client.

Files to pay attention to (have denser logic):
- Permission.java
- WeaviatePermission.java
- Role.java
- WeaviateRole.java
