### PR TITLE
feat: RBAC support (Sync/Async)

### DIFF
--- a/src/main/java/io/weaviate/client/WeaviateClient.java
+++ b/src/main/java/io/weaviate/client/WeaviateClient.java
@@ -22,6 +22,7 @@ import io.weaviate.client.v1.misc.Misc;
 import io.weaviate.client.v1.misc.api.MetaGetter;
 import io.weaviate.client.v1.rbac.Roles;
 import io.weaviate.client.v1.schema.Schema;
+import io.weaviate.client.v1.users.Users;
 
 public class WeaviateClient {
   private final Config config;
@@ -104,6 +105,10 @@ public class WeaviateClient {
 
   public Roles roles() {
     return new Roles(httpClient, config);
+  }
+
+  public Users users() {
+    return new Users(httpClient, config);
   }
 
   private DbVersionProvider initDbVersionProvider() {

--- a/src/main/java/io/weaviate/client/WeaviateClient.java
+++ b/src/main/java/io/weaviate/client/WeaviateClient.java
@@ -20,6 +20,7 @@ import io.weaviate.client.v1.graphql.GraphQL;
 import io.weaviate.client.v1.grpc.GRPC;
 import io.weaviate.client.v1.misc.Misc;
 import io.weaviate.client.v1.misc.api.MetaGetter;
+import io.weaviate.client.v1.rbac.Roles;
 import io.weaviate.client.v1.schema.Schema;
 
 public class WeaviateClient {
@@ -99,6 +100,10 @@ public class WeaviateClient {
 
   public GRPC gRPC() {
     return new GRPC(httpClient, config, tokenProvider);
+  }
+
+  public Roles roles() {
+    return new Roles(httpClient, config);
   }
 
   private DbVersionProvider initDbVersionProvider() {

--- a/src/main/java/io/weaviate/client/base/BaseClient.java
+++ b/src/main/java/io/weaviate/client/base/BaseClient.java
@@ -46,9 +46,6 @@ public abstract class BaseClient<T> {
       HttpResponse response = this.sendHttpRequest(endpoint, payload, method);
       int statusCode = response.getStatusCode();
       String responseBody = response.getBody();
-      System.out.println("response: " + responseBody);
-      System.out.println("Status Code: " + String.valueOf(response.getStatusCode()));
-
       if (statusCode < 399) {
         T body = toResponse(responseBody, classOfT);
         return new Response<>(statusCode, body, null);
@@ -64,9 +61,7 @@ public abstract class BaseClient<T> {
 
   protected HttpResponse sendHttpRequest(String endpoint, Object payload, String method) throws Exception {
     String address = config.getBaseURL() + endpoint;
-    System.out.println(method + " request: " + address);
     String json = toJsonString(payload);
-    System.out.println("with body: " + json);
     if (method.equals("POST")) {
       return client.sendPostRequest(address, json);
     }

--- a/src/main/java/io/weaviate/client/base/BaseClient.java
+++ b/src/main/java/io/weaviate/client/base/BaseClient.java
@@ -46,6 +46,8 @@ public abstract class BaseClient<T> {
       HttpResponse response = this.sendHttpRequest(endpoint, payload, method);
       int statusCode = response.getStatusCode();
       String responseBody = response.getBody();
+      System.out.println("response: " + responseBody);
+      System.out.println("Status Code: " + String.valueOf(response.getStatusCode()));
 
       if (statusCode < 399) {
         T body = toResponse(responseBody, classOfT);
@@ -62,7 +64,9 @@ public abstract class BaseClient<T> {
 
   protected HttpResponse sendHttpRequest(String endpoint, Object payload, String method) throws Exception {
     String address = config.getBaseURL() + endpoint;
+    System.out.println(method + " request: " + address);
     String json = toJsonString(payload);
+    System.out.println("with body: " + json);
     if (method.equals("POST")) {
       return client.sendPostRequest(address, json);
     }

--- a/src/main/java/io/weaviate/client/base/Result.java
+++ b/src/main/java/io/weaviate/client/base/Result.java
@@ -7,7 +7,6 @@ import java.util.stream.Collectors;
 
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpResponse;
-import org.apache.hc.core5.http.HttpStatus;
 
 import io.weaviate.client.base.http.async.ResponseParser;
 import lombok.AccessLevel;
@@ -69,7 +68,7 @@ public class Result<T> {
    */
   public static Result<Boolean> voidToBoolean(Response<Void> response) {
     int status = response.getStatusCode();
-    return new Result<>(status, status == 200, response.getErrors());
+    return new Result<>(status, status < 299, response.getErrors());
   }
 
   /**
@@ -83,7 +82,7 @@ public class Result<T> {
       @Override
       public Result<Boolean> parse(HttpResponse response, String body, ContentType contentType) {
         Response<Object> resp = this.serializer.toResponse(response.getCode(), body, Object.class);
-        return new Result<>(resp.getStatusCode(), resp.getStatusCode() == HttpStatus.SC_OK, resp.getErrors());
+        return new Result<>(resp.getStatusCode(), resp.getStatusCode() < 299, resp.getErrors());
       }
     };
   }

--- a/src/main/java/io/weaviate/client/base/Result.java
+++ b/src/main/java/io/weaviate/client/base/Result.java
@@ -5,6 +5,11 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.HttpStatus;
+
+import io.weaviate.client.base.http.async.ResponseParser;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.ToString;
@@ -23,11 +28,13 @@ public class Result<T> {
 
   public Result(int statusCode, T body, WeaviateErrorResponse errors) {
     if (errors != null && errors.getError() != null) {
-      List<WeaviateErrorMessage> items = errors.getError().stream().filter(Objects::nonNull).collect(Collectors.toList());
+      List<WeaviateErrorMessage> items = errors.getError().stream().filter(Objects::nonNull)
+          .collect(Collectors.toList());
       this.error = new WeaviateError(statusCode, items);
       this.result = body;
     } else if (errors != null && errors.getMessage() != null) {
-      this.error = new WeaviateError(statusCode, Collections.singletonList(WeaviateErrorMessage.builder().message(errors.getMessage()).build()));
+      this.error = new WeaviateError(statusCode,
+          Collections.singletonList(WeaviateErrorMessage.builder().message(errors.getMessage()).build()));
       this.result = body;
     } else {
       this.result = body;
@@ -40,12 +47,47 @@ public class Result<T> {
   }
 
   /**
-   * Copy the Result object with a null body, preserving only the status code and the error message.
+   * Copy the Result object with a null body, preserving only the status code and
+   * the error message.
    *
-   * @param <C> Would-be response type. It's required for type safety, but can be anything since the body is always set to null.
+   * @param <C> Would-be response type. It's required for type safety, but can be
+   *            anything since the body is always set to null.
    * @return A copy of this Result.
    */
   public <C> Result<C> toErrorResult() {
-    return new Result<>(this.error.getStatusCode(), null, WeaviateErrorResponse.builder().error(this.error.getMessages()).build());
+    return new Result<>(this.error.getStatusCode(), null,
+        WeaviateErrorResponse.builder().error(this.error.getMessages()).build());
   }
+
+  /**
+   * Convert {@code Result<Void>} response to a {@code Result<Boolean>}.
+   * Returns true if response status code is 200.
+   *
+   * @param response Response from a call that does not return a value, like
+   *                 {@link BaseClient#sendDeleteRequest}.
+   * @return {@code Result<Boolean>}
+   */
+  public static Result<Boolean> voidToBoolean(Response<Void> response) {
+    int status = response.getStatusCode();
+    return new Result<>(status, status == 200, response.getErrors());
+  }
+
+  /**
+   * Get a custom parser to convert {@code Result<Void>} response as to a
+   * {@code Result<Void>}. Result is true if response status code is 200.
+   *
+   * @param response Response from an async call that does not return a value,
+   *                 like {@link AsyncBaseClient#sendDeleteRequest}.
+   * @return {@code Result<Boolean>}
+   */
+  public static ResponseParser<Boolean> voidToBooleanParser() {
+    return new ResponseParser<Boolean>() {
+      @Override
+      public Result<Boolean> parse(HttpResponse response, String body, ContentType contentType) {
+        Response<Object> resp = this.serializer.toResponse(response.getCode(), body, Object.class);
+        return new Result<>(resp.getStatusCode(), resp.getStatusCode() == HttpStatus.SC_OK, resp.getErrors());
+      }
+    };
+  }
+
 }

--- a/src/main/java/io/weaviate/client/base/Result.java
+++ b/src/main/java/io/weaviate/client/base/Result.java
@@ -61,7 +61,7 @@ public class Result<T> {
 
   /**
    * Convert {@code Result<Void>} response to a {@code Result<Boolean>}.
-   * Returns true if response status code is 200.
+   * The result contains true if status code is 200.
    *
    * @param response Response from a call that does not return a value, like
    *                 {@link BaseClient#sendDeleteRequest}.
@@ -74,10 +74,8 @@ public class Result<T> {
 
   /**
    * Get a custom parser to convert {@code Result<Void>} response as to a
-   * {@code Result<Void>}. Result is true if response status code is 200.
+   * {@code Result<Void>}. The result contains true if status code is 200.
    *
-   * @param response Response from an async call that does not return a value,
-   *                 like {@link AsyncBaseClient#sendDeleteRequest}.
    * @return {@code Result<Boolean>}
    */
   public static ResponseParser<Boolean> voidToBooleanParser() {

--- a/src/main/java/io/weaviate/client/v1/async/WeaviateAsyncClient.java
+++ b/src/main/java/io/weaviate/client/v1/async/WeaviateAsyncClient.java
@@ -1,5 +1,11 @@
 package io.weaviate.client.v1.async;
 
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.io.CloseMode;
+
 import io.weaviate.client.Config;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.base.http.async.AsyncHttpClient;
@@ -13,13 +19,10 @@ import io.weaviate.client.v1.async.cluster.Cluster;
 import io.weaviate.client.v1.async.data.Data;
 import io.weaviate.client.v1.async.graphql.GraphQL;
 import io.weaviate.client.v1.async.misc.Misc;
+import io.weaviate.client.v1.async.rbac.Roles;
 import io.weaviate.client.v1.async.schema.Schema;
 import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 import io.weaviate.client.v1.misc.model.Meta;
-import java.util.Optional;
-import java.util.concurrent.ExecutionException;
-import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
-import org.apache.hc.core5.io.CloseMode;
 
 public class WeaviateAsyncClient implements AutoCloseable {
   private final Config config;
@@ -72,9 +75,12 @@ public class WeaviateAsyncClient implements AutoCloseable {
     return new GraphQL(client, config, tokenProvider);
   }
 
+  public Roles roles() {
+    return new Roles(client, config, tokenProvider);
+  }
+
   private DbVersionProvider initDbVersionProvider() {
-    DbVersionProvider.VersionGetter getter = () ->
-      Optional.ofNullable(this.getMeta())
+    DbVersionProvider.VersionGetter getter = () -> Optional.ofNullable(this.getMeta())
         .filter(result -> !result.hasErrors())
         .map(result -> result.getResult().getVersion());
 

--- a/src/main/java/io/weaviate/client/v1/async/WeaviateAsyncClient.java
+++ b/src/main/java/io/weaviate/client/v1/async/WeaviateAsyncClient.java
@@ -21,6 +21,7 @@ import io.weaviate.client.v1.async.graphql.GraphQL;
 import io.weaviate.client.v1.async.misc.Misc;
 import io.weaviate.client.v1.async.rbac.Roles;
 import io.weaviate.client.v1.async.schema.Schema;
+import io.weaviate.client.v1.async.users.Users;
 import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 import io.weaviate.client.v1.misc.model.Meta;
 
@@ -77,6 +78,10 @@ public class WeaviateAsyncClient implements AutoCloseable {
 
   public Roles roles() {
     return new Roles(client, config, tokenProvider);
+  }
+
+  public Users users() {
+    return new Users(client, config, tokenProvider);
   }
 
   private DbVersionProvider initDbVersionProvider() {

--- a/src/main/java/io/weaviate/client/v1/async/rbac/Roles.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/Roles.java
@@ -8,13 +8,10 @@ import io.weaviate.client.v1.async.rbac.api.PermissionAdder;
 import io.weaviate.client.v1.async.rbac.api.PermissionChecker;
 import io.weaviate.client.v1.async.rbac.api.PermissionRemover;
 import io.weaviate.client.v1.async.rbac.api.RoleAllGetter;
-import io.weaviate.client.v1.async.rbac.api.RoleAssigner;
 import io.weaviate.client.v1.async.rbac.api.RoleCreator;
 import io.weaviate.client.v1.async.rbac.api.RoleDeleter;
 import io.weaviate.client.v1.async.rbac.api.RoleExists;
 import io.weaviate.client.v1.async.rbac.api.RoleGetter;
-import io.weaviate.client.v1.async.rbac.api.RoleRevoker;
-import io.weaviate.client.v1.async.rbac.api.UserRolesGetter;
 import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 import lombok.RequiredArgsConstructor;
 
@@ -68,11 +65,6 @@ public class Roles {
     return new RoleGetter(client, config, tokenProvider);
   };
 
-  /** Get roles assigned to a user. */
-  public UserRolesGetter userRolesGetter() {
-    return new UserRolesGetter(client, config, tokenProvider);
-  };
-
   /** Get users assigned to a role. */
   public AssignedUsersGetter assignedUsersGetter() {
     return new AssignedUsersGetter(client, config, tokenProvider);
@@ -81,13 +73,5 @@ public class Roles {
   /** Check if a role exists. */
   public RoleExists exists() {
     return new RoleExists(client, config, tokenProvider);
-  }
-
-  public RoleAssigner assigner() {
-    return new RoleAssigner(client, config, tokenProvider);
-  }
-
-  public RoleRevoker revoker() {
-    return new RoleRevoker(client, config, tokenProvider);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/async/rbac/Roles.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/Roles.java
@@ -1,0 +1,93 @@
+package io.weaviate.client.v1.async.rbac;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.v1.async.rbac.api.AssignedUsersGetter;
+import io.weaviate.client.v1.async.rbac.api.PermissionAdder;
+import io.weaviate.client.v1.async.rbac.api.PermissionChecker;
+import io.weaviate.client.v1.async.rbac.api.PermissionRemover;
+import io.weaviate.client.v1.async.rbac.api.RoleAllGetter;
+import io.weaviate.client.v1.async.rbac.api.RoleAssigner;
+import io.weaviate.client.v1.async.rbac.api.RoleCreator;
+import io.weaviate.client.v1.async.rbac.api.RoleDeleter;
+import io.weaviate.client.v1.async.rbac.api.RoleExists;
+import io.weaviate.client.v1.async.rbac.api.RoleGetter;
+import io.weaviate.client.v1.async.rbac.api.RoleRevoker;
+import io.weaviate.client.v1.async.rbac.api.UserRolesGetter;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class Roles {
+
+  private final CloseableHttpAsyncClient client;
+  private final Config config;
+  private final AccessTokenProvider tokenProvider;
+
+  public RoleCreator creator() {
+    return new RoleCreator(client, config, tokenProvider);
+  }
+
+  /** Get all existing roles. */
+  public RoleDeleter deleter() {
+    return new RoleDeleter(client, config, tokenProvider);
+  }
+
+  /**
+   * Add permissions to an existing role.
+   * Note: This method is an upsert operation. If the permission already exists,
+   * it will be updated. If it does not exist, it will be created.
+   */
+  public PermissionAdder permissionAdder() {
+    return new PermissionAdder(client, config, tokenProvider);
+  }
+
+  /**
+   * Remove permissions from a role.
+   * Note: This method is a downsert operation. If the permission does not
+   * exist, it will be ignored. If these permissions are the only permissions of
+   * the role, the role will be deleted.
+   */
+  public PermissionRemover permissionRemover() {
+    return new PermissionRemover(client, config, tokenProvider);
+  }
+
+  /** Check if a role has a permission. */
+  public PermissionChecker permissionChecker() {
+    return new PermissionChecker(client, config, tokenProvider);
+  }
+
+  /** Get all existing roles. */
+  public RoleAllGetter allGetter() {
+    return new RoleAllGetter(client, config, tokenProvider);
+  };
+
+  /** Get role and its assiciated permissions. */
+  public RoleGetter getter() {
+    return new RoleGetter(client, config, tokenProvider);
+  };
+
+  /** Get roles assigned to a user. */
+  public UserRolesGetter userRolesGetter() {
+    return new UserRolesGetter(client, config, tokenProvider);
+  };
+
+  /** Get users assigned to a role. */
+  public AssignedUsersGetter assignedUsersGetter() {
+    return new AssignedUsersGetter(client, config, tokenProvider);
+  };
+
+  /** Check if a role exists. */
+  public RoleExists exists() {
+    return new RoleExists(client, config, tokenProvider);
+  }
+
+  public RoleAssigner assigner() {
+    return new RoleAssigner(client, config, tokenProvider);
+  }
+
+  public RoleRevoker revoker() {
+    return new RoleRevoker(client, config, tokenProvider);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/rbac/api/AssignedUsersGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/api/AssignedUsersGetter.java
@@ -1,0 +1,51 @@
+package io.weaviate.client.v1.async.rbac.api;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpResponse;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Response;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.async.ResponseParser;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+
+public class AssignedUsersGetter extends AsyncBaseClient<List<String>> implements AsyncClientResult<List<String>> {
+  private String role;
+
+  public AssignedUsersGetter(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  public AssignedUsersGetter withRole(String role) {
+    this.role = role;
+    return this;
+  }
+
+  @Override
+  public Future<Result<List<String>>> run(FutureCallback<Result<List<String>>> callback) {
+    return sendGetRequest(path(), callback, new ResponseParser<List<String>>() {
+      @Override
+      public Result<List<String>> parse(HttpResponse response, String body, ContentType contentType) {
+        Response<String[]> resp = this.serializer.toResponse(response.getCode(), body, String[].class);
+        List<String> roles = Optional.ofNullable(resp.getBody())
+            .map(Arrays::asList)
+            .orElse(new ArrayList<>());
+        return new Result<>(resp.getStatusCode(), roles, resp.getErrors());
+      }
+    });
+  }
+
+  private String path() {
+    return String.format("/authz/roles/%s/users", this.role);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/rbac/api/PermissionAdder.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/api/PermissionAdder.java
@@ -35,6 +35,15 @@ public class PermissionAdder extends AsyncBaseClient<Void> implements AsyncClien
     return this;
   }
 
+  public PermissionAdder withPermissions(Permission<?>[]... permissions) {
+    List<Permission<?>> all = new ArrayList<>();
+    for (Permission<?>[] perm : permissions) {
+      all.addAll(Arrays.asList(perm));
+    }
+    this.permissions = all;
+    return this;
+  }
+
   /** The API signature for this method is { "permissions": [...] } */
   @AllArgsConstructor
   private static class Body {

--- a/src/main/java/io/weaviate/client/v1/async/rbac/api/PermissionAdder.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/api/PermissionAdder.java
@@ -17,7 +17,7 @@ import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import io.weaviate.client.v1.rbac.model.Permission;
 import lombok.AllArgsConstructor;
 
-public class PermissionAdder extends AsyncBaseClient<Void> implements AsyncClientResult<Void> {
+public class PermissionAdder extends AsyncBaseClient<Boolean> implements AsyncClientResult<Boolean> {
   private String role;
   private List<Permission<?>> permissions = new ArrayList<>();
 
@@ -51,9 +51,9 @@ public class PermissionAdder extends AsyncBaseClient<Void> implements AsyncClien
   }
 
   @Override
-  public Future<Result<Void>> run(FutureCallback<Result<Void>> callback) {
+  public Future<Result<Boolean>> run(FutureCallback<Result<Boolean>> callback) {
     List<WeaviatePermission> permissions = WeaviatePermission.mergePermissions(this.permissions);
-    return sendPostRequest(path(), new Body(permissions), Void.class, callback);
+    return sendPostRequest(path(), new Body(permissions), callback, Result.voidToBooleanParser());
   }
 
   private String path() {

--- a/src/main/java/io/weaviate/client/v1/async/rbac/api/PermissionAdder.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/api/PermissionAdder.java
@@ -1,0 +1,53 @@
+package io.weaviate.client.v1.async.rbac.api;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import io.weaviate.client.v1.rbac.api.WeaviatePermission;
+import io.weaviate.client.v1.rbac.model.Permission;
+import lombok.AllArgsConstructor;
+
+public class PermissionAdder extends AsyncBaseClient<Void> implements AsyncClientResult<Void> {
+  private String role;
+  private List<Permission<?>> permissions = new ArrayList<>();
+
+  public PermissionAdder(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  public PermissionAdder withRole(String name) {
+    this.role = name;
+    return this;
+  }
+
+  public PermissionAdder withPermissions(Permission<?>... permissions) {
+    this.permissions = Arrays.asList(permissions);
+    return this;
+  }
+
+  /** The API signature for this method is { "permissions": [...] } */
+  @AllArgsConstructor
+  private static class Body {
+    public final List<?> permissions;
+  }
+
+  @Override
+  public Future<Result<Void>> run(FutureCallback<Result<Void>> callback) {
+    List<WeaviatePermission> permissions = WeaviatePermission.mergePermissions(this.permissions);
+    return sendPostRequest(path(), new Body(permissions), Void.class, callback);
+  }
+
+  private String path() {
+    return String.format("/authz/roles/%s/add-permissions", this.role);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/rbac/api/PermissionChecker.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/api/PermissionChecker.java
@@ -1,0 +1,41 @@
+package io.weaviate.client.v1.async.rbac.api;
+
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import io.weaviate.client.v1.rbac.model.Permission;
+
+public class PermissionChecker extends AsyncBaseClient<Boolean> implements AsyncClientResult<Boolean> {
+  private String role;
+  private Permission<?> permission;
+
+  public PermissionChecker(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  public PermissionChecker withRole(String role) {
+    this.role = role;
+    return this;
+  }
+
+  public PermissionChecker withPermission(Permission<?> permission) {
+    this.permission = permission;
+    return this;
+  }
+
+  @Override
+  public Future<Result<Boolean>> run(FutureCallback<Result<Boolean>> callback) {
+    return sendPostRequest(path(), permission.toWeaviate(), Boolean.class, callback);
+  }
+
+  private String path() {
+    return String.format("/authz/roles/%s/has-permission", this.role);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/rbac/api/PermissionChecker.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/api/PermissionChecker.java
@@ -32,7 +32,7 @@ public class PermissionChecker extends AsyncBaseClient<Boolean> implements Async
 
   @Override
   public Future<Result<Boolean>> run(FutureCallback<Result<Boolean>> callback) {
-    return sendPostRequest(path(), permission.toWeaviate(), Boolean.class, callback);
+    return sendPostRequest(path(), permission.firstToWeaviate(), Boolean.class, callback);
   }
 
   private String path() {

--- a/src/main/java/io/weaviate/client/v1/async/rbac/api/PermissionRemover.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/api/PermissionRemover.java
@@ -1,0 +1,53 @@
+package io.weaviate.client.v1.async.rbac.api;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import io.weaviate.client.v1.rbac.api.WeaviatePermission;
+import io.weaviate.client.v1.rbac.model.Permission;
+import lombok.AllArgsConstructor;
+
+public class PermissionRemover extends AsyncBaseClient<Void> implements AsyncClientResult<Void> {
+  private String role;
+  private List<Permission<?>> permissions = new ArrayList<>();
+
+  public PermissionRemover(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  public PermissionRemover withRole(String role) {
+    this.role = role;
+    return this;
+  }
+
+  public PermissionRemover withPermissions(Permission<?>... permissions) {
+    this.permissions = Arrays.asList(permissions);
+    return this;
+  }
+
+  /** The API signature for this method is { "permissions": [...] } */
+  @AllArgsConstructor
+  private static class Body {
+    public final List<?> permissions;
+  }
+
+  @Override
+  public Future<Result<Void>> run(FutureCallback<Result<Void>> callback) {
+    List<WeaviatePermission> permissions = WeaviatePermission.mergePermissions(this.permissions);
+    return sendPostRequest(path(), new Body(permissions), Void.class, callback);
+  }
+
+  private String path() {
+    return String.format("/authz/roles/%s/remove-permissions", this.role);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/rbac/api/PermissionRemover.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/api/PermissionRemover.java
@@ -17,7 +17,7 @@ import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import io.weaviate.client.v1.rbac.model.Permission;
 import lombok.AllArgsConstructor;
 
-public class PermissionRemover extends AsyncBaseClient<Void> implements AsyncClientResult<Void> {
+public class PermissionRemover extends AsyncBaseClient<Boolean> implements AsyncClientResult<Boolean> {
   private String role;
   private List<Permission<?>> permissions = new ArrayList<>();
 
@@ -51,9 +51,9 @@ public class PermissionRemover extends AsyncBaseClient<Void> implements AsyncCli
   }
 
   @Override
-  public Future<Result<Void>> run(FutureCallback<Result<Void>> callback) {
+  public Future<Result<Boolean>> run(FutureCallback<Result<Boolean>> callback) {
     List<WeaviatePermission> permissions = WeaviatePermission.mergePermissions(this.permissions);
-    return sendPostRequest(path(), new Body(permissions), Void.class, callback);
+    return sendPostRequest(path(), new Body(permissions), callback, Result.voidToBooleanParser());
   }
 
   private String path() {

--- a/src/main/java/io/weaviate/client/v1/async/rbac/api/PermissionRemover.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/api/PermissionRemover.java
@@ -35,6 +35,15 @@ public class PermissionRemover extends AsyncBaseClient<Void> implements AsyncCli
     return this;
   }
 
+  public PermissionRemover withPermissions(Permission<?>[]... permissions) {
+    List<Permission<?>> all = new ArrayList<>();
+    for (Permission<?>[] perm : permissions) {
+      all.addAll(Arrays.asList(perm));
+    }
+    this.permissions = all;
+    return this;
+  }
+
   /** The API signature for this method is { "permissions": [...] } */
   @AllArgsConstructor
   private static class Body {

--- a/src/main/java/io/weaviate/client/v1/async/rbac/api/RoleAllGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/api/RoleAllGetter.java
@@ -1,0 +1,46 @@
+package io.weaviate.client.v1.async.rbac.api;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpResponse;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Response;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.async.ResponseParser;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import io.weaviate.client.v1.rbac.api.WeaviateRole;
+import io.weaviate.client.v1.rbac.model.Role;
+
+public class RoleAllGetter extends AsyncBaseClient<List<Role>> implements AsyncClientResult<List<Role>> {
+
+  public RoleAllGetter(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  @Override
+  public Future<Result<List<Role>>> run(FutureCallback<Result<List<Role>>> callback) {
+    return sendGetRequest("/authz/roles", callback, new ResponseParser<List<Role>>() {
+      @Override
+      public Result<List<Role>> parse(HttpResponse response, String body, ContentType contentType) {
+        Response<WeaviateRole[]> resp = this.serializer.toResponse(response.getCode(), body, WeaviateRole[].class);
+        List<Role> roles = Optional.ofNullable(resp.getBody())
+            .map(Arrays::asList)
+            .orElse(new ArrayList<>())
+            .stream()
+            .map(w -> w.toRole())
+            .toList();
+        return new Result<>(resp.getStatusCode(), roles, resp.getErrors());
+      }
+    });
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/rbac/api/RoleAllGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/api/RoleAllGetter.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.core5.concurrent.FutureCallback;
@@ -38,7 +39,7 @@ public class RoleAllGetter extends AsyncBaseClient<List<Role>> implements AsyncC
             .orElse(new ArrayList<>())
             .stream()
             .map(w -> w.toRole())
-            .toList();
+            .collect(Collectors.toList());
         return new Result<>(resp.getStatusCode(), roles, resp.getErrors());
       }
     });

--- a/src/main/java/io/weaviate/client/v1/async/rbac/api/RoleAssigner.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/api/RoleAssigner.java
@@ -15,7 +15,7 @@ import io.weaviate.client.base.Result;
 import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 import lombok.AllArgsConstructor;
 
-public class RoleAssigner extends AsyncBaseClient<Void> implements AsyncClientResult<Void> {
+public class RoleAssigner extends AsyncBaseClient<Boolean> implements AsyncClientResult<Boolean> {
   private String user;
   private List<String> roles = new ArrayList<>();
 
@@ -40,8 +40,8 @@ public class RoleAssigner extends AsyncBaseClient<Void> implements AsyncClientRe
   }
 
   @Override
-  public Future<Result<Void>> run(FutureCallback<Result<Void>> callback) {
-    return sendPostRequest(path(), new Body(this.roles), Void.class, callback);
+  public Future<Result<Boolean>> run(FutureCallback<Result<Boolean>> callback) {
+    return sendPostRequest(path(), new Body(this.roles), callback, Result.voidToBooleanParser());
   }
 
   private String path() {

--- a/src/main/java/io/weaviate/client/v1/async/rbac/api/RoleAssigner.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/api/RoleAssigner.java
@@ -1,0 +1,50 @@
+package io.weaviate.client.v1.async.rbac.api;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import lombok.AllArgsConstructor;
+
+public class RoleAssigner extends AsyncBaseClient<Void> implements AsyncClientResult<Void> {
+  private String user;
+  private List<String> roles = new ArrayList<>();
+
+  public RoleAssigner(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  public RoleAssigner withUser(String user) {
+    this.user = user;
+    return this;
+  }
+
+  public RoleAssigner witRoles(String... roles) {
+    this.roles = Arrays.asList(roles);
+    return this;
+  }
+
+  /** The API signature for this method is { "roles": [...] } */
+  @AllArgsConstructor
+  private static class Body {
+    public final List<String> roles;
+  }
+
+  @Override
+  public Future<Result<Void>> run(FutureCallback<Result<Void>> callback) {
+    return sendPostRequest(path(), new Body(this.roles), Void.class, callback);
+  }
+
+  private String path() {
+    return String.format("/authz/users/%s/assign", this.user);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/rbac/api/RoleCreator.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/api/RoleCreator.java
@@ -16,7 +16,7 @@ import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 import io.weaviate.client.v1.rbac.api.WeaviateRole;
 import io.weaviate.client.v1.rbac.model.Permission;
 
-public class RoleCreator extends AsyncBaseClient<Void> implements AsyncClientResult<Void> {
+public class RoleCreator extends AsyncBaseClient<Boolean> implements AsyncClientResult<Boolean> {
   private String name;
   private List<Permission<?>> permissions = new ArrayList<>();
 
@@ -44,8 +44,8 @@ public class RoleCreator extends AsyncBaseClient<Void> implements AsyncClientRes
   }
 
   @Override
-  public Future<Result<Void>> run(FutureCallback<Result<Void>> callback) {
+  public Future<Result<Boolean>> run(FutureCallback<Result<Boolean>> callback) {
     WeaviateRole role = new WeaviateRole(this.name, this.permissions);
-    return sendPostRequest("/authz/roles", role, Void.class, callback);
+    return sendPostRequest("/authz/roles", role, callback, Result.voidToBooleanParser());
   }
 }

--- a/src/main/java/io/weaviate/client/v1/async/rbac/api/RoleCreator.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/api/RoleCreator.java
@@ -1,0 +1,42 @@
+package io.weaviate.client.v1.async.rbac.api;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import io.weaviate.client.v1.rbac.api.WeaviateRole;
+import io.weaviate.client.v1.rbac.model.Permission;
+
+public class RoleCreator extends AsyncBaseClient<Void> implements AsyncClientResult<Void> {
+  private String name;
+  private List<Permission<?>> permissions = new ArrayList<>();
+
+  public RoleCreator(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  public RoleCreator withName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public RoleCreator withPermissions(Permission<?>... permissions) {
+    this.permissions = Arrays.asList(permissions);
+    return this;
+  }
+
+  @Override
+  public Future<Result<Void>> run(FutureCallback<Result<Void>> callback) {
+    WeaviateRole role = new WeaviateRole(this.name, this.permissions);
+    return sendPostRequest("/authz/roles", role, Void.class, callback);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/rbac/api/RoleCreator.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/api/RoleCreator.java
@@ -34,6 +34,15 @@ public class RoleCreator extends AsyncBaseClient<Void> implements AsyncClientRes
     return this;
   }
 
+  public RoleCreator withPermissions(Permission<?>[]... permissions) {
+    List<Permission<?>> all = new ArrayList<>();
+    for (Permission<?>[] perm : permissions) {
+      all.addAll(Arrays.asList(perm));
+    }
+    this.permissions = all;
+    return this;
+  }
+
   @Override
   public Future<Result<Void>> run(FutureCallback<Result<Void>> callback) {
     WeaviateRole role = new WeaviateRole(this.name, this.permissions);

--- a/src/main/java/io/weaviate/client/v1/async/rbac/api/RoleDeleter.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/api/RoleDeleter.java
@@ -1,0 +1,30 @@
+package io.weaviate.client.v1.async.rbac.api;
+
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+
+public class RoleDeleter extends AsyncBaseClient<Void> implements AsyncClientResult<Void> {
+  private String name;
+
+  public RoleDeleter(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  public RoleDeleter withName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  @Override
+  public Future<Result<Void>> run(FutureCallback<Result<Void>> callback) {
+    return sendDeleteRequest("/authz/roles/" + this.name, null, Void.class, callback);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/rbac/api/RoleDeleter.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/api/RoleDeleter.java
@@ -11,7 +11,7 @@ import io.weaviate.client.base.AsyncClientResult;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 
-public class RoleDeleter extends AsyncBaseClient<Void> implements AsyncClientResult<Void> {
+public class RoleDeleter extends AsyncBaseClient<Boolean> implements AsyncClientResult<Boolean> {
   private String name;
 
   public RoleDeleter(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
@@ -24,7 +24,7 @@ public class RoleDeleter extends AsyncBaseClient<Void> implements AsyncClientRes
   }
 
   @Override
-  public Future<Result<Void>> run(FutureCallback<Result<Void>> callback) {
-    return sendDeleteRequest("/authz/roles/" + this.name, null, Void.class, callback);
+  public Future<Result<Boolean>> run(FutureCallback<Result<Boolean>> callback) {
+    return sendDeleteRequest("/authz/roles/" + this.name, null, callback, Result.voidToBooleanParser());
   }
 }

--- a/src/main/java/io/weaviate/client/v1/async/rbac/api/RoleExists.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/api/RoleExists.java
@@ -1,0 +1,50 @@
+package io.weaviate.client.v1.async.rbac.api;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.HttpStatus;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.WeaviateError;
+import io.weaviate.client.base.WeaviateErrorResponse;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import io.weaviate.client.v1.rbac.model.Role;
+
+public class RoleExists extends AsyncBaseClient<Boolean> implements AsyncClientResult<Boolean> {
+  private final RoleGetter getter;
+
+  public RoleExists(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+    this.getter = new RoleGetter(httpClient, config, tokenProvider);
+  }
+
+  public RoleExists withName(String name) {
+    this.getter.withName(name);
+    return this;
+  }
+
+  @Override
+  public Future<Result<Boolean>> run(FutureCallback<Result<Boolean>> callback) {
+    return CompletableFuture.supplyAsync(() -> {
+      try {
+        Result<Role> resp = this.getter.run().get();
+        if (resp.hasErrors()) {
+          WeaviateError error = resp.getError();
+          return new Result<>(error.getStatusCode(), null,
+              WeaviateErrorResponse.builder().error(error.getMessages()).build());
+        }
+        return new Result<Boolean>(HttpStatus.SC_OK, resp.getResult() != null, null);
+      } catch (InterruptedException | ExecutionException e) {
+        throw new CompletionException(e);
+      }
+    });
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/rbac/api/RoleGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/api/RoleGetter.java
@@ -1,0 +1,44 @@
+package io.weaviate.client.v1.async.rbac.api;
+
+import java.util.Optional;
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpResponse;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Response;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.async.ResponseParser;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import io.weaviate.client.v1.rbac.api.WeaviateRole;
+import io.weaviate.client.v1.rbac.model.Role;
+
+public class RoleGetter extends AsyncBaseClient<Role> implements AsyncClientResult<Role> {
+  private String name;
+
+  public RoleGetter(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  public RoleGetter withName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  @Override
+  public Future<Result<Role>> run(FutureCallback<Result<Role>> callback) {
+    return sendGetRequest("/authz/roles/" + this.name, callback, new ResponseParser<Role>() {
+      @Override
+      public Result<Role> parse(HttpResponse response, String body, ContentType contentType) {
+        Response<WeaviateRole> resp = this.serializer.toResponse(response.getCode(), body, WeaviateRole.class);
+        Role role = Optional.ofNullable(resp.getBody()).map(WeaviateRole::toRole).orElse(null);
+        return new Result<>(resp.getStatusCode(), role, resp.getErrors());
+      }
+    });
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/rbac/api/RoleRevoker.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/api/RoleRevoker.java
@@ -16,7 +16,7 @@ import io.weaviate.client.base.Result;
 import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 import lombok.AllArgsConstructor;
 
-public class RoleRevoker extends AsyncBaseClient<Void> implements AsyncClientResult<Void> {
+public class RoleRevoker extends AsyncBaseClient<Boolean> implements AsyncClientResult<Boolean> {
   private String user;
   private List<String> roles = new ArrayList<>();
 
@@ -41,8 +41,8 @@ public class RoleRevoker extends AsyncBaseClient<Void> implements AsyncClientRes
   }
 
   @Override
-  public Future<Result<Void>> run(FutureCallback<Result<Void>> callback) {
-    return sendPostRequest(path(), new Body(this.roles), Void.class, callback);
+  public Future<Result<Boolean>> run(FutureCallback<Result<Boolean>> callback) {
+    return sendPostRequest(path(), new Body(this.roles), callback, Result.voidToBooleanParser());
   }
 
   private String path() {

--- a/src/main/java/io/weaviate/client/v1/async/rbac/api/RoleRevoker.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/api/RoleRevoker.java
@@ -1,0 +1,51 @@
+package io.weaviate.client.v1.async.rbac.api;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import lombok.AllArgsConstructor;
+
+public class RoleRevoker extends AsyncBaseClient<Void> implements AsyncClientResult<Void> {
+  private String user;
+  private List<String> roles = new ArrayList<>();
+
+  public RoleRevoker(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  public RoleRevoker withUser(String user) {
+    this.user = user;
+    return this;
+  }
+
+  public RoleRevoker witRoles(String... roles) {
+    this.roles = Collections.unmodifiableList(Arrays.asList(roles));
+    return this;
+  }
+
+  /** The API signature for this method is { "roles": [...] } */
+  @AllArgsConstructor
+  private static class Body {
+    public final List<String> roles;
+  }
+
+  @Override
+  public Future<Result<Void>> run(FutureCallback<Result<Void>> callback) {
+    return sendPostRequest(path(), new Body(this.roles), Void.class, callback);
+  }
+
+  private String path() {
+    return String.format("/authz/users/%s/revoke", this.user);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/rbac/api/UserRolesGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/api/UserRolesGetter.java
@@ -1,0 +1,58 @@
+package io.weaviate.client.v1.async.rbac.api;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpResponse;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Response;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.async.ResponseParser;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import io.weaviate.client.v1.rbac.api.WeaviateRole;
+import io.weaviate.client.v1.rbac.model.Role;
+
+public class UserRolesGetter extends AsyncBaseClient<List<Role>> implements AsyncClientResult<List<Role>> {
+  private String user;
+
+  public UserRolesGetter(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  /** Leave unset to fetch roles assigned to the current user. */
+  public UserRolesGetter withUser(String user) {
+    this.user = user;
+    return this;
+  }
+
+  @Override
+  public Future<Result<List<Role>>> run(FutureCallback<Result<List<Role>>> callback) {
+    String path = this.user == null ? "/authz/users/own-roles" : this.path();
+    return sendGetRequest(path, callback, new ResponseParser<List<Role>>() {
+      @Override
+      public Result<List<Role>> parse(HttpResponse response, String body, ContentType contentType) {
+        Response<WeaviateRole[]> resp = this.serializer.toResponse(response.getCode(), body, WeaviateRole[].class);
+        List<Role> roles = Optional.ofNullable(resp.getBody())
+            .map(Arrays::asList)
+            .orElse(new ArrayList<>())
+            .stream()
+            .map(w -> w.toRole())
+            .toList();
+        return new Result<>(resp.getStatusCode(), roles, resp.getErrors());
+      }
+    });
+  }
+
+  private String path() {
+    return String.format("/authz/users/%s/roles", this.user);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/users/Users.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/Users.java
@@ -3,6 +3,7 @@ package io.weaviate.client.v1.async.users;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 
 import io.weaviate.client.Config;
+import io.weaviate.client.v1.async.users.api.MyUserGetter;
 import io.weaviate.client.v1.async.users.api.RoleAssigner;
 import io.weaviate.client.v1.async.users.api.RoleRevoker;
 import io.weaviate.client.v1.async.users.api.UserRolesGetter;
@@ -15,6 +16,11 @@ public class Users {
   private final CloseableHttpAsyncClient client;
   private final Config config;
   private final AccessTokenProvider tokenProvider;
+
+  /** Get information about the current user. */
+  public MyUserGetter myUserGetter() {
+    return new MyUserGetter(client, config, tokenProvider);
+  };
 
   /** Get roles assigned to a user. */
   public UserRolesGetter userRolesGetter() {

--- a/src/main/java/io/weaviate/client/v1/async/users/Users.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/Users.java
@@ -1,0 +1,31 @@
+package io.weaviate.client.v1.async.users;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.v1.async.users.api.RoleAssigner;
+import io.weaviate.client.v1.async.users.api.RoleRevoker;
+import io.weaviate.client.v1.async.users.api.UserRolesGetter;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class Users {
+
+  private final CloseableHttpAsyncClient client;
+  private final Config config;
+  private final AccessTokenProvider tokenProvider;
+
+  /** Get roles assigned to a user. */
+  public UserRolesGetter userRolesGetter() {
+    return new UserRolesGetter(client, config, tokenProvider);
+  };
+
+  public RoleAssigner assigner() {
+    return new RoleAssigner(client, config, tokenProvider);
+  }
+
+  public RoleRevoker revoker() {
+    return new RoleRevoker(client, config, tokenProvider);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/users/api/MyUserGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/api/MyUserGetter.java
@@ -1,0 +1,39 @@
+package io.weaviate.client.v1.async.users.api;
+
+import java.util.Optional;
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpResponse;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Response;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.async.ResponseParser;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import io.weaviate.client.v1.users.api.WeaviateUser;
+import io.weaviate.client.v1.users.model.User;
+
+public class MyUserGetter extends AsyncBaseClient<User> implements AsyncClientResult<User> {
+  public MyUserGetter(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  @Override
+  public Future<Result<User>> run(FutureCallback<Result<User>> callback) {
+    return sendGetRequest("/users/own-info", callback, new ResponseParser<User>() {
+      @Override
+      public Result<User> parse(HttpResponse response, String body, ContentType contentType) {
+        Response<WeaviateUser> resp = this.serializer.toResponse(response.getCode(), body, WeaviateUser.class);
+        User user = Optional.ofNullable(resp.getBody())
+            .map(WeaviateUser::toUser)
+            .orElse(null);
+        return new Result<>(resp.getStatusCode(), user, resp.getErrors());
+      }
+    });
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/users/api/RoleAssigner.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/api/RoleAssigner.java
@@ -1,8 +1,7 @@
-package io.weaviate.client.v1.async.rbac.api;
+package io.weaviate.client.v1.async.users.api;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Future;
 
@@ -16,21 +15,21 @@ import io.weaviate.client.base.Result;
 import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 import lombok.AllArgsConstructor;
 
-public class RoleRevoker extends AsyncBaseClient<Boolean> implements AsyncClientResult<Boolean> {
+public class RoleAssigner extends AsyncBaseClient<Boolean> implements AsyncClientResult<Boolean> {
   private String user;
   private List<String> roles = new ArrayList<>();
 
-  public RoleRevoker(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+  public RoleAssigner(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
     super(httpClient, config, tokenProvider);
   }
 
-  public RoleRevoker withUser(String user) {
+  public RoleAssigner withUser(String user) {
     this.user = user;
     return this;
   }
 
-  public RoleRevoker witRoles(String... roles) {
-    this.roles = Collections.unmodifiableList(Arrays.asList(roles));
+  public RoleAssigner witRoles(String... roles) {
+    this.roles = Arrays.asList(roles);
     return this;
   }
 
@@ -46,6 +45,6 @@ public class RoleRevoker extends AsyncBaseClient<Boolean> implements AsyncClient
   }
 
   private String path() {
-    return String.format("/authz/users/%s/revoke", this.user);
+    return String.format("/authz/users/%s/assign", this.user);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/async/users/api/RoleAssigner.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/api/RoleAssigner.java
@@ -16,15 +16,15 @@ import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 import lombok.AllArgsConstructor;
 
 public class RoleAssigner extends AsyncBaseClient<Boolean> implements AsyncClientResult<Boolean> {
-  private String user;
+  private String userId;
   private List<String> roles = new ArrayList<>();
 
   public RoleAssigner(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
     super(httpClient, config, tokenProvider);
   }
 
-  public RoleAssigner withUser(String user) {
-    this.user = user;
+  public RoleAssigner withUserId(String id) {
+    this.userId = id;
     return this;
   }
 
@@ -45,6 +45,6 @@ public class RoleAssigner extends AsyncBaseClient<Boolean> implements AsyncClien
   }
 
   private String path() {
-    return String.format("/authz/users/%s/assign", this.user);
+    return String.format("/authz/users/%s/assign", this.userId);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/async/users/api/RoleRevoker.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/api/RoleRevoker.java
@@ -17,15 +17,15 @@ import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 import lombok.AllArgsConstructor;
 
 public class RoleRevoker extends AsyncBaseClient<Boolean> implements AsyncClientResult<Boolean> {
-  private String user;
+  private String userId;
   private List<String> roles = new ArrayList<>();
 
   public RoleRevoker(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
     super(httpClient, config, tokenProvider);
   }
 
-  public RoleRevoker withUser(String user) {
-    this.user = user;
+  public RoleRevoker withUserId(String id) {
+    this.userId = id;
     return this;
   }
 
@@ -46,6 +46,6 @@ public class RoleRevoker extends AsyncBaseClient<Boolean> implements AsyncClient
   }
 
   private String path() {
-    return String.format("/authz/users/%s/revoke", this.user);
+    return String.format("/authz/users/%s/revoke", this.userId);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/async/users/api/RoleRevoker.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/api/RoleRevoker.java
@@ -1,7 +1,8 @@
-package io.weaviate.client.v1.async.rbac.api;
+package io.weaviate.client.v1.async.users.api;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Future;
 
@@ -15,21 +16,21 @@ import io.weaviate.client.base.Result;
 import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 import lombok.AllArgsConstructor;
 
-public class RoleAssigner extends AsyncBaseClient<Boolean> implements AsyncClientResult<Boolean> {
+public class RoleRevoker extends AsyncBaseClient<Boolean> implements AsyncClientResult<Boolean> {
   private String user;
   private List<String> roles = new ArrayList<>();
 
-  public RoleAssigner(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+  public RoleRevoker(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
     super(httpClient, config, tokenProvider);
   }
 
-  public RoleAssigner withUser(String user) {
+  public RoleRevoker withUser(String user) {
     this.user = user;
     return this;
   }
 
-  public RoleAssigner witRoles(String... roles) {
-    this.roles = Arrays.asList(roles);
+  public RoleRevoker witRoles(String... roles) {
+    this.roles = Collections.unmodifiableList(Arrays.asList(roles));
     return this;
   }
 
@@ -45,6 +46,6 @@ public class RoleAssigner extends AsyncBaseClient<Boolean> implements AsyncClien
   }
 
   private String path() {
-    return String.format("/authz/users/%s/assign", this.user);
+    return String.format("/authz/users/%s/revoke", this.user);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/async/users/api/UserRolesGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/api/UserRolesGetter.java
@@ -23,15 +23,15 @@ import io.weaviate.client.v1.rbac.api.WeaviateRole;
 import io.weaviate.client.v1.rbac.model.Role;
 
 public class UserRolesGetter extends AsyncBaseClient<List<Role>> implements AsyncClientResult<List<Role>> {
-  private String user;
+  private String userId;
 
   public UserRolesGetter(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
     super(httpClient, config, tokenProvider);
   }
 
   /** Leave unset to fetch roles assigned to the current user. */
-  public UserRolesGetter withUser(String user) {
-    this.user = user;
+  public UserRolesGetter withUserId(String id) {
+    this.userId = id;
     return this;
   }
 
@@ -53,6 +53,6 @@ public class UserRolesGetter extends AsyncBaseClient<List<Role>> implements Asyn
   }
 
   private String path() {
-    return String.format("/authz/users/%s/roles", this.user);
+    return String.format("/authz/users/%s/roles", this.userId);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/async/users/api/UserRolesGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/api/UserRolesGetter.java
@@ -1,4 +1,4 @@
-package io.weaviate.client.v1.async.rbac.api;
+package io.weaviate.client.v1.async.users.api;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,8 +36,7 @@ public class UserRolesGetter extends AsyncBaseClient<List<Role>> implements Asyn
 
   @Override
   public Future<Result<List<Role>>> run(FutureCallback<Result<List<Role>>> callback) {
-    String path = this.user == null ? "/authz/users/own-roles" : this.path();
-    return sendGetRequest(path, callback, new ResponseParser<List<Role>>() {
+    return sendGetRequest(path(), callback, new ResponseParser<List<Role>>() {
       @Override
       public Result<List<Role>> parse(HttpResponse response, String body, ContentType contentType) {
         Response<WeaviateRole[]> resp = this.serializer.toResponse(response.getCode(), body, WeaviateRole[].class);

--- a/src/main/java/io/weaviate/client/v1/async/users/api/UserRolesGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/api/UserRolesGetter.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.core5.concurrent.FutureCallback;
@@ -45,7 +46,7 @@ public class UserRolesGetter extends AsyncBaseClient<List<Role>> implements Asyn
             .orElse(new ArrayList<>())
             .stream()
             .map(w -> w.toRole())
-            .toList();
+            .collect(Collectors.toList());
         return new Result<>(resp.getStatusCode(), roles, resp.getErrors());
       }
     });

--- a/src/main/java/io/weaviate/client/v1/backup/api/BackupCanceler.java
+++ b/src/main/java/io/weaviate/client/v1/backup/api/BackupCanceler.java
@@ -15,7 +15,8 @@ import io.weaviate.client.base.util.UrlEncoder;
  * BackupCanceler can cancel an in-progress backup by ID.
  *
  * <p>
- * Canceling backups which have successfully completed before being interrupted is not supported and will result in an error.
+ * Canceling backups which have successfully completed before being interrupted
+ * is not supported and will result in an error.
  */
 public class BackupCanceler extends BaseClient<Void> implements ClientResult<Void> {
   private String backend;
@@ -70,4 +71,3 @@ public class BackupCanceler extends BaseClient<Void> implements ClientResult<Voi
     return path;
   }
 }
-

--- a/src/main/java/io/weaviate/client/v1/rbac/Roles.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/Roles.java
@@ -7,13 +7,10 @@ import io.weaviate.client.v1.rbac.api.PermissionAdder;
 import io.weaviate.client.v1.rbac.api.PermissionChecker;
 import io.weaviate.client.v1.rbac.api.PermissionRemover;
 import io.weaviate.client.v1.rbac.api.RoleAllGetter;
-import io.weaviate.client.v1.rbac.api.RoleAssigner;
 import io.weaviate.client.v1.rbac.api.RoleCreator;
 import io.weaviate.client.v1.rbac.api.RoleDeleter;
 import io.weaviate.client.v1.rbac.api.RoleExists;
 import io.weaviate.client.v1.rbac.api.RoleGetter;
-import io.weaviate.client.v1.rbac.api.RoleRevoker;
-import io.weaviate.client.v1.rbac.api.UserRolesGetter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -66,11 +63,6 @@ public class Roles {
     return new RoleGetter(httpClient, config);
   };
 
-  /** Get roles assigned to a user. */
-  public UserRolesGetter userRolesGetter() {
-    return new UserRolesGetter(httpClient, config);
-  };
-
   /** Get users assigned to a role. */
   public AssignedUsersGetter assignedUsersGetter() {
     return new AssignedUsersGetter(httpClient, config);
@@ -79,15 +71,5 @@ public class Roles {
   /** Check if a role exists. */
   public RoleExists exists() {
     return new RoleExists(httpClient, config);
-  }
-
-  /** Assign a role to a user. Note that 'root' cannot be assigned. */
-  public RoleAssigner assigner() {
-    return new RoleAssigner(httpClient, config);
-  }
-
-  /** Revoke a role from a user. Note that 'root' cannot be revoked. */
-  public RoleRevoker revoker() {
-    return new RoleRevoker(httpClient, config);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/Roles.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/Roles.java
@@ -1,57 +1,90 @@
 package io.weaviate.client.v1.rbac;
 
+import io.weaviate.client.Config;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.rbac.api.AssignedUsersGetter;
+import io.weaviate.client.v1.rbac.api.PermissionAdder;
+import io.weaviate.client.v1.rbac.api.PermissionChecker;
+import io.weaviate.client.v1.rbac.api.PermissionRemover;
+import io.weaviate.client.v1.rbac.api.RoleAllGetter;
+import io.weaviate.client.v1.rbac.api.RoleAssigner;
+import io.weaviate.client.v1.rbac.api.RoleCreator;
+import io.weaviate.client.v1.rbac.api.RoleDeleter;
+import io.weaviate.client.v1.rbac.api.RoleExists;
+import io.weaviate.client.v1.rbac.api.RoleGetter;
+import io.weaviate.client.v1.rbac.api.RoleRevoker;
+import io.weaviate.client.v1.rbac.api.UserRolesGetter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 public class Roles {
-  public Roles() {
+
+  private final HttpClient httpClient;
+  private final Config config;
+
+  public RoleCreator creator() {
+    return new RoleCreator(httpClient, config);
   }
 
-  // public Role create(String name, Permission... permissions) {
-  // }
-  //
-  /// ** Get all existing roles. */
-  // public void delete(String role) {
-  // }
-  //
-  /// **
-  // * Add permissions to an existing role.
-  // * Note: This method is an upsert operation. If the permission already exists,
-  // * it will be updated. If it does not exist, it will be created.
-  // */
-  // public void addPermissions(String role, Permission... permissions) {
-  // }
-  //
-  /// **
-  // * Remove permissions from a role.
-  // * Note: This method is a downsert operation. If the permission does not
-  // exist,
-  // * it will be ignored. If these permissions are the only permissions of the
-  // * role, the role will be deleted.
-  // */
-  // public void removePermissions(String role, Permission... permissions) {
-  // }
-  //
-  /// ** Get all existing roles. */
-  // public void getAll() {
-  // };
-  //
-  /// ** Get permissions associated with a role. */
-  // public List<Permission> getRolePermissions(String role) {
-  // };
-  //
-  /// ** Get roles assigned to the current user. */
-  // public List<Role> getUserRoles() {
-  // };
-  //
-  /// ** Get roles assigned to a user. */
-  // public List<Role> getUserRoles(String user) {
-  // };
-  //
-  /// ** Check if a role exists. */
-  // public boolean exists(String role) {
-  // }
-  //
-  // public void assign(String user, String... roles) {
-  // }
-  //
-  // public void revoke(String user, String... roles) {
-  // }
+  /** Get all existing roles. */
+  public RoleDeleter deleter() {
+    return new RoleDeleter(httpClient, config);
+  }
+
+  /**
+   * Add permissions to an existing role.
+   * Note: This method is an upsert operation. If the permission already exists,
+   * it will be updated. If it does not exist, it will be created.
+   */
+  public PermissionAdder permissionAdder() {
+    return new PermissionAdder(httpClient, config);
+  }
+
+  /**
+   * Remove permissions from a role.
+   * Note: This method is a downsert operation. If the permission does not
+   * exist, it will be ignored. If these permissions are the only permissions of
+   * the role, the role will be deleted.
+   */
+  public PermissionRemover permissionRemover() {
+    return new PermissionRemover(httpClient, config);
+  }
+
+  /** Check if a role has a permission. */
+  public PermissionChecker permissionChecker() {
+    return new PermissionChecker(httpClient, config);
+  }
+
+  /** Get all existing roles. */
+  public RoleAllGetter allGetter() {
+    return new RoleAllGetter(httpClient, config);
+  };
+
+  /** Get role and its assiciated permissions. */
+  public RoleGetter getter() {
+    return new RoleGetter(httpClient, config);
+  };
+
+  /** Get roles assigned to a user. */
+  public UserRolesGetter userRolesGetter() {
+    return new UserRolesGetter(httpClient, config);
+  };
+
+  /** Get users assigned to a role. */
+  public AssignedUsersGetter assignedUsersGetter() {
+    return new AssignedUsersGetter(httpClient, config);
+  };
+
+  /** Check if a role exists. */
+  public RoleExists exists() {
+    return new RoleExists(httpClient, config);
+  }
+
+  public RoleAssigner assigner() {
+    return new RoleAssigner(httpClient, config);
+  }
+
+  public RoleRevoker revoker() {
+    return new RoleRevoker(httpClient, config);
+  }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/Roles.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/Roles.java
@@ -1,0 +1,57 @@
+package io.weaviate.client.v1.rbac;
+
+public class Roles {
+  public Roles() {
+  }
+
+  // public Role create(String name, Permission... permissions) {
+  // }
+  //
+  /// ** Get all existing roles. */
+  // public void delete(String role) {
+  // }
+  //
+  /// **
+  // * Add permissions to an existing role.
+  // * Note: This method is an upsert operation. If the permission already exists,
+  // * it will be updated. If it does not exist, it will be created.
+  // */
+  // public void addPermissions(String role, Permission... permissions) {
+  // }
+  //
+  /// **
+  // * Remove permissions from a role.
+  // * Note: This method is a downsert operation. If the permission does not
+  // exist,
+  // * it will be ignored. If these permissions are the only permissions of the
+  // * role, the role will be deleted.
+  // */
+  // public void removePermissions(String role, Permission... permissions) {
+  // }
+  //
+  /// ** Get all existing roles. */
+  // public void getAll() {
+  // };
+  //
+  /// ** Get permissions associated with a role. */
+  // public List<Permission> getRolePermissions(String role) {
+  // };
+  //
+  /// ** Get roles assigned to the current user. */
+  // public List<Role> getUserRoles() {
+  // };
+  //
+  /// ** Get roles assigned to a user. */
+  // public List<Role> getUserRoles(String user) {
+  // };
+  //
+  /// ** Check if a role exists. */
+  // public boolean exists(String role) {
+  // }
+  //
+  // public void assign(String user, String... roles) {
+  // }
+  //
+  // public void revoke(String user, String... roles) {
+  // }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/Roles.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/Roles.java
@@ -22,11 +22,12 @@ public class Roles {
   private final HttpClient httpClient;
   private final Config config;
 
+  /** Create a new role. */
   public RoleCreator creator() {
     return new RoleCreator(httpClient, config);
   }
 
-  /** Get all existing roles. */
+  /** Delete a role. */
   public RoleDeleter deleter() {
     return new RoleDeleter(httpClient, config);
   }
@@ -60,7 +61,7 @@ public class Roles {
     return new RoleAllGetter(httpClient, config);
   };
 
-  /** Get role and its assiciated permissions. */
+  /** Get role and its associated permissions. */
   public RoleGetter getter() {
     return new RoleGetter(httpClient, config);
   };
@@ -80,10 +81,12 @@ public class Roles {
     return new RoleExists(httpClient, config);
   }
 
+  /** Assign a role to a user. Note that 'root' cannot be assigned. */
   public RoleAssigner assigner() {
     return new RoleAssigner(httpClient, config);
   }
 
+  /** Revoke a role from a user. Note that 'root' cannot be revoked. */
   public RoleRevoker revoker() {
     return new RoleRevoker(httpClient, config);
   }

--- a/src/main/java/io/weaviate/client/v1/rbac/api/AssignedUsersGetter.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/AssignedUsersGetter.java
@@ -13,14 +13,14 @@ import io.weaviate.client.base.Result;
 import io.weaviate.client.base.http.HttpClient;
 
 public class AssignedUsersGetter extends BaseClient<String[]> implements ClientResult<List<String>> {
-  private String name;
+  private String role;
 
   public AssignedUsersGetter(HttpClient httpClient, Config config) {
     super(httpClient, config);
   }
 
-  public AssignedUsersGetter withName(String name) {
-    this.name = name;
+  public AssignedUsersGetter withRole(String role) {
+    this.role = role;
     return this;
   }
 
@@ -34,6 +34,6 @@ public class AssignedUsersGetter extends BaseClient<String[]> implements ClientR
   }
 
   private String path() {
-    return String.format("/authz/roles/%s/users", this.name);
+    return String.format("/authz/roles/%s/users", this.role);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/api/AssignedUsersGetter.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/AssignedUsersGetter.java
@@ -1,0 +1,39 @@
+package io.weaviate.client.v1.rbac.api;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Response;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+
+public class AssignedUsersGetter extends BaseClient<String[]> implements ClientResult<List<String>> {
+  private String name;
+
+  public AssignedUsersGetter(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public AssignedUsersGetter withName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  @Override
+  public Result<List<String>> run() {
+    Response<String[]> resp = sendGetRequest(path(), String[].class);
+    List<String> roles = Optional.ofNullable(resp.getBody())
+        .map(Arrays::asList)
+        .orElse(new ArrayList<>());
+    return new Result<>(resp.getStatusCode(), roles, resp.getErrors());
+  }
+
+  private String path() {
+    return String.format("/authz/roles/%s/users", this.name);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/PermissionAdder.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/PermissionAdder.java
@@ -1,0 +1,41 @@
+package io.weaviate.client.v1.rbac.api;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.rbac.model.Permission;
+
+public class PermissionAdder extends BaseClient<Void> implements ClientResult<Void> {
+  private String name;
+  private List<Permission<?>> permissions = new ArrayList<>();
+
+  public PermissionAdder(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public PermissionAdder withName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public PermissionAdder withPermissions(Permission<?>... permissions) {
+    this.permissions = Arrays.asList(permissions);
+    return this;
+  }
+
+  @Override
+  public Result<Void> run() {
+    List<WeaviatePermission> permissions = WeaviatePermission.mergePermissions(this.permissions);
+    return new Result<Void>(sendPostRequest(path(), permissions, Void.class));
+  }
+
+  private String path() {
+    return String.format("/authz/roles/%s/add-permissions", this.name);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/PermissionAdder.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/PermissionAdder.java
@@ -30,6 +30,15 @@ public class PermissionAdder extends BaseClient<Void> implements ClientResult<Vo
     return this;
   }
 
+  public PermissionAdder withPermissions(Permission<?>[]... permissions) {
+    List<Permission<?>> all = new ArrayList<>();
+    for (Permission<?>[] perm : permissions) {
+      all.addAll(Arrays.asList(perm));
+    }
+    this.permissions = all;
+    return this;
+  }
+
   @AllArgsConstructor
   private static class Body {
     public final List<?> permissions;

--- a/src/main/java/io/weaviate/client/v1/rbac/api/PermissionAdder.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/PermissionAdder.java
@@ -10,17 +10,18 @@ import io.weaviate.client.base.ClientResult;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.base.http.HttpClient;
 import io.weaviate.client.v1.rbac.model.Permission;
+import lombok.AllArgsConstructor;
 
 public class PermissionAdder extends BaseClient<Void> implements ClientResult<Void> {
-  private String name;
+  private String role;
   private List<Permission<?>> permissions = new ArrayList<>();
 
   public PermissionAdder(HttpClient httpClient, Config config) {
     super(httpClient, config);
   }
 
-  public PermissionAdder withName(String name) {
-    this.name = name;
+  public PermissionAdder withRole(String name) {
+    this.role = name;
     return this;
   }
 
@@ -29,13 +30,18 @@ public class PermissionAdder extends BaseClient<Void> implements ClientResult<Vo
     return this;
   }
 
+  @AllArgsConstructor
+  private static class Body {
+    public final List<?> permissions;
+  }
+
   @Override
   public Result<Void> run() {
     List<WeaviatePermission> permissions = WeaviatePermission.mergePermissions(this.permissions);
-    return new Result<Void>(sendPostRequest(path(), permissions, Void.class));
+    return new Result<Void>(sendPostRequest(path(), new Body(permissions), Void.class));
   }
 
   private String path() {
-    return String.format("/authz/roles/%s/add-permissions", this.name);
+    return String.format("/authz/roles/%s/add-permissions", this.role);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/api/PermissionAdder.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/PermissionAdder.java
@@ -7,7 +7,6 @@ import java.util.List;
 import io.weaviate.client.Config;
 import io.weaviate.client.base.BaseClient;
 import io.weaviate.client.base.ClientResult;
-import io.weaviate.client.base.Response;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.base.http.HttpClient;
 import io.weaviate.client.v1.rbac.model.Permission;
@@ -28,15 +27,6 @@ public class PermissionAdder extends BaseClient<Void> implements ClientResult<Bo
 
   public PermissionAdder withPermissions(Permission<?>... permissions) {
     this.permissions = Arrays.asList(permissions);
-    return this;
-  }
-
-  public PermissionAdder withPermissions(Permission<?>[]... permissions) {
-    List<Permission<?>> all = new ArrayList<>();
-    for (Permission<?>[] perm : permissions) {
-      all.addAll(Arrays.asList(perm));
-    }
-    this.permissions = all;
     return this;
   }
 

--- a/src/main/java/io/weaviate/client/v1/rbac/api/PermissionAdder.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/PermissionAdder.java
@@ -7,12 +7,13 @@ import java.util.List;
 import io.weaviate.client.Config;
 import io.weaviate.client.base.BaseClient;
 import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Response;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.base.http.HttpClient;
 import io.weaviate.client.v1.rbac.model.Permission;
 import lombok.AllArgsConstructor;
 
-public class PermissionAdder extends BaseClient<Void> implements ClientResult<Void> {
+public class PermissionAdder extends BaseClient<Void> implements ClientResult<Boolean> {
   private String role;
   private List<Permission<?>> permissions = new ArrayList<>();
 
@@ -45,9 +46,9 @@ public class PermissionAdder extends BaseClient<Void> implements ClientResult<Vo
   }
 
   @Override
-  public Result<Void> run() {
+  public Result<Boolean> run() {
     List<WeaviatePermission> permissions = WeaviatePermission.mergePermissions(this.permissions);
-    return new Result<Void>(sendPostRequest(path(), new Body(permissions), Void.class));
+    return Result.voidToBoolean(sendPostRequest(path(), new Body(permissions), Void.class));
   }
 
   private String path() {

--- a/src/main/java/io/weaviate/client/v1/rbac/api/PermissionChecker.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/PermissionChecker.java
@@ -8,15 +8,15 @@ import io.weaviate.client.base.http.HttpClient;
 import io.weaviate.client.v1.rbac.model.Permission;
 
 public class PermissionChecker extends BaseClient<Boolean> implements ClientResult<Boolean> {
-  private String name;
+  private String role;
   private Permission<?> permission;
 
   public PermissionChecker(HttpClient httpClient, Config config) {
     super(httpClient, config);
   }
 
-  public PermissionChecker withName(String name) {
-    this.name = name;
+  public PermissionChecker withRole(String role) {
+    this.role = role;
     return this;
   }
 
@@ -27,10 +27,10 @@ public class PermissionChecker extends BaseClient<Boolean> implements ClientResu
 
   @Override
   public Result<Boolean> run() {
-    return new Result<Boolean>(sendPostRequest(path(), permission, Boolean.class));
+    return new Result<Boolean>(sendPostRequest(path(), permission.toWeaviate(), Boolean.class));
   }
 
   private String path() {
-    return String.format("/authz/roles/%s/has-permission", this.name);
+    return String.format("/authz/roles/%s/has-permission", this.role);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/api/PermissionChecker.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/PermissionChecker.java
@@ -1,0 +1,36 @@
+package io.weaviate.client.v1.rbac.api;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.rbac.model.Permission;
+
+public class PermissionChecker extends BaseClient<Boolean> implements ClientResult<Boolean> {
+  private String name;
+  private Permission<?> permission;
+
+  public PermissionChecker(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public PermissionChecker withName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public PermissionChecker withPermission(Permission<?> permission) {
+    this.permission = permission;
+    return this;
+  }
+
+  @Override
+  public Result<Boolean> run() {
+    return new Result<Boolean>(sendPostRequest(path(), permission, Boolean.class));
+  }
+
+  private String path() {
+    return String.format("/authz/roles/%s/has-permission", this.name);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/PermissionChecker.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/PermissionChecker.java
@@ -27,7 +27,7 @@ public class PermissionChecker extends BaseClient<Boolean> implements ClientResu
 
   @Override
   public Result<Boolean> run() {
-    return new Result<Boolean>(sendPostRequest(path(), permission.toWeaviate(), Boolean.class));
+    return new Result<Boolean>(sendPostRequest(path(), permission.firstToWeaviate(), Boolean.class));
   }
 
   private String path() {

--- a/src/main/java/io/weaviate/client/v1/rbac/api/PermissionRemover.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/PermissionRemover.java
@@ -12,7 +12,7 @@ import io.weaviate.client.base.http.HttpClient;
 import io.weaviate.client.v1.rbac.model.Permission;
 import lombok.AllArgsConstructor;
 
-public class PermissionRemover extends BaseClient<Void> implements ClientResult<Void> {
+public class PermissionRemover extends BaseClient<Void> implements ClientResult<Boolean> {
   private String role;
   private List<Permission<?>> permissions = new ArrayList<>();
 
@@ -45,9 +45,9 @@ public class PermissionRemover extends BaseClient<Void> implements ClientResult<
   }
 
   @Override
-  public Result<Void> run() {
+  public Result<Boolean> run() {
     List<WeaviatePermission> permissions = WeaviatePermission.mergePermissions(this.permissions);
-    return new Result<Void>(sendPostRequest(path(), new Body(permissions), Void.class));
+    return Result.voidToBoolean(sendPostRequest(path(), new Body(permissions), Void.class));
   }
 
   private String path() {

--- a/src/main/java/io/weaviate/client/v1/rbac/api/PermissionRemover.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/PermissionRemover.java
@@ -10,17 +10,18 @@ import io.weaviate.client.base.ClientResult;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.base.http.HttpClient;
 import io.weaviate.client.v1.rbac.model.Permission;
+import lombok.AllArgsConstructor;
 
 public class PermissionRemover extends BaseClient<Void> implements ClientResult<Void> {
-  private String name;
+  private String role;
   private List<Permission<?>> permissions = new ArrayList<>();
 
   public PermissionRemover(HttpClient httpClient, Config config) {
     super(httpClient, config);
   }
 
-  public PermissionRemover withName(String name) {
-    this.name = name;
+  public PermissionRemover withRole(String role) {
+    this.role = role;
     return this;
   }
 
@@ -29,13 +30,18 @@ public class PermissionRemover extends BaseClient<Void> implements ClientResult<
     return this;
   }
 
+  @AllArgsConstructor
+  private static class Body {
+    public final List<?> permissions;
+  }
+
   @Override
   public Result<Void> run() {
     List<WeaviatePermission> permissions = WeaviatePermission.mergePermissions(this.permissions);
-    return new Result<Void>(sendPostRequest(path(), permissions, Void.class));
+    return new Result<Void>(sendPostRequest(path(), new Body(permissions), Void.class));
   }
 
   private String path() {
-    return String.format("/authz/roles/%s/remove-permissions", this.name);
+    return String.format("/authz/roles/%s/remove-permissions", this.role);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/api/PermissionRemover.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/PermissionRemover.java
@@ -1,0 +1,41 @@
+package io.weaviate.client.v1.rbac.api;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.rbac.model.Permission;
+
+public class PermissionRemover extends BaseClient<Void> implements ClientResult<Void> {
+  private String name;
+  private List<Permission<?>> permissions = new ArrayList<>();
+
+  public PermissionRemover(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public PermissionRemover withName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public PermissionRemover withPermissions(Permission<?>... permissions) {
+    this.permissions = Arrays.asList(permissions);
+    return this;
+  }
+
+  @Override
+  public Result<Void> run() {
+    List<WeaviatePermission> permissions = WeaviatePermission.mergePermissions(this.permissions);
+    return new Result<Void>(sendPostRequest(path(), permissions, Void.class));
+  }
+
+  private String path() {
+    return String.format("/authz/roles/%s/remove-permissions", this.name);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/PermissionRemover.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/PermissionRemover.java
@@ -30,6 +30,15 @@ public class PermissionRemover extends BaseClient<Void> implements ClientResult<
     return this;
   }
 
+  public PermissionRemover withPermissions(Permission<?>[]... permissions) {
+    List<Permission<?>> all = new ArrayList<>();
+    for (Permission<?>[] perm : permissions) {
+      all.addAll(Arrays.asList(perm));
+    }
+    this.permissions = all;
+    return this;
+  }
+
   @AllArgsConstructor
   private static class Body {
     public final List<?> permissions;

--- a/src/main/java/io/weaviate/client/v1/rbac/api/PermissionRemover.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/PermissionRemover.java
@@ -30,15 +30,6 @@ public class PermissionRemover extends BaseClient<Void> implements ClientResult<
     return this;
   }
 
-  public PermissionRemover withPermissions(Permission<?>[]... permissions) {
-    List<Permission<?>> all = new ArrayList<>();
-    for (Permission<?>[] perm : permissions) {
-      all.addAll(Arrays.asList(perm));
-    }
-    this.permissions = all;
-    return this;
-  }
-
   @AllArgsConstructor
   private static class Body {
     public final List<?> permissions;

--- a/src/main/java/io/weaviate/client/v1/rbac/api/RoleAllGetter.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/RoleAllGetter.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import io.weaviate.client.Config;
 import io.weaviate.client.base.BaseClient;
@@ -27,7 +28,7 @@ public class RoleAllGetter extends BaseClient<WeaviateRole[]> implements ClientR
         .orElse(new ArrayList<>())
         .stream()
         .map(w -> w.toRole())
-        .toList();
+        .collect(Collectors.toList());
     return new Result<>(resp.getStatusCode(), roles, resp.getErrors());
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/api/RoleAllGetter.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/RoleAllGetter.java
@@ -1,0 +1,33 @@
+package io.weaviate.client.v1.rbac.api;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Response;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.rbac.model.Role;
+
+public class RoleAllGetter extends BaseClient<WeaviateRole[]> implements ClientResult<List<Role>> {
+
+  public RoleAllGetter(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  @Override
+  public Result<List<Role>> run() {
+    Response<WeaviateRole[]> resp = sendGetRequest("/authz/roles", WeaviateRole[].class);
+    List<Role> roles = Optional.ofNullable(resp.getBody())
+        .map(Arrays::asList)
+        .orElse(new ArrayList<>())
+        .stream()
+        .map(w -> w.toRole())
+        .toList();
+    return new Result<>(resp.getStatusCode(), roles, resp.getErrors());
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/RoleAssigner.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/RoleAssigner.java
@@ -7,11 +7,12 @@ import java.util.List;
 import io.weaviate.client.Config;
 import io.weaviate.client.base.BaseClient;
 import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Response;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.base.http.HttpClient;
 import lombok.AllArgsConstructor;
 
-public class RoleAssigner extends BaseClient<Void> implements ClientResult<Void> {
+public class RoleAssigner extends BaseClient<Void> implements ClientResult<Boolean> {
   private String user;
   private List<String> roles = new ArrayList<>();
 
@@ -36,8 +37,10 @@ public class RoleAssigner extends BaseClient<Void> implements ClientResult<Void>
   }
 
   @Override
-  public Result<Void> run() {
-    return new Result<Void>(sendPostRequest(path(), new Body(this.roles), Void.class));
+  public Result<Boolean> run() {
+    Response<Void> resp = sendPostRequest(path(), new Body(this.roles), Void.class);
+    int status = resp.getStatusCode();
+    return new Result<Boolean>(status, status == 200, resp.getErrors());
   }
 
   private String path() {

--- a/src/main/java/io/weaviate/client/v1/rbac/api/RoleAssigner.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/RoleAssigner.java
@@ -1,0 +1,46 @@
+package io.weaviate.client.v1.rbac.api;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import lombok.AllArgsConstructor;
+
+public class RoleAssigner extends BaseClient<Void> implements ClientResult<Void> {
+  private String user;
+  private List<String> roles = new ArrayList<>();
+
+  public RoleAssigner(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public RoleAssigner withUser(String user) {
+    this.user = user;
+    return this;
+  }
+
+  public RoleAssigner witRoles(String... roles) {
+    this.roles = Arrays.asList(roles);
+    return this;
+  }
+
+  /** The API signature for this method is { "roles": [...] } */
+  @AllArgsConstructor
+  private static class Body {
+    public final List<String> roles;
+  }
+
+  @Override
+  public Result<Void> run() {
+    return new Result<Void>(sendPostRequest(path(), new Body(this.roles), Void.class));
+  }
+
+  private String path() {
+    return String.format("/authz/users/%s/assign", this.user);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/RoleCreator.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/RoleCreator.java
@@ -1,0 +1,37 @@
+package io.weaviate.client.v1.rbac.api;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.rbac.model.Permission;
+
+public class RoleCreator extends BaseClient<Void> implements ClientResult<Void> {
+  private String name;
+  private List<Permission<?>> permissions = new ArrayList<>();
+
+  public RoleCreator(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public RoleCreator withName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public RoleCreator withPermissions(Permission<?>... permissions) {
+    this.permissions = Arrays.asList(permissions);
+    return this;
+  }
+
+  @Override
+  public Result<Void> run() {
+    WeaviateRole role = new WeaviateRole(this.name, this.permissions);
+    return new Result<Void>(sendPostRequest("/authz/roles", role, Void.class));
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/RoleCreator.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/RoleCreator.java
@@ -29,6 +29,15 @@ public class RoleCreator extends BaseClient<Void> implements ClientResult<Void> 
     return this;
   }
 
+  public RoleCreator withPermissions(Permission<?>[]... permissions) {
+    List<Permission<?>> all = new ArrayList<>();
+    for (Permission<?>[] perm : permissions) {
+      all.addAll(Arrays.asList(perm));
+    }
+    this.permissions = all;
+    return this;
+  }
+
   @Override
   public Result<Void> run() {
     WeaviateRole role = new WeaviateRole(this.name, this.permissions);

--- a/src/main/java/io/weaviate/client/v1/rbac/api/RoleCreator.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/RoleCreator.java
@@ -11,7 +11,7 @@ import io.weaviate.client.base.Result;
 import io.weaviate.client.base.http.HttpClient;
 import io.weaviate.client.v1.rbac.model.Permission;
 
-public class RoleCreator extends BaseClient<Void> implements ClientResult<Void> {
+public class RoleCreator extends BaseClient<Void> implements ClientResult<Boolean> {
   private String name;
   private List<Permission<?>> permissions = new ArrayList<>();
 
@@ -39,8 +39,8 @@ public class RoleCreator extends BaseClient<Void> implements ClientResult<Void> 
   }
 
   @Override
-  public Result<Void> run() {
+  public Result<Boolean> run() {
     WeaviateRole role = new WeaviateRole(this.name, this.permissions);
-    return new Result<Void>(sendPostRequest("/authz/roles", role, Void.class));
+    return Result.voidToBoolean(sendPostRequest("/authz/roles", role, Void.class));
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/api/RoleCreator.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/RoleCreator.java
@@ -29,15 +29,6 @@ public class RoleCreator extends BaseClient<Void> implements ClientResult<Boolea
     return this;
   }
 
-  public RoleCreator withPermissions(Permission<?>[]... permissions) {
-    List<Permission<?>> all = new ArrayList<>();
-    for (Permission<?>[] perm : permissions) {
-      all.addAll(Arrays.asList(perm));
-    }
-    this.permissions = all;
-    return this;
-  }
-
   @Override
   public Result<Boolean> run() {
     WeaviateRole role = new WeaviateRole(this.name, this.permissions);

--- a/src/main/java/io/weaviate/client/v1/rbac/api/RoleDeleter.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/RoleDeleter.java
@@ -1,0 +1,25 @@
+package io.weaviate.client.v1.rbac.api;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+
+public class RoleDeleter extends BaseClient<Void> implements ClientResult<Void> {
+  private String name;
+
+  public RoleDeleter(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public RoleDeleter withName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  @Override
+  public Result<Void> run() {
+    return new Result<Void>(sendDeleteRequest("/authz/roles/" + this.name, null, Void.class));
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/RoleDeleter.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/RoleDeleter.java
@@ -6,7 +6,7 @@ import io.weaviate.client.base.ClientResult;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.base.http.HttpClient;
 
-public class RoleDeleter extends BaseClient<Void> implements ClientResult<Void> {
+public class RoleDeleter extends BaseClient<Void> implements ClientResult<Boolean> {
   private String name;
 
   public RoleDeleter(HttpClient httpClient, Config config) {
@@ -19,7 +19,7 @@ public class RoleDeleter extends BaseClient<Void> implements ClientResult<Void> 
   }
 
   @Override
-  public Result<Void> run() {
-    return new Result<Void>(sendDeleteRequest("/authz/roles/" + this.name, null, Void.class));
+  public Result<Boolean> run() {
+    return Result.voidToBoolean(sendDeleteRequest("/authz/roles/" + this.name, null, Void.class));
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/api/RoleExists.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/RoleExists.java
@@ -1,0 +1,38 @@
+package io.weaviate.client.v1.rbac.api;
+
+import org.apache.hc.core5.http.HttpStatus;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.WeaviateError;
+import io.weaviate.client.base.WeaviateErrorResponse;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.rbac.model.Role;
+
+public class RoleExists extends BaseClient<Boolean> implements ClientResult<Boolean> {
+  private RoleGetter getter;
+
+  public RoleExists(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+    this.getter = new RoleGetter(httpClient, config);
+  }
+
+  public RoleExists withName(String name) {
+    this.getter.withName(name);
+    return this;
+  }
+
+  @Override
+  public Result<Boolean> run() {
+    Result<Role> resp = this.getter.run();
+    if (resp.hasErrors()) {
+      WeaviateError error = resp.getError();
+      return new Result<>(error.getStatusCode(), null,
+          WeaviateErrorResponse.builder().error(error.getMessages()).build());
+
+    }
+    return new Result<Boolean>(HttpStatus.SC_OK, resp.getResult() != null, null);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/RoleGetter.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/RoleGetter.java
@@ -25,7 +25,7 @@ public class RoleGetter extends BaseClient<WeaviateRole> implements ClientResult
   @Override
   public Result<Role> run() {
     Response<WeaviateRole> resp = sendGetRequest("/authz/roles/" + this.name, WeaviateRole.class);
-    WeaviateRole role = Optional.ofNullable(resp.getBody()).orElse(null);
-    return new Result<Role>(resp.getStatusCode(), role.toRole(), resp.getErrors());
+    Role role = Optional.ofNullable(resp.getBody()).map(WeaviateRole::toRole).orElse(null);
+    return new Result<Role>(resp.getStatusCode(), role, resp.getErrors());
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/api/RoleGetter.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/RoleGetter.java
@@ -1,0 +1,31 @@
+package io.weaviate.client.v1.rbac.api;
+
+import java.util.Optional;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Response;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.rbac.model.Role;
+
+public class RoleGetter extends BaseClient<WeaviateRole> implements ClientResult<Role> {
+  private String name;
+
+  public RoleGetter(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public RoleGetter withName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  @Override
+  public Result<Role> run() {
+    Response<WeaviateRole> resp = sendGetRequest("/authz/roles/" + this.name, WeaviateRole.class);
+    WeaviateRole role = Optional.ofNullable(resp.getBody()).orElse(null);
+    return new Result<Role>(resp.getStatusCode(), role.toRole(), resp.getErrors());
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/RoleRevoker.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/RoleRevoker.java
@@ -1,0 +1,47 @@
+package io.weaviate.client.v1.rbac.api;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import lombok.AllArgsConstructor;
+
+public class RoleRevoker extends BaseClient<Void> implements ClientResult<Void> {
+  private String user;
+  private List<String> roles = new ArrayList<>();
+
+  public RoleRevoker(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public RoleRevoker withUser(String user) {
+    this.user = user;
+    return this;
+  }
+
+  public RoleRevoker witRoles(String... roles) {
+    this.roles = Collections.unmodifiableList(Arrays.asList(roles));
+    return this;
+  }
+
+  /** The API signature for this method is { "roles": [...] } */
+  @AllArgsConstructor
+  private static class Body {
+    public final List<String> roles;
+  }
+
+  @Override
+  public Result<Void> run() {
+    return new Result<Void>(sendPostRequest(path(), new Body(this.roles), Void.class));
+  }
+
+  private String path() {
+    return String.format("/authz/users/%s/revoke", this.user);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/RoleRevoker.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/RoleRevoker.java
@@ -12,7 +12,7 @@ import io.weaviate.client.base.Result;
 import io.weaviate.client.base.http.HttpClient;
 import lombok.AllArgsConstructor;
 
-public class RoleRevoker extends BaseClient<Void> implements ClientResult<Void> {
+public class RoleRevoker extends BaseClient<Void> implements ClientResult<Boolean> {
   private String user;
   private List<String> roles = new ArrayList<>();
 
@@ -37,8 +37,8 @@ public class RoleRevoker extends BaseClient<Void> implements ClientResult<Void> 
   }
 
   @Override
-  public Result<Void> run() {
-    return new Result<Void>(sendPostRequest(path(), new Body(this.roles), Void.class));
+  public Result<Boolean> run() {
+    return Result.voidToBoolean(sendPostRequest(path(), new Body(this.roles), Void.class));
   }
 
   private String path() {

--- a/src/main/java/io/weaviate/client/v1/rbac/api/UserRolesGetter.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/UserRolesGetter.java
@@ -28,12 +28,8 @@ public class UserRolesGetter extends BaseClient<WeaviateRole[]> implements Clien
 
   @Override
   public Result<List<Role>> run() {
-    Response<WeaviateRole[]> resp;
-    if (this.user == null) {
-      resp = sendGetRequest("/authz/users/own-roles", WeaviateRole[].class);
-    } else {
-      resp = sendGetRequest(path(), WeaviateRole[].class);
-    }
+    String path = this.user == null ? "/authz/users/own-roles" : this.path();
+    Response<WeaviateRole[]> resp = sendGetRequest(path, WeaviateRole[].class);
     List<Role> roles = Optional.ofNullable(resp.getBody())
         .map(Arrays::asList)
         .orElse(new ArrayList<>())

--- a/src/main/java/io/weaviate/client/v1/rbac/api/UserRolesGetter.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/UserRolesGetter.java
@@ -1,0 +1,49 @@
+package io.weaviate.client.v1.rbac.api;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Response;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.rbac.model.Role;
+
+public class UserRolesGetter extends BaseClient<WeaviateRole[]> implements ClientResult<List<Role>> {
+  private String user;
+
+  public UserRolesGetter(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  /** Leave unset to fetch roles assigned to the current user. */
+  public UserRolesGetter withUser(String user) {
+    this.user = user;
+    return this;
+  }
+
+  @Override
+  public Result<List<Role>> run() {
+    Response<WeaviateRole[]> resp;
+    if (this.user == null) {
+      resp = sendGetRequest("/authz/users/own-roles", WeaviateRole[].class);
+    } else {
+      resp = sendGetRequest(path(), WeaviateRole[].class);
+    }
+    List<Role> roles = Optional.ofNullable(resp.getBody())
+        .map(Arrays::asList)
+        .orElse(new ArrayList<>())
+        .stream()
+        .map(w -> w.toRole())
+        .toList();
+    return new Result<>(resp.getStatusCode(), roles, resp.getErrors());
+  }
+
+  private String path() {
+    return String.format("/authz/users/%s/roles", this.user);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/WeaviatePermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/WeaviatePermission.java
@@ -1,7 +1,7 @@
 package io.weaviate.client.v1.rbac.api;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.weaviate.client.v1.rbac.model.BackupsPermission;
 import io.weaviate.client.v1.rbac.model.CollectionsPermission;
@@ -10,14 +10,19 @@ import io.weaviate.client.v1.rbac.model.NodesPermission;
 import io.weaviate.client.v1.rbac.model.Permission;
 import io.weaviate.client.v1.rbac.model.RolesPermission;
 import io.weaviate.client.v1.rbac.model.TenantsPermission;
+import io.weaviate.client.v1.rbac.model.UsersPermission;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
 
 /** API model for serializing/deserializing permissions. */
 @Getter
 @Builder
 @AllArgsConstructor
+@EqualsAndHashCode
+@ToString
 public class WeaviatePermission {
   String action;
   BackupsPermission backups;
@@ -26,6 +31,7 @@ public class WeaviatePermission {
   NodesPermission nodes;
   RolesPermission roles;
   TenantsPermission tenants;
+  UsersPermission users;
 
   public WeaviatePermission(String action) {
     this.action = action;
@@ -45,10 +51,16 @@ public class WeaviatePermission {
       this.roles = (RolesPermission) perm;
     } else if (perm instanceof TenantsPermission) {
       this.tenants = (TenantsPermission) perm;
+    } else if (perm instanceof UsersPermission) {
+      this.users = (UsersPermission) perm;
     }
   }
 
   public static List<WeaviatePermission> mergePermissions(List<Permission<?>> permissions) {
-    return permissions.stream().map(perm -> perm.toWeaviate()).collect(Collectors.toList());
+    List<WeaviatePermission> merged = new ArrayList<>();
+    for (Permission<?> perm : permissions) {
+      merged.addAll(perm.toWeaviate());
+    }
+    return merged;
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/api/WeaviatePermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/WeaviatePermission.java
@@ -13,6 +13,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+/** API model for serializing/deserializing permissions. */
 @Getter
 @Builder
 @AllArgsConstructor

--- a/src/main/java/io/weaviate/client/v1/rbac/api/WeaviatePermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/WeaviatePermission.java
@@ -1,0 +1,54 @@
+package io.weaviate.client.v1.rbac.api;
+
+import io.weaviate.client.v1.rbac.model.BackupsPermission;
+import io.weaviate.client.v1.rbac.model.ClusterPermission;
+import io.weaviate.client.v1.rbac.model.CollectionsPermission;
+import io.weaviate.client.v1.rbac.model.DataPermission;
+import io.weaviate.client.v1.rbac.model.NodesPermission;
+import io.weaviate.client.v1.rbac.model.Permission;
+import io.weaviate.client.v1.rbac.model.RolesPermission;
+import io.weaviate.client.v1.rbac.model.TenantsPermission;
+import io.weaviate.client.v1.rbac.model.UsersPermission;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class WeaviatePermission {
+  String action;
+  BackupsPermission backups;
+  ClusterPermission cluster;
+  CollectionsPermission collections;
+  DataPermission data;
+  NodesPermission nodes;
+  RolesPermission roles;
+  TenantsPermission tenants;
+  UsersPermission users;
+
+  public WeaviatePermission(String action) {
+    this.action = action;
+  }
+
+  public <P extends Permission<P>> WeaviatePermission(String action, Permission<P> perm) {
+    this.action = action;
+    if (perm instanceof BackupsPermission) {
+      this.backups = (BackupsPermission) perm;
+    } else if (perm instanceof ClusterPermission) {
+      this.cluster = (ClusterPermission) perm;
+    } else if (perm instanceof CollectionsPermission) {
+      this.collections = (CollectionsPermission) perm;
+    } else if (perm instanceof DataPermission) {
+      this.data = (DataPermission) perm;
+    } else if (perm instanceof NodesPermission) {
+      this.nodes = (NodesPermission) perm;
+    } else if (perm instanceof RolesPermission) {
+      this.roles = (RolesPermission) perm;
+    } else if (perm instanceof TenantsPermission) {
+      this.tenants = (TenantsPermission) perm;
+    } else if (perm instanceof UsersPermission) {
+      this.users = (UsersPermission) perm;
+    }
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/WeaviatePermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/WeaviatePermission.java
@@ -8,7 +8,6 @@ import io.weaviate.client.v1.rbac.model.NodesPermission;
 import io.weaviate.client.v1.rbac.model.Permission;
 import io.weaviate.client.v1.rbac.model.RolesPermission;
 import io.weaviate.client.v1.rbac.model.TenantsPermission;
-import io.weaviate.client.v1.rbac.model.UsersPermission;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,13 +18,11 @@ import lombok.Getter;
 public class WeaviatePermission {
   String action;
   BackupsPermission backups;
-  ClusterPermission cluster;
   CollectionsPermission collections;
   DataPermission data;
   NodesPermission nodes;
   RolesPermission roles;
   TenantsPermission tenants;
-  UsersPermission users;
 
   public WeaviatePermission(String action) {
     this.action = action;
@@ -35,8 +32,6 @@ public class WeaviatePermission {
     this.action = action;
     if (perm instanceof BackupsPermission) {
       this.backups = (BackupsPermission) perm;
-    } else if (perm instanceof ClusterPermission) {
-      this.cluster = (ClusterPermission) perm;
     } else if (perm instanceof CollectionsPermission) {
       this.collections = (CollectionsPermission) perm;
     } else if (perm instanceof DataPermission) {
@@ -47,8 +42,6 @@ public class WeaviatePermission {
       this.roles = (RolesPermission) perm;
     } else if (perm instanceof TenantsPermission) {
       this.tenants = (TenantsPermission) perm;
-    } else if (perm instanceof UsersPermission) {
-      this.users = (UsersPermission) perm;
     }
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/api/WeaviatePermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/WeaviatePermission.java
@@ -1,6 +1,7 @@
 package io.weaviate.client.v1.rbac.api;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import io.weaviate.client.v1.rbac.model.BackupsPermission;
 import io.weaviate.client.v1.rbac.model.CollectionsPermission;
@@ -48,6 +49,6 @@ public class WeaviatePermission {
   }
 
   public static List<WeaviatePermission> mergePermissions(List<Permission<?>> permissions) {
-    return permissions.stream().map(perm -> perm.toWeaviate()).toList();
+    return permissions.stream().map(perm -> perm.toWeaviate()).collect(Collectors.toList());
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/api/WeaviatePermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/WeaviatePermission.java
@@ -1,7 +1,8 @@
 package io.weaviate.client.v1.rbac.api;
 
+import java.util.List;
+
 import io.weaviate.client.v1.rbac.model.BackupsPermission;
-import io.weaviate.client.v1.rbac.model.ClusterPermission;
 import io.weaviate.client.v1.rbac.model.CollectionsPermission;
 import io.weaviate.client.v1.rbac.model.DataPermission;
 import io.weaviate.client.v1.rbac.model.NodesPermission;
@@ -43,5 +44,9 @@ public class WeaviatePermission {
     } else if (perm instanceof TenantsPermission) {
       this.tenants = (TenantsPermission) perm;
     }
+  }
+
+  public static List<WeaviatePermission> mergePermissions(List<Permission<?>> permissions) {
+    return permissions.stream().map(perm -> perm.toWeaviate()).toList();
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/api/WeaviateRole.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/WeaviateRole.java
@@ -1,6 +1,7 @@
 package io.weaviate.client.v1.rbac.api;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import io.weaviate.client.v1.rbac.model.Permission;
 import io.weaviate.client.v1.rbac.model.Role;
@@ -20,7 +21,7 @@ public class WeaviateRole {
   /** Create {@link Role} from the API response object. */
   public Role toRole() {
     List<Permission<?>> permissions = this.permissions.stream()
-        .<Permission<?>>map(perm -> Permission.fromWeaviate(perm)).toList();
+        .<Permission<?>>map(perm -> Permission.fromWeaviate(perm)).collect(Collectors.toList());
     return new Role(this.name, permissions);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/api/WeaviateRole.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/WeaviateRole.java
@@ -6,6 +6,7 @@ import io.weaviate.client.v1.rbac.model.Permission;
 import io.weaviate.client.v1.rbac.model.Role;
 import lombok.Getter;
 
+/** API model for serializing/deserializing roles. */
 @Getter
 public class WeaviateRole {
   String name;
@@ -16,6 +17,7 @@ public class WeaviateRole {
     this.permissions = WeaviatePermission.mergePermissions(permissions);
   }
 
+  /** Create {@link Role} from the API response object. */
   public Role toRole() {
     List<Permission<?>> permissions = this.permissions.stream()
         .<Permission<?>>map(perm -> Permission.fromWeaviate(perm)).toList();

--- a/src/main/java/io/weaviate/client/v1/rbac/api/WeaviateRole.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/WeaviateRole.java
@@ -1,32 +1,24 @@
 package io.weaviate.client.v1.rbac.api;
 
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import io.weaviate.client.v1.rbac.model.Permission;
 import io.weaviate.client.v1.rbac.model.Role;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder
-@AllArgsConstructor
 public class WeaviateRole {
   String name;
-  List<Map<String, Map<String, ?>>> permissions;
+  List<WeaviatePermission> permissions;
 
-  public WeaviateRole(Role role) {
-    this.name = role.name;
-    this.permissions = mergePermissions(role.permissions);
-  }
-
-  private static List<Map<String, Map<String, ?>>> mergePermissions(List<Permission<?>> permissions) {
-    return null;
+  public WeaviateRole(String name, List<Permission<?>> permissions) {
+    this.name = name;
+    this.permissions = WeaviatePermission.mergePermissions(permissions);
   }
 
   public Role toRole() {
-    return null;
+    List<Permission<?>> permissions = this.permissions.stream()
+        .<Permission<?>>map(perm -> Permission.fromWeaviate(perm)).toList();
+    return new Role(this.name, permissions);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/api/WeaviateRole.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/WeaviateRole.java
@@ -1,0 +1,32 @@
+package io.weaviate.client.v1.rbac.api;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import io.weaviate.client.v1.rbac.model.Permission;
+import io.weaviate.client.v1.rbac.model.Role;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class WeaviateRole {
+  String name;
+  List<Map<String, Map<String, ?>>> permissions;
+
+  public WeaviateRole(Role role) {
+    this.name = role.name;
+    this.permissions = mergePermissions(role.permissions);
+  }
+
+  private static List<Map<String, Map<String, ?>>> mergePermissions(List<Permission<?>> permissions) {
+    return null;
+  }
+
+  public Role toRole() {
+    return null;
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/WeaviateRole.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/WeaviateRole.java
@@ -23,7 +23,6 @@ public class WeaviateRole {
   WeaviateRole(String name, WeaviatePermission... permissions) {
     this.name = name;
     this.permissions = Arrays.asList(permissions);
-
   }
 
   /** Create {@link Role} from the API response object. */

--- a/src/main/java/io/weaviate/client/v1/rbac/api/WeaviateRole.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/WeaviateRole.java
@@ -1,5 +1,6 @@
 package io.weaviate.client.v1.rbac.api;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -18,10 +19,18 @@ public class WeaviateRole {
     this.permissions = WeaviatePermission.mergePermissions(permissions);
   }
 
+  /** Exposed for testing. */
+  WeaviateRole(String name, WeaviatePermission... permissions) {
+    this.name = name;
+    this.permissions = Arrays.asList(permissions);
+
+  }
+
   /** Create {@link Role} from the API response object. */
   public Role toRole() {
     List<Permission<?>> permissions = this.permissions.stream()
-        .<Permission<?>>map(perm -> Permission.fromWeaviate(perm)).collect(Collectors.toList());
-    return new Role(this.name, permissions);
+        .<Permission<?>>map(perm -> Permission.fromWeaviate(perm))
+        .collect(Collectors.toList());
+    return new Role(this.name, Permission.merge(permissions));
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/model/BackupsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/BackupsPermission.java
@@ -2,9 +2,11 @@ package io.weaviate.client.v1.rbac.model;
 
 import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
+@EqualsAndHashCode(callSuper = true)
 public class BackupsPermission extends Permission<BackupsPermission> {
   final String collection;
 

--- a/src/main/java/io/weaviate/client/v1/rbac/model/BackupsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/BackupsPermission.java
@@ -1,6 +1,5 @@
 package io.weaviate.client.v1.rbac.model;
 
-import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -17,11 +16,6 @@ public class BackupsPermission extends Permission<BackupsPermission> {
 
   BackupsPermission(String collection, String action) {
     this(collection, RbacAction.fromString(Action.class, action));
-  }
-
-  @Override
-  public WeaviatePermission toWeaviate() {
-    return new WeaviatePermission(this.action, this);
   }
 
   @AllArgsConstructor

--- a/src/main/java/io/weaviate/client/v1/rbac/model/BackupsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/BackupsPermission.java
@@ -5,12 +5,11 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-public class BackupsPermission implements Permission<BackupsPermission> {
-  final transient String action;
+public class BackupsPermission extends Permission<BackupsPermission> {
   final String collection;
 
   public BackupsPermission(Action action, String collection) {
-    this.action = action.getValue();
+    super(action);
     this.collection = collection;
   }
 

--- a/src/main/java/io/weaviate/client/v1/rbac/model/BackupsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/BackupsPermission.java
@@ -1,0 +1,33 @@
+package io.weaviate.client.v1.rbac.model;
+
+import io.weaviate.client.v1.rbac.api.WeaviatePermission;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class BackupsPermission implements Permission<BackupsPermission> {
+  final transient String action;
+  final String collection;
+
+  public BackupsPermission(Action action, String collection) {
+    this.action = action.getValue();
+    this.collection = collection;
+  }
+
+  @Override
+  public WeaviatePermission toWeaviate() {
+    return new WeaviatePermission(this.action, this);
+  }
+
+  @Override
+  public BackupsPermission fromWeaviate(WeaviatePermission perm) {
+    return null;
+  }
+
+  @AllArgsConstructor
+  public enum Action {
+    MANAGE("manage_backups");
+
+    @Getter
+    private final String value;
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/model/BackupsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/BackupsPermission.java
@@ -16,7 +16,7 @@ public class BackupsPermission extends Permission<BackupsPermission> {
   }
 
   BackupsPermission(String collection, String action) {
-    this(collection, CustomAction.fromString(Action.class, action));
+    this(collection, RbacAction.fromString(Action.class, action));
   }
 
   @Override
@@ -25,7 +25,7 @@ public class BackupsPermission extends Permission<BackupsPermission> {
   }
 
   @AllArgsConstructor
-  public enum Action implements CustomAction {
+  public enum Action implements RbacAction {
     MANAGE("manage_backups");
 
     @Getter

--- a/src/main/java/io/weaviate/client/v1/rbac/model/BackupsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/BackupsPermission.java
@@ -4,6 +4,7 @@ import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@Getter
 public class BackupsPermission implements Permission<BackupsPermission> {
   final transient String action;
   final String collection;
@@ -13,18 +14,17 @@ public class BackupsPermission implements Permission<BackupsPermission> {
     this.collection = collection;
   }
 
+  BackupsPermission(String action, String collection) {
+    this(CustomAction.fromString(Action.class, action), collection);
+  }
+
   @Override
   public WeaviatePermission toWeaviate() {
     return new WeaviatePermission(this.action, this);
   }
 
-  @Override
-  public BackupsPermission fromWeaviate(WeaviatePermission perm) {
-    return null;
-  }
-
   @AllArgsConstructor
-  public enum Action {
+  public enum Action implements CustomAction {
     MANAGE("manage_backups");
 
     @Getter

--- a/src/main/java/io/weaviate/client/v1/rbac/model/BackupsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/BackupsPermission.java
@@ -10,13 +10,13 @@ import lombok.Getter;
 public class BackupsPermission extends Permission<BackupsPermission> {
   final String collection;
 
-  public BackupsPermission(Action action, String collection) {
+  public BackupsPermission(String collection, Action action) {
     super(action);
     this.collection = collection;
   }
 
-  BackupsPermission(String action, String collection) {
-    this(CustomAction.fromString(Action.class, action), collection);
+  BackupsPermission(String collection, String action) {
+    this(collection, CustomAction.fromString(Action.class, action));
   }
 
   @Override

--- a/src/main/java/io/weaviate/client/v1/rbac/model/BackupsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/BackupsPermission.java
@@ -9,8 +9,8 @@ import lombok.Getter;
 public class BackupsPermission extends Permission<BackupsPermission> {
   final String collection;
 
-  public BackupsPermission(String collection, Action action) {
-    super(action);
+  public BackupsPermission(String collection, Action... actions) {
+    super(actions);
     this.collection = collection;
   }
 

--- a/src/main/java/io/weaviate/client/v1/rbac/model/ClusterPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/ClusterPermission.java
@@ -1,0 +1,31 @@
+package io.weaviate.client.v1.rbac.model;
+
+import io.weaviate.client.v1.rbac.api.WeaviatePermission;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class ClusterPermission implements Permission<ClusterPermission> {
+  final String action;
+
+  public ClusterPermission(Action action) {
+    this.action = action.getValue();
+  }
+
+  @Override
+  public WeaviatePermission toWeaviate() {
+    return new WeaviatePermission(this.action);
+  }
+
+  @Override
+  public ClusterPermission fromWeaviate(WeaviatePermission perm) {
+    return null;
+  }
+
+  @AllArgsConstructor
+  public enum Action {
+    READ("read_cluster");
+
+    @Getter
+    private final String value;
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/model/ClusterPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/ClusterPermission.java
@@ -13,7 +13,7 @@ public class ClusterPermission extends Permission<ClusterPermission> {
   }
 
   ClusterPermission(String action) {
-    this(CustomAction.fromString(Action.class, action));
+    this(RbacAction.fromString(Action.class, action));
   }
 
   @Override
@@ -22,7 +22,7 @@ public class ClusterPermission extends Permission<ClusterPermission> {
   }
 
   @AllArgsConstructor
-  public enum Action implements CustomAction {
+  public enum Action implements RbacAction {
     READ("read_cluster");
 
     @Getter

--- a/src/main/java/io/weaviate/client/v1/rbac/model/ClusterPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/ClusterPermission.java
@@ -1,6 +1,5 @@
 package io.weaviate.client.v1.rbac.model;
 
-import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -14,11 +13,6 @@ public class ClusterPermission extends Permission<ClusterPermission> {
 
   ClusterPermission(String action) {
     this(RbacAction.fromString(Action.class, action));
-  }
-
-  @Override
-  public WeaviatePermission toWeaviate() {
-    return new WeaviatePermission(this.action);
   }
 
   @AllArgsConstructor

--- a/src/main/java/io/weaviate/client/v1/rbac/model/ClusterPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/ClusterPermission.java
@@ -7,8 +7,8 @@ import lombok.Getter;
 @Getter
 @EqualsAndHashCode(callSuper = true)
 public class ClusterPermission extends Permission<ClusterPermission> {
-  public ClusterPermission(Action action) {
-    super(action);
+  public ClusterPermission(Action... actions) {
+    super(actions);
   }
 
   ClusterPermission(String action) {

--- a/src/main/java/io/weaviate/client/v1/rbac/model/ClusterPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/ClusterPermission.java
@@ -4,6 +4,7 @@ import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@Getter
 public class ClusterPermission implements Permission<ClusterPermission> {
   final String action;
 
@@ -11,18 +12,17 @@ public class ClusterPermission implements Permission<ClusterPermission> {
     this.action = action.getValue();
   }
 
+  ClusterPermission(String action) {
+    this(CustomAction.fromString(Action.class, action));
+  }
+
   @Override
   public WeaviatePermission toWeaviate() {
     return new WeaviatePermission(this.action);
   }
 
-  @Override
-  public ClusterPermission fromWeaviate(WeaviatePermission perm) {
-    return null;
-  }
-
   @AllArgsConstructor
-  public enum Action {
+  public enum Action implements CustomAction {
     READ("read_cluster");
 
     @Getter

--- a/src/main/java/io/weaviate/client/v1/rbac/model/ClusterPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/ClusterPermission.java
@@ -2,9 +2,11 @@ package io.weaviate.client.v1.rbac.model;
 
 import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
+@EqualsAndHashCode(callSuper = true)
 public class ClusterPermission extends Permission<ClusterPermission> {
   public ClusterPermission(Action action) {
     super(action);

--- a/src/main/java/io/weaviate/client/v1/rbac/model/ClusterPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/ClusterPermission.java
@@ -5,11 +5,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-public class ClusterPermission implements Permission<ClusterPermission> {
-  final String action;
-
+public class ClusterPermission extends Permission<ClusterPermission> {
   public ClusterPermission(Action action) {
-    this.action = action.getValue();
+    super(action);
   }
 
   ClusterPermission(String action) {

--- a/src/main/java/io/weaviate/client/v1/rbac/model/CollectionsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/CollectionsPermission.java
@@ -5,8 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-public class CollectionsPermission implements Permission<CollectionsPermission> {
-  final transient String action;
+public class CollectionsPermission extends Permission<CollectionsPermission> {
   final String collection;
   final String tenant;
 
@@ -19,7 +18,7 @@ public class CollectionsPermission implements Permission<CollectionsPermission> 
   }
 
   private CollectionsPermission(Action action, String collection, String tenant) {
-    this.action = action.getValue();
+    super(action);
     this.collection = collection;
     this.tenant = tenant;
   }
@@ -34,8 +33,10 @@ public class CollectionsPermission implements Permission<CollectionsPermission> 
     CREATE("create_collections"),
     READ("read_collections"),
     UPDATE("update_collections"),
-    DELETE("delete_collections"),
-    MANAGE("manage_collections");
+    DELETE("delete_collections");
+
+    // Not part of the public API yet.
+    // MANAGE("manage_collections");
 
     @Getter
     private final String value;

--- a/src/main/java/io/weaviate/client/v1/rbac/model/CollectionsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/CollectionsPermission.java
@@ -2,9 +2,11 @@ package io.weaviate.client.v1.rbac.model;
 
 import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
+@EqualsAndHashCode(callSuper = true)
 public class CollectionsPermission extends Permission<CollectionsPermission> {
   final String collection;
   final String tenant;

--- a/src/main/java/io/weaviate/client/v1/rbac/model/CollectionsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/CollectionsPermission.java
@@ -9,8 +9,8 @@ import lombok.Getter;
 public class CollectionsPermission extends Permission<CollectionsPermission> {
   final String collection;
 
-  public CollectionsPermission(String collection, Action action) {
-    super(action);
+  public CollectionsPermission(String collection, Action... actions) {
+    super(actions);
     this.collection = collection;
   }
 

--- a/src/main/java/io/weaviate/client/v1/rbac/model/CollectionsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/CollectionsPermission.java
@@ -11,15 +11,15 @@ public class CollectionsPermission extends Permission<CollectionsPermission> {
   final String collection;
   final String tenant;
 
-  public CollectionsPermission(Action action, String collection) {
-    this(action, collection, "*");
+  public CollectionsPermission(String collection, Action action) {
+    this(collection, "*", action);
   }
 
-  CollectionsPermission(String action, String collection) {
-    this(CustomAction.fromString(Action.class, action), collection);
+  CollectionsPermission(String collection, String action) {
+    this(collection, CustomAction.fromString(Action.class, action));
   }
 
-  private CollectionsPermission(Action action, String collection, String tenant) {
+  private CollectionsPermission(String collection, String tenant, Action action) {
     super(action);
     this.collection = collection;
     this.tenant = tenant;

--- a/src/main/java/io/weaviate/client/v1/rbac/model/CollectionsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/CollectionsPermission.java
@@ -1,6 +1,5 @@
 package io.weaviate.client.v1.rbac.model;
 
-import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -17,11 +16,6 @@ public class CollectionsPermission extends Permission<CollectionsPermission> {
 
   CollectionsPermission(String collection, String action) {
     this(collection, RbacAction.fromString(Action.class, action));
-  }
-
-  @Override
-  public WeaviatePermission toWeaviate() {
-    return new WeaviatePermission(this.action, this);
   }
 
   @AllArgsConstructor

--- a/src/main/java/io/weaviate/client/v1/rbac/model/CollectionsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/CollectionsPermission.java
@@ -1,0 +1,44 @@
+package io.weaviate.client.v1.rbac.model;
+
+import io.weaviate.client.v1.rbac.api.WeaviatePermission;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+public class CollectionsPermission implements Permission<CollectionsPermission> {
+  final transient String action;
+  final String collection;
+  final String tenant;
+
+  public CollectionsPermission(Action action, String collection) {
+    this(action, collection, "*");
+  }
+
+  private CollectionsPermission(Action action, String collection, String tenant) {
+    this.action = action.getValue();
+    this.collection = collection;
+    this.tenant = tenant;
+  }
+
+  @Override
+  public WeaviatePermission toWeaviate() {
+    return new WeaviatePermission(this.action, this);
+  }
+
+  @Override
+  public CollectionsPermission fromWeaviate(WeaviatePermission perm) {
+    return null;
+  }
+
+  @AllArgsConstructor
+  public enum Action {
+    CREATE("create_collections"),
+    READ("read_collections"),
+    UPDATE("update_collections"),
+    DELETE("delete_collections"),
+    MANAGE("manage_collections");
+
+    @Getter
+    private final String value;
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/model/CollectionsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/CollectionsPermission.java
@@ -9,20 +9,14 @@ import lombok.Getter;
 @EqualsAndHashCode(callSuper = true)
 public class CollectionsPermission extends Permission<CollectionsPermission> {
   final String collection;
-  final String tenant;
 
   public CollectionsPermission(String collection, Action action) {
-    this(collection, "*", action);
+    super(action);
+    this.collection = collection;
   }
 
   CollectionsPermission(String collection, String action) {
     this(collection, RbacAction.fromString(Action.class, action));
-  }
-
-  private CollectionsPermission(String collection, String tenant, Action action) {
-    super(action);
-    this.collection = collection;
-    this.tenant = tenant;
   }
 
   @Override

--- a/src/main/java/io/weaviate/client/v1/rbac/model/CollectionsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/CollectionsPermission.java
@@ -16,7 +16,7 @@ public class CollectionsPermission extends Permission<CollectionsPermission> {
   }
 
   CollectionsPermission(String collection, String action) {
-    this(collection, CustomAction.fromString(Action.class, action));
+    this(collection, RbacAction.fromString(Action.class, action));
   }
 
   private CollectionsPermission(String collection, String tenant, Action action) {
@@ -31,7 +31,7 @@ public class CollectionsPermission extends Permission<CollectionsPermission> {
   }
 
   @AllArgsConstructor
-  public enum Action implements CustomAction {
+  public enum Action implements RbacAction {
     CREATE("create_collections"),
     READ("read_collections"),
     UPDATE("update_collections"),

--- a/src/main/java/io/weaviate/client/v1/rbac/model/CollectionsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/CollectionsPermission.java
@@ -14,6 +14,10 @@ public class CollectionsPermission implements Permission<CollectionsPermission> 
     this(action, collection, "*");
   }
 
+  CollectionsPermission(String action, String collection) {
+    this(CustomAction.fromString(Action.class, action), collection);
+  }
+
   private CollectionsPermission(Action action, String collection, String tenant) {
     this.action = action.getValue();
     this.collection = collection;
@@ -25,13 +29,8 @@ public class CollectionsPermission implements Permission<CollectionsPermission> 
     return new WeaviatePermission(this.action, this);
   }
 
-  @Override
-  public CollectionsPermission fromWeaviate(WeaviatePermission perm) {
-    return null;
-  }
-
   @AllArgsConstructor
-  public enum Action {
+  public enum Action implements CustomAction {
     CREATE("create_collections"),
     READ("read_collections"),
     UPDATE("update_collections"),

--- a/src/main/java/io/weaviate/client/v1/rbac/model/DataPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/DataPermission.java
@@ -15,6 +15,10 @@ public class DataPermission implements Permission<DataPermission> {
     this(action, collection, "*", "*");
   }
 
+  DataPermission(String action, String collection) {
+    this(CustomAction.fromString(Action.class, action), collection);
+  }
+
   private DataPermission(Action action, String collection, String object, String tenant) {
     this.action = action.getValue();
     this.collection = collection;
@@ -27,13 +31,8 @@ public class DataPermission implements Permission<DataPermission> {
     return new WeaviatePermission(this.action, this);
   }
 
-  @Override
-  public DataPermission fromWeaviate(WeaviatePermission perm) {
-    return null;
-  }
-
   @AllArgsConstructor
-  public enum Action {
+  public enum Action implements CustomAction {
     CREATE("create_data"),
     READ("read_data"),
     UPDATE("update_data"),

--- a/src/main/java/io/weaviate/client/v1/rbac/model/DataPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/DataPermission.java
@@ -9,22 +9,14 @@ import lombok.Getter;
 @EqualsAndHashCode(callSuper = true)
 public class DataPermission extends Permission<DataPermission> {
   final String collection;
-  final String object;
-  final String tenant;
 
   public DataPermission(String collection, Action action) {
-    this(collection, "*", "*", action);
+    super(action);
+    this.collection = collection;
   }
 
   DataPermission(String collection, String action) {
     this(collection, RbacAction.fromString(Action.class, action));
-  }
-
-  private DataPermission(String collection, String object, String tenant, Action action) {
-    super(action);
-    this.collection = collection;
-    this.object = object;
-    this.tenant = tenant;
   }
 
   @Override

--- a/src/main/java/io/weaviate/client/v1/rbac/model/DataPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/DataPermission.java
@@ -1,6 +1,5 @@
 package io.weaviate.client.v1.rbac.model;
 
-import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -17,11 +16,6 @@ public class DataPermission extends Permission<DataPermission> {
 
   DataPermission(String collection, String action) {
     this(collection, RbacAction.fromString(Action.class, action));
-  }
-
-  @Override
-  public WeaviatePermission toWeaviate() {
-    return new WeaviatePermission(this.action, this);
   }
 
   @AllArgsConstructor

--- a/src/main/java/io/weaviate/client/v1/rbac/model/DataPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/DataPermission.java
@@ -9,8 +9,8 @@ import lombok.Getter;
 public class DataPermission extends Permission<DataPermission> {
   final String collection;
 
-  public DataPermission(String collection, Action action) {
-    super(action);
+  public DataPermission(String collection, Action... actions) {
+    super(actions);
     this.collection = collection;
   }
 

--- a/src/main/java/io/weaviate/client/v1/rbac/model/DataPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/DataPermission.java
@@ -1,0 +1,46 @@
+package io.weaviate.client.v1.rbac.model;
+
+import io.weaviate.client.v1.rbac.api.WeaviatePermission;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+public class DataPermission implements Permission<DataPermission> {
+  final transient String action;
+  final String collection;
+  final String object;
+  final String tenant;
+
+  public DataPermission(Action action, String collection) {
+    this(action, collection, "*", "*");
+  }
+
+  private DataPermission(Action action, String collection, String object, String tenant) {
+    this.action = action.getValue();
+    this.collection = collection;
+    this.object = object;
+    this.tenant = tenant;
+  }
+
+  @Override
+  public WeaviatePermission toWeaviate() {
+    return new WeaviatePermission(this.action, this);
+  }
+
+  @Override
+  public DataPermission fromWeaviate(WeaviatePermission perm) {
+    return null;
+  }
+
+  @AllArgsConstructor
+  public enum Action {
+    CREATE("create_data"),
+    READ("read_data"),
+    UPDATE("update_data"),
+    DELETE("delete_data"),
+    MANAGE("manage_data");
+
+    @Getter
+    private final String value;
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/model/DataPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/DataPermission.java
@@ -2,9 +2,11 @@ package io.weaviate.client.v1.rbac.model;
 
 import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
+@EqualsAndHashCode(callSuper = true)
 public class DataPermission extends Permission<DataPermission> {
   final String collection;
   final String object;

--- a/src/main/java/io/weaviate/client/v1/rbac/model/DataPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/DataPermission.java
@@ -12,15 +12,15 @@ public class DataPermission extends Permission<DataPermission> {
   final String object;
   final String tenant;
 
-  public DataPermission(Action action, String collection) {
-    this(action, collection, "*", "*");
+  public DataPermission(String collection, Action action) {
+    this(collection, "*", "*", action);
   }
 
-  DataPermission(String action, String collection) {
-    this(CustomAction.fromString(Action.class, action), collection);
+  DataPermission(String collection, String action) {
+    this(collection, CustomAction.fromString(Action.class, action));
   }
 
-  private DataPermission(Action action, String collection, String object, String tenant) {
+  private DataPermission(String collection, String object, String tenant, Action action) {
     super(action);
     this.collection = collection;
     this.object = object;

--- a/src/main/java/io/weaviate/client/v1/rbac/model/DataPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/DataPermission.java
@@ -5,8 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-public class DataPermission implements Permission<DataPermission> {
-  final transient String action;
+public class DataPermission extends Permission<DataPermission> {
   final String collection;
   final String object;
   final String tenant;
@@ -20,7 +19,7 @@ public class DataPermission implements Permission<DataPermission> {
   }
 
   private DataPermission(Action action, String collection, String object, String tenant) {
-    this.action = action.getValue();
+    super(action);
     this.collection = collection;
     this.object = object;
     this.tenant = tenant;

--- a/src/main/java/io/weaviate/client/v1/rbac/model/DataPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/DataPermission.java
@@ -17,7 +17,7 @@ public class DataPermission extends Permission<DataPermission> {
   }
 
   DataPermission(String collection, String action) {
-    this(collection, CustomAction.fromString(Action.class, action));
+    this(collection, RbacAction.fromString(Action.class, action));
   }
 
   private DataPermission(String collection, String object, String tenant, Action action) {
@@ -33,7 +33,7 @@ public class DataPermission extends Permission<DataPermission> {
   }
 
   @AllArgsConstructor
-  public enum Action implements CustomAction {
+  public enum Action implements RbacAction {
     CREATE("create_data"),
     READ("read_data"),
     UPDATE("update_data"),

--- a/src/main/java/io/weaviate/client/v1/rbac/model/NodesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/NodesPermission.java
@@ -19,11 +19,11 @@ public class NodesPermission extends Permission<NodesPermission> {
   }
 
   NodesPermission(Verbosity verbosity, String action) {
-    this(verbosity, CustomAction.fromString(Action.class, action));
+    this(verbosity, RbacAction.fromString(Action.class, action));
   }
 
   NodesPermission(String collection, Verbosity verbosity, String action) {
-    this(collection, verbosity, CustomAction.fromString(Action.class, action));
+    this(collection, verbosity, RbacAction.fromString(Action.class, action));
   }
 
   /** NodesPermission for a defined collection. */
@@ -39,7 +39,7 @@ public class NodesPermission extends Permission<NodesPermission> {
   }
 
   @AllArgsConstructor
-  public enum Action implements CustomAction {
+  public enum Action implements RbacAction {
     READ("read_nodes");
 
     @Getter

--- a/src/main/java/io/weaviate/client/v1/rbac/model/NodesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/NodesPermission.java
@@ -4,9 +4,11 @@ import com.google.gson.annotations.SerializedName;
 
 import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
+@EqualsAndHashCode(callSuper = true)
 public class NodesPermission extends Permission<NodesPermission> {
   final String collection;
   final Verbosity verbosity;

--- a/src/main/java/io/weaviate/client/v1/rbac/model/NodesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/NodesPermission.java
@@ -13,15 +13,15 @@ public class NodesPermission extends Permission<NodesPermission> {
   final Verbosity verbosity;
 
   /** Create permission scoped to all collections. */
-  public NodesPermission(Verbosity verbosity, Action action) {
-    this("*", verbosity, action);
+  public NodesPermission(Verbosity verbosity, Action... actions) {
+    this("*", verbosity, actions);
   }
 
   /**
    * Permission scoped to a collection with {@link Verbosity#VERBOSE}.
    */
-  public NodesPermission(String collection, Action action) {
-    this(collection, Verbosity.VERBOSE, action);
+  public NodesPermission(String collection, Action... actions) {
+    this(collection, Verbosity.VERBOSE, actions);
   }
 
   NodesPermission(Verbosity verbosity, String action) {
@@ -32,8 +32,8 @@ public class NodesPermission extends Permission<NodesPermission> {
     this(collection, verbosity, RbacAction.fromString(Action.class, action));
   }
 
-  NodesPermission(String collection, Verbosity verbosity, Action action) {
-    super(action);
+  NodesPermission(String collection, Verbosity verbosity, Action... actions) {
+    super(actions);
     this.collection = collection;
     this.verbosity = verbosity;
   }

--- a/src/main/java/io/weaviate/client/v1/rbac/model/NodesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/NodesPermission.java
@@ -1,0 +1,50 @@
+package io.weaviate.client.v1.rbac.model;
+
+import io.weaviate.client.v1.rbac.api.WeaviatePermission;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+public class NodesPermission implements Permission<NodesPermission> {
+  final transient String action;
+  final String collection;
+  final Verbosity verbosity;
+
+  public NodesPermission(Action action, Verbosity verbosity) {
+    this(action, verbosity, "*");
+  }
+
+  public NodesPermission(Action action, Verbosity verbosity, String collection) {
+    this.action = action.getValue();
+    this.collection = collection;
+    this.verbosity = verbosity;
+  }
+
+  @Override
+  public WeaviatePermission toWeaviate() {
+    return new WeaviatePermission(this.action, this);
+  }
+
+  @Override
+  public NodesPermission fromWeaviate(WeaviatePermission perm) {
+    return null;
+  }
+
+  @AllArgsConstructor
+  public enum Action {
+    READ("read_nodes");
+
+    @Getter
+    private final String value;
+  }
+
+  @AllArgsConstructor
+  public enum Verbosity {
+    MINIMAL("minimal"),
+    VERBOSE("verbose");
+
+    @Getter
+    private final String value;
+  }
+
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/model/NodesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/NodesPermission.java
@@ -13,9 +13,16 @@ public class NodesPermission extends Permission<NodesPermission> {
   final String collection;
   final Verbosity verbosity;
 
-  /** NodesPermission for all collections. */
+  /** Create permission scoped to all collections. */
   public NodesPermission(Verbosity verbosity, Action action) {
     this("*", verbosity, action);
+  }
+
+  /**
+   * Permission scoped to a collection with {@link Verbosity#VERBOSE}.
+   */
+  public NodesPermission(String collection, Action action) {
+    this(collection, Verbosity.VERBOSE, action);
   }
 
   NodesPermission(Verbosity verbosity, String action) {
@@ -26,8 +33,7 @@ public class NodesPermission extends Permission<NodesPermission> {
     this(collection, verbosity, RbacAction.fromString(Action.class, action));
   }
 
-  /** NodesPermission for a defined collection. */
-  public NodesPermission(String collection, Verbosity verbosity, Action action) {
+  NodesPermission(String collection, Verbosity verbosity, Action action) {
     super(action);
     this.collection = collection;
     this.verbosity = verbosity;

--- a/src/main/java/io/weaviate/client/v1/rbac/model/NodesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/NodesPermission.java
@@ -7,8 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-public class NodesPermission implements Permission<NodesPermission> {
-  final transient String action;
+public class NodesPermission extends Permission<NodesPermission> {
   final String collection;
   final Verbosity verbosity;
 
@@ -25,7 +24,7 @@ public class NodesPermission implements Permission<NodesPermission> {
   }
 
   public NodesPermission(Action action, Verbosity verbosity, String collection) {
-    this.action = action.getValue();
+    super(action);
     this.collection = collection;
     this.verbosity = verbosity;
   }

--- a/src/main/java/io/weaviate/client/v1/rbac/model/NodesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/NodesPermission.java
@@ -13,19 +13,21 @@ public class NodesPermission extends Permission<NodesPermission> {
   final String collection;
   final Verbosity verbosity;
 
-  public NodesPermission(Action action, Verbosity verbosity) {
-    this(action, verbosity, "*");
+  /** NodesPermission for all collections. */
+  public NodesPermission(Verbosity verbosity, Action action) {
+    this("*", verbosity, action);
   }
 
-  NodesPermission(String action, Verbosity verbosity) {
-    this(CustomAction.fromString(Action.class, action), verbosity);
+  NodesPermission(Verbosity verbosity, String action) {
+    this(verbosity, CustomAction.fromString(Action.class, action));
   }
 
-  NodesPermission(String action, Verbosity verbosity, String collection) {
-    this(CustomAction.fromString(Action.class, action), verbosity, collection);
+  NodesPermission(String collection, Verbosity verbosity, String action) {
+    this(collection, verbosity, CustomAction.fromString(Action.class, action));
   }
 
-  public NodesPermission(Action action, Verbosity verbosity, String collection) {
+  /** NodesPermission for a defined collection. */
+  public NodesPermission(String collection, Verbosity verbosity, Action action) {
     super(action);
     this.collection = collection;
     this.verbosity = verbosity;

--- a/src/main/java/io/weaviate/client/v1/rbac/model/NodesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/NodesPermission.java
@@ -2,7 +2,6 @@ package io.weaviate.client.v1.rbac.model;
 
 import com.google.gson.annotations.SerializedName;
 
-import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -37,11 +36,6 @@ public class NodesPermission extends Permission<NodesPermission> {
     super(action);
     this.collection = collection;
     this.verbosity = verbosity;
-  }
-
-  @Override
-  public WeaviatePermission toWeaviate() {
-    return new WeaviatePermission(this.action, this);
   }
 
   @AllArgsConstructor

--- a/src/main/java/io/weaviate/client/v1/rbac/model/NodesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/NodesPermission.java
@@ -1,5 +1,7 @@
 package io.weaviate.client.v1.rbac.model;
 
+import com.google.gson.annotations.SerializedName;
+
 import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,6 +16,14 @@ public class NodesPermission implements Permission<NodesPermission> {
     this(action, verbosity, "*");
   }
 
+  NodesPermission(String action, Verbosity verbosity) {
+    this(CustomAction.fromString(Action.class, action), verbosity);
+  }
+
+  NodesPermission(String action, Verbosity verbosity, String collection) {
+    this(CustomAction.fromString(Action.class, action), verbosity, collection);
+  }
+
   public NodesPermission(Action action, Verbosity verbosity, String collection) {
     this.action = action.getValue();
     this.collection = collection;
@@ -25,13 +35,8 @@ public class NodesPermission implements Permission<NodesPermission> {
     return new WeaviatePermission(this.action, this);
   }
 
-  @Override
-  public NodesPermission fromWeaviate(WeaviatePermission perm) {
-    return null;
-  }
-
   @AllArgsConstructor
-  public enum Action {
+  public enum Action implements CustomAction {
     READ("read_nodes");
 
     @Getter
@@ -40,11 +45,10 @@ public class NodesPermission implements Permission<NodesPermission> {
 
   @AllArgsConstructor
   public enum Verbosity {
-    MINIMAL("minimal"),
-    VERBOSE("verbose");
-
-    @Getter
-    private final String value;
+    @SerializedName("minimal")
+    MINIMAL,
+    @SerializedName("verbose")
+    VERBOSE;
   }
 
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
@@ -53,7 +53,7 @@ public abstract class Permission<P extends Permission<P>> {
    * Example:
    * {@code Permission.backups(BackupsPermission.Action.MANAGE, "Pizza") }
    */
-  public static BackupsPermission[] backups(BackupsPermission.Action action, String collection) {
+  public static BackupsPermission[] backups(String collection, BackupsPermission.Action action) {
     checkDeprecation(action);
     return new BackupsPermission[] { new BackupsPermission(collection, action) };
   }

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
@@ -41,6 +41,9 @@ public abstract class Permission<P extends Permission<P>> {
     return null;
   }
 
+  // TODO: add overloaded methods for creating multiple permissions (actions) for
+  // the same collection/tenant/user etc.
+
   public static BackupsPermission backups(BackupsPermission.Action action, String collection) {
     return new BackupsPermission(action, collection);
   }

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
+import io.weaviate.client.v1.async.rbac.api.PermissionChecker;
 import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import io.weaviate.client.v1.rbac.model.NodesPermission.Verbosity;
 import lombok.EqualsAndHashCode;
@@ -38,7 +39,12 @@ public abstract class Permission<P extends Permission<P>> {
             .collect(Collectors.toList()));
   }
 
-  /** Convert the permission to a list of {@link WeaviatePermission}. */
+  /**
+   * Create {@link WeaviatePermission} with the first action in the actions list.
+   *
+   * This is meant to be used with {@link PermissionChecker}, which can only
+   * include a permission with a single action in the request.
+   */
   public WeaviatePermission firstToWeaviate() {
     if (actions.isEmpty()) {
       return null;
@@ -46,6 +52,7 @@ public abstract class Permission<P extends Permission<P>> {
     return this.toWeaviate(actions.iterator().next());
   };
 
+  /** Convert the permission to a list of {@link WeaviatePermission}. */
   public List<WeaviatePermission> toWeaviate() {
     return this.actions.stream().map(this::toWeaviate).collect(Collectors.toList());
   }

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
@@ -1,0 +1,45 @@
+package io.weaviate.client.v1.rbac.model;
+
+import io.weaviate.client.v1.rbac.api.WeaviatePermission;
+
+public interface Permission<P extends Permission<P>> {
+  WeaviatePermission toWeaviate();
+
+  P fromWeaviate(WeaviatePermission perm);
+
+  static ClusterPermission backups(ClusterPermission.Action action) {
+    return new ClusterPermission(action);
+  }
+
+  static BackupsPermission backups(BackupsPermission.Action action, String collection) {
+    return new BackupsPermission(action, collection);
+  }
+
+  static CollectionsPermission collections(CollectionsPermission.Action action, String collection) {
+    return new CollectionsPermission(action, collection);
+  }
+
+  static DataPermission data(DataPermission.Action action, String collection) {
+    return new DataPermission(action, collection);
+  }
+
+  static NodesPermission nodes(NodesPermission.Action action, NodesPermission.Verbosity verbosity) {
+    return new NodesPermission(action, verbosity);
+  }
+
+  static NodesPermission nodes(NodesPermission.Action action, NodesPermission.Verbosity verbosity, String collection) {
+    return new NodesPermission(action, verbosity, collection);
+  }
+
+  static RolesPermission roles(RolesPermission.Action action, String role) {
+    return new RolesPermission(action, role);
+  }
+
+  static TenantsPermission tenants(TenantsPermission.Action action) {
+    return new TenantsPermission(action);
+  }
+
+  static UsersPermission users(UsersPermission.Action action) {
+    return new UsersPermission(action);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
@@ -1,6 +1,7 @@
 package io.weaviate.client.v1.rbac.model;
 
 import io.weaviate.client.v1.rbac.api.WeaviatePermission;
+import io.weaviate.client.v1.rbac.model.NodesPermission.Verbosity;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -34,27 +35,53 @@ public abstract class Permission<P extends Permission<P>> {
       }
       return new NodesPermission(nodes.getVerbosity(), action);
     } else if (perm.getRoles() != null) {
-      return new RolesPermission(perm.getRoles().getRole(), action);
+      RolesPermission roles = perm.getRoles();
+      return new RolesPermission(roles.getRole(), roles.getScope(), action);
     } else if (perm.getTenants() != null) {
       return new TenantsPermission(action);
     } else if (RbacAction.isValid(ClusterPermission.Action.class, action)) {
       return new ClusterPermission(action);
+    } else if (RbacAction.isValid(UsersPermission.Action.class, action)) {
+      return new UsersPermission(action);
     }
     return null;
   }
 
+  /**
+   * Create {@link BackupsPermission} for a collection.
+   * <p>
+   * Example:
+   * {@code Permission.backups(BackupsPermission.Action.MANAGE, "Pizza") }
+   */
   public static BackupsPermission[] backups(BackupsPermission.Action action, String collection) {
     return new BackupsPermission[] { new BackupsPermission(collection, action) };
   }
 
+  /**
+   * Create {@link ClusterPermission} permission.
+   * <p>
+   * Example: {@code Permission.cluster(ClusterPermission.Action.READ, "Pizza") }
+   */
   public static ClusterPermission[] cluster(ClusterPermission.Action action) {
     return new ClusterPermission[] { new ClusterPermission(action) };
   }
 
+  /**
+   * Create permission for managing collection's configuration.
+   * <p>
+   * Example:
+   * {@code Permission.collections("Pizza", CollectionsPermission.Action.READ) }
+   */
   public static CollectionsPermission[] collections(String collection, CollectionsPermission.Action action) {
     return new CollectionsPermission[] { new CollectionsPermission(collection, action) };
   }
 
+  /**
+   * Create permission for collection's configuration.
+   * <p>
+   * Example:
+   * {@code Permission.collections("Pizza", CollectionsPermission.Action.READ, CollectionsPermission.Action.UPDATE) }
+   */
   public static CollectionsPermission[] collections(String collection, CollectionsPermission.Action... actions) {
     CollectionsPermission[] permissions = new CollectionsPermission[actions.length];
     for (int i = 0; i < actions.length; i++) {
@@ -63,10 +90,23 @@ public abstract class Permission<P extends Permission<P>> {
     return permissions;
   }
 
+  /**
+   * Create permissions for multiple actions for managing collection's data.
+   * <p>
+   * Example:
+   * {@code Permission.data("Pizza", DataPermission.Action.READ, DataPermission.Action.UPDATE) }
+   */
   public static DataPermission[] data(String collection, DataPermission.Action action) {
     return new DataPermission[] { new DataPermission(collection, action) };
   }
 
+  /**
+   * Create permissions for multiple actions for managing collection's
+   * data.
+   * <p>
+   * Example:
+   * {@code Permission.data("Pizza", DataPermission.Action.READ, DataPermission.Action.UPDATE) }
+   */
   public static DataPermission[] data(String collection, DataPermission.Action... actions) {
     DataPermission[] permissions = new DataPermission[actions.length];
     for (int i = 0; i < actions.length; i++) {
@@ -75,19 +115,43 @@ public abstract class Permission<P extends Permission<P>> {
     return permissions;
   }
 
+  /**
+   * Create {@link NodesPermission} scoped to all collections.
+   * <p>
+   * Example:
+   * {@code Permission.nodes(NodesPermission.Verbosity.MINIMAL, NodesPermission.Action.READ) }
+   */
   public static NodesPermission[] nodes(NodesPermission.Verbosity verbosity, NodesPermission.Action action) {
     return new NodesPermission[] { new NodesPermission(verbosity, action) };
   }
 
-  public static NodesPermission[] nodes(String collection, NodesPermission.Verbosity verbosity,
-      NodesPermission.Action action) {
-    return new NodesPermission[] { new NodesPermission(collection, verbosity, action) };
+  /**
+   * Create {@link NodesPermission} scoped to a specific collection. Verbosity is
+   * set to {@link Verbosity#VERBOSE} by default.
+   * <p>
+   * Example:
+   * {@code Permission.nodes("Pizza", NodesPermission.Action.READ) }
+   */
+  public static NodesPermission[] nodes(String collection, NodesPermission.Action action) {
+    return new NodesPermission[] { new NodesPermission(collection, action) };
   }
 
+  /**
+   * Create {@link RolesPermission} for a role.
+   * <p>
+   * Example:
+   * {@code Permission.roles("MyRole", RolesPermission.Action.READ) }
+   */
   public static RolesPermission[] roles(String role, RolesPermission.Action action) {
     return new RolesPermission[] { new RolesPermission(role, action) };
   }
 
+  /**
+   * Create {@link RolesPermission} for multiple actions.
+   * <p>
+   * Example:
+   * {@code Permission.roles("MyRole", RolesPermission.Action.READ, RolesPermission.Action.UPDATE) }
+   */
   public static RolesPermission[] roles(String role, RolesPermission.Action... actions) {
     RolesPermission[] permissions = new RolesPermission[actions.length];
     for (int i = 0; i < actions.length; i++) {
@@ -96,8 +160,24 @@ public abstract class Permission<P extends Permission<P>> {
     return permissions;
   }
 
+  /**
+   * Create {@link TenantsPermission} for a tenant.
+   * <p>
+   * Example:
+   * {@code Permission.tenants(TenantsPermission.Action.READ) }
+   */
   public static TenantsPermission[] tenants(TenantsPermission.Action action) {
     return new TenantsPermission[] { new TenantsPermission(action) };
+  }
+
+  /**
+   * Create {@link UsersPermission}.
+   * <p>
+   * Example:
+   * {@code Permission.users(UsersPermission.Action.READ) }
+   */
+  public static UsersPermission[] users(UsersPermission.Action action) {
+    return new UsersPermission[] { new UsersPermission(action) };
   }
 
   public String toString() {

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
@@ -54,6 +54,7 @@ public abstract class Permission<P extends Permission<P>> {
    * {@code Permission.backups(BackupsPermission.Action.MANAGE, "Pizza") }
    */
   public static BackupsPermission[] backups(BackupsPermission.Action action, String collection) {
+    checkDeprecation(action);
     return new BackupsPermission[] { new BackupsPermission(collection, action) };
   }
 
@@ -63,17 +64,8 @@ public abstract class Permission<P extends Permission<P>> {
    * Example: {@code Permission.cluster(ClusterPermission.Action.READ, "Pizza") }
    */
   public static ClusterPermission[] cluster(ClusterPermission.Action action) {
+    checkDeprecation(action);
     return new ClusterPermission[] { new ClusterPermission(action) };
-  }
-
-  /**
-   * Create permission for managing collection's configuration.
-   * <p>
-   * Example:
-   * {@code Permission.collections("Pizza", CollectionsPermission.Action.READ) }
-   */
-  public static CollectionsPermission[] collections(String collection, CollectionsPermission.Action action) {
-    return new CollectionsPermission[] { new CollectionsPermission(collection, action) };
   }
 
   /**
@@ -85,19 +77,10 @@ public abstract class Permission<P extends Permission<P>> {
   public static CollectionsPermission[] collections(String collection, CollectionsPermission.Action... actions) {
     CollectionsPermission[] permissions = new CollectionsPermission[actions.length];
     for (int i = 0; i < actions.length; i++) {
+      checkDeprecation(actions[i]);
       permissions[i] = new CollectionsPermission(collection, actions[i]);
     }
     return permissions;
-  }
-
-  /**
-   * Create permissions for multiple actions for managing collection's data.
-   * <p>
-   * Example:
-   * {@code Permission.data("Pizza", DataPermission.Action.READ, DataPermission.Action.UPDATE) }
-   */
-  public static DataPermission[] data(String collection, DataPermission.Action action) {
-    return new DataPermission[] { new DataPermission(collection, action) };
   }
 
   /**
@@ -110,6 +93,7 @@ public abstract class Permission<P extends Permission<P>> {
   public static DataPermission[] data(String collection, DataPermission.Action... actions) {
     DataPermission[] permissions = new DataPermission[actions.length];
     for (int i = 0; i < actions.length; i++) {
+      checkDeprecation(actions[i]);
       permissions[i] = new DataPermission(collection, actions[i]);
     }
     return permissions;
@@ -133,17 +117,8 @@ public abstract class Permission<P extends Permission<P>> {
    * {@code Permission.nodes("Pizza", NodesPermission.Action.READ) }
    */
   public static NodesPermission[] nodes(String collection, NodesPermission.Action action) {
+    checkDeprecation(action);
     return new NodesPermission[] { new NodesPermission(collection, action) };
-  }
-
-  /**
-   * Create {@link RolesPermission} for a role.
-   * <p>
-   * Example:
-   * {@code Permission.roles("MyRole", RolesPermission.Action.READ) }
-   */
-  public static RolesPermission[] roles(String role, RolesPermission.Action action) {
-    return new RolesPermission[] { new RolesPermission(role, action) };
   }
 
   /**
@@ -155,6 +130,7 @@ public abstract class Permission<P extends Permission<P>> {
   public static RolesPermission[] roles(String role, RolesPermission.Action... actions) {
     RolesPermission[] permissions = new RolesPermission[actions.length];
     for (int i = 0; i < actions.length; i++) {
+      checkDeprecation(actions[i]);
       permissions[i] = new RolesPermission(role, actions[i]);
     }
     return permissions;
@@ -167,6 +143,7 @@ public abstract class Permission<P extends Permission<P>> {
    * {@code Permission.tenants(TenantsPermission.Action.READ) }
    */
   public static TenantsPermission[] tenants(TenantsPermission.Action action) {
+    checkDeprecation(action);
     return new TenantsPermission[] { new TenantsPermission(action) };
   }
 
@@ -177,10 +154,19 @@ public abstract class Permission<P extends Permission<P>> {
    * {@code Permission.users(UsersPermission.Action.READ) }
    */
   public static UsersPermission[] users(UsersPermission.Action action) {
+    checkDeprecation(action);
     return new UsersPermission[] { new UsersPermission(action) };
+  }
+
+  private static void checkDeprecation(RbacAction action) throws IllegalArgumentException {
+    if (action.isDeprecated()) {
+      throw new IllegalArgumentException(action.getValue()
+          + " is hard-deprecated and should only be used to read legacy permissions created in v1.28");
+    }
   }
 
   public String toString() {
     return String.format("Permission<action=%s>", this.action);
   }
+
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
@@ -37,7 +37,7 @@ public abstract class Permission<P extends Permission<P>> {
       return new UsersPermission(action);
     }
     return null;
-  };
+  }
 
   public static BackupsPermission backups(BackupsPermission.Action action, String collection) {
     return new BackupsPermission(action, collection);
@@ -75,6 +75,11 @@ public abstract class Permission<P extends Permission<P>> {
   // public static UsersPermission users(UsersPermission.Action action) {
   // return new UsersPermission(action);
   // }
+
+  public String toString() {
+    return String.format("Permission<action=%s>", this.action);
+  }
+
 }
 
 interface CustomAction {

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
@@ -1,8 +1,10 @@
 package io.weaviate.client.v1.rbac.model;
 
 import io.weaviate.client.v1.rbac.api.WeaviatePermission;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+@EqualsAndHashCode
 public abstract class Permission<P extends Permission<P>> {
   @Getter
   final transient String action;
@@ -79,7 +81,6 @@ public abstract class Permission<P extends Permission<P>> {
   public String toString() {
     return String.format("Permission<action=%s>", this.action);
   }
-
 }
 
 interface CustomAction {

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
@@ -18,25 +18,23 @@ public abstract class Permission<P extends Permission<P>> {
   public static Permission<?> fromWeaviate(WeaviatePermission perm) {
     String action = perm.getAction();
     if (perm.getBackups() != null) {
-      return new BackupsPermission(action, perm.getBackups().getCollection());
+      return new BackupsPermission(perm.getBackups().getCollection(), action);
     } else if (perm.getCollections() != null) {
-      return new CollectionsPermission(action, perm.getCollections().getCollection());
+      return new CollectionsPermission(perm.getCollections().getCollection(), action);
     } else if (perm.getData() != null) {
-      return new DataPermission(action, perm.getData().getCollection());
+      return new DataPermission(perm.getData().getCollection(), action);
     } else if (perm.getNodes() != null) {
       NodesPermission nodes = perm.getNodes();
       if (nodes.getCollection() != null) {
-        return new NodesPermission(action, perm.getNodes().getVerbosity(), nodes.getCollection());
+        return new NodesPermission(nodes.getCollection(), nodes.getVerbosity(), action);
       }
-      return new NodesPermission(action, perm.getNodes().getVerbosity());
+      return new NodesPermission(nodes.getVerbosity(), action);
     } else if (perm.getRoles() != null) {
-      return new RolesPermission(action, perm.getRoles().getRole());
+      return new RolesPermission(perm.getRoles().getRole(), action);
     } else if (perm.getTenants() != null) {
       return new TenantsPermission(action);
     } else if (CustomAction.isValid(ClusterPermission.Action.class, action)) {
       return new ClusterPermission(action);
-    } else if (CustomAction.isValid(UsersPermission.Action.class, action)) {
-      return new UsersPermission(action);
     }
     return null;
   }
@@ -44,42 +42,62 @@ public abstract class Permission<P extends Permission<P>> {
   // TODO: add overloaded methods for creating multiple permissions (actions) for
   // the same collection/tenant/user etc.
 
-  public static BackupsPermission backups(BackupsPermission.Action action, String collection) {
-    return new BackupsPermission(action, collection);
+  public static BackupsPermission[] backups(BackupsPermission.Action action, String collection) {
+    return new BackupsPermission[] { new BackupsPermission(collection, action) };
   }
 
-  public static ClusterPermission cluster(ClusterPermission.Action action) {
-    return new ClusterPermission(action);
+  public static ClusterPermission[] cluster(ClusterPermission.Action action) {
+    return new ClusterPermission[] { new ClusterPermission(action) };
   }
 
-  public static CollectionsPermission collections(CollectionsPermission.Action action, String collection) {
-    return new CollectionsPermission(action, collection);
+  public static CollectionsPermission[] collections(String collection, CollectionsPermission.Action action) {
+    return new CollectionsPermission[] { new CollectionsPermission(collection, action) };
   }
 
-  public static DataPermission data(DataPermission.Action action, String collection) {
-    return new DataPermission(action, collection);
+  public static CollectionsPermission[] collections(String collection, CollectionsPermission.Action... actions) {
+    CollectionsPermission[] permissions = new CollectionsPermission[actions.length];
+    for (int i = 0; i < actions.length; i++) {
+      permissions[i] = new CollectionsPermission(collection, actions[i]);
+    }
+    return permissions;
   }
 
-  public static NodesPermission nodes(NodesPermission.Action action, NodesPermission.Verbosity verbosity) {
-    return new NodesPermission(action, verbosity);
+  public static DataPermission[] data(String collection, DataPermission.Action action) {
+    return new DataPermission[] { new DataPermission(collection, action) };
   }
 
-  public static NodesPermission nodes(NodesPermission.Action action, NodesPermission.Verbosity verbosity,
-      String collection) {
-    return new NodesPermission(action, verbosity, collection);
+  public static DataPermission[] data(String collection, DataPermission.Action... actions) {
+    DataPermission[] permissions = new DataPermission[actions.length];
+    for (int i = 0; i < actions.length; i++) {
+      permissions[i] = new DataPermission(collection, actions[i]);
+    }
+    return permissions;
   }
 
-  public static RolesPermission roles(RolesPermission.Action action, String role) {
-    return new RolesPermission(action, role);
+  public static NodesPermission[] nodes(NodesPermission.Verbosity verbosity, NodesPermission.Action action) {
+    return new NodesPermission[] { new NodesPermission(verbosity, action) };
   }
 
-  public static TenantsPermission tenants(TenantsPermission.Action action) {
-    return new TenantsPermission(action);
+  public static NodesPermission[] nodes(String collection, NodesPermission.Verbosity verbosity,
+      NodesPermission.Action action) {
+    return new NodesPermission[] { new NodesPermission(collection, verbosity, action) };
   }
 
-  // public static UsersPermission users(UsersPermission.Action action) {
-  // return new UsersPermission(action);
-  // }
+  public static RolesPermission[] roles(String role, RolesPermission.Action action) {
+    return new RolesPermission[] { new RolesPermission(role, action) };
+  }
+
+  public static RolesPermission[] roles(String role, RolesPermission.Action... actions) {
+    RolesPermission[] permissions = new RolesPermission[actions.length];
+    for (int i = 0; i < actions.length; i++) {
+      permissions[i] = new RolesPermission(role, actions[i]);
+    }
+    return permissions;
+  }
+
+  public static TenantsPermission[] tenants(TenantsPermission.Action action) {
+    return new TenantsPermission[] { new TenantsPermission(action) };
+  }
 
   public String toString() {
     return String.format("Permission<action=%s>", this.action);

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
@@ -15,7 +15,9 @@ public abstract class Permission<P extends Permission<P>> {
   }
 
   /** Convert the permission to {@link WeaviatePermission}. */
-  public abstract WeaviatePermission toWeaviate();
+  public WeaviatePermission toWeaviate() {
+    return new WeaviatePermission(this.action, this);
+  };
 
   /**
    * Convert {@link WeaviatePermission} to concrete {@link Permission}.

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
@@ -5,14 +5,43 @@ import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 public interface Permission<P extends Permission<P>> {
   WeaviatePermission toWeaviate();
 
-  P fromWeaviate(WeaviatePermission perm);
-
-  static ClusterPermission backups(ClusterPermission.Action action) {
-    return new ClusterPermission(action);
-  }
+  @SuppressWarnings("unchecked")
+  static <P extends Permission<P>> P fromWeaviate(WeaviatePermission perm) {
+    String action = perm.getAction();
+    if (perm.getBackups() != null) {
+      return (P) new BackupsPermission(action, perm.getBackups().getCollection());
+    } else if (perm.getCollections() != null) {
+      return (P) new CollectionsPermission(action, perm.getCollections().getCollection());
+    } else if (perm.getData() != null) {
+      return (P) new DataPermission(action, perm.getData().getCollection());
+    } else if (perm.getNodes() != null) {
+      NodesPermission out;
+      NodesPermission nodes = perm.getNodes();
+      if (nodes.getCollection() != null) {
+        out = new NodesPermission(action, perm.getNodes().getVerbosity(), nodes.getCollection());
+      } else {
+        out = new NodesPermission(action, perm.getNodes().getVerbosity());
+      }
+      return (P) out;
+    } else if (perm.getRoles() != null) {
+      return (P) new RolesPermission(action, perm.getRoles().getRole());
+    } else if (perm.getTenants() != null) {
+      return (P) new TenantsPermission(action);
+    } else if (CustomAction.isValid(ClusterPermission.Action.class, action)) {
+      System.out.println("cluster:" + action);
+      return (P) new ClusterPermission(action);
+    } else if (CustomAction.isValid(UsersPermission.Action.class, action)) {
+      return (P) new UsersPermission(action);
+    }
+    return null;
+  };
 
   static BackupsPermission backups(BackupsPermission.Action action, String collection) {
     return new BackupsPermission(action, collection);
+  }
+
+  static ClusterPermission cluster(ClusterPermission.Action action) {
+    return new ClusterPermission(action);
   }
 
   static CollectionsPermission collections(CollectionsPermission.Action action, String collection) {
@@ -41,5 +70,27 @@ public interface Permission<P extends Permission<P>> {
 
   static UsersPermission users(UsersPermission.Action action) {
     return new UsersPermission(action);
+  }
+}
+
+interface CustomAction {
+  String getValue();
+
+  static <E extends Enum<E> & CustomAction> E fromString(Class<E> enumClass, String value) {
+    for (E action : enumClass.getEnumConstants()) {
+      if (action.getValue().equals(value)) {
+        return action;
+      }
+    }
+    throw new IllegalArgumentException("No enum constant for value: " + value);
+  }
+
+  static <A extends CustomAction> boolean isValid(Class<A> enumClass, String value) {
+    for (CustomAction action : enumClass.getEnumConstants()) {
+      if (action.getValue().equals(value)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
@@ -1,76 +1,80 @@
 package io.weaviate.client.v1.rbac.model;
 
 import io.weaviate.client.v1.rbac.api.WeaviatePermission;
+import lombok.Getter;
 
-public interface Permission<P extends Permission<P>> {
-  WeaviatePermission toWeaviate();
+public abstract class Permission<P extends Permission<P>> {
+  @Getter
+  final transient String action;
 
-  @SuppressWarnings("unchecked")
-  static <P extends Permission<P>> P fromWeaviate(WeaviatePermission perm) {
+  Permission(CustomAction action) {
+    this.action = action.getValue();
+  }
+
+  public abstract WeaviatePermission toWeaviate();
+
+  public static Permission<?> fromWeaviate(WeaviatePermission perm) {
     String action = perm.getAction();
     if (perm.getBackups() != null) {
-      return (P) new BackupsPermission(action, perm.getBackups().getCollection());
+      return new BackupsPermission(action, perm.getBackups().getCollection());
     } else if (perm.getCollections() != null) {
-      return (P) new CollectionsPermission(action, perm.getCollections().getCollection());
+      return new CollectionsPermission(action, perm.getCollections().getCollection());
     } else if (perm.getData() != null) {
-      return (P) new DataPermission(action, perm.getData().getCollection());
+      return new DataPermission(action, perm.getData().getCollection());
     } else if (perm.getNodes() != null) {
-      NodesPermission out;
       NodesPermission nodes = perm.getNodes();
       if (nodes.getCollection() != null) {
-        out = new NodesPermission(action, perm.getNodes().getVerbosity(), nodes.getCollection());
-      } else {
-        out = new NodesPermission(action, perm.getNodes().getVerbosity());
+        return new NodesPermission(action, perm.getNodes().getVerbosity(), nodes.getCollection());
       }
-      return (P) out;
+      return new NodesPermission(action, perm.getNodes().getVerbosity());
     } else if (perm.getRoles() != null) {
-      return (P) new RolesPermission(action, perm.getRoles().getRole());
+      return new RolesPermission(action, perm.getRoles().getRole());
     } else if (perm.getTenants() != null) {
-      return (P) new TenantsPermission(action);
+      return new TenantsPermission(action);
     } else if (CustomAction.isValid(ClusterPermission.Action.class, action)) {
-      System.out.println("cluster:" + action);
-      return (P) new ClusterPermission(action);
+      return new ClusterPermission(action);
     } else if (CustomAction.isValid(UsersPermission.Action.class, action)) {
-      return (P) new UsersPermission(action);
+      return new UsersPermission(action);
     }
     return null;
   };
 
-  static BackupsPermission backups(BackupsPermission.Action action, String collection) {
+  public static BackupsPermission backups(BackupsPermission.Action action, String collection) {
     return new BackupsPermission(action, collection);
   }
 
-  static ClusterPermission cluster(ClusterPermission.Action action) {
+  public static ClusterPermission cluster(ClusterPermission.Action action) {
     return new ClusterPermission(action);
   }
 
-  static CollectionsPermission collections(CollectionsPermission.Action action, String collection) {
+  public static CollectionsPermission collections(CollectionsPermission.Action action, String collection) {
     return new CollectionsPermission(action, collection);
   }
 
-  static DataPermission data(DataPermission.Action action, String collection) {
+  public static DataPermission data(DataPermission.Action action, String collection) {
     return new DataPermission(action, collection);
   }
 
-  static NodesPermission nodes(NodesPermission.Action action, NodesPermission.Verbosity verbosity) {
+  public static NodesPermission nodes(NodesPermission.Action action, NodesPermission.Verbosity verbosity) {
     return new NodesPermission(action, verbosity);
   }
 
-  static NodesPermission nodes(NodesPermission.Action action, NodesPermission.Verbosity verbosity, String collection) {
+  public static NodesPermission nodes(NodesPermission.Action action, NodesPermission.Verbosity verbosity,
+      String collection) {
     return new NodesPermission(action, verbosity, collection);
   }
 
-  static RolesPermission roles(RolesPermission.Action action, String role) {
+  public static RolesPermission roles(RolesPermission.Action action, String role) {
     return new RolesPermission(action, role);
   }
 
-  static TenantsPermission tenants(TenantsPermission.Action action) {
+  public static TenantsPermission tenants(TenantsPermission.Action action) {
     return new TenantsPermission(action);
   }
 
-  static UsersPermission users(UsersPermission.Action action) {
-    return new UsersPermission(action);
-  }
+  // public static UsersPermission users(UsersPermission.Action action) {
+  // return new UsersPermission(action);
+  // }
 }
 
 interface CustomAction {

--- a/src/main/java/io/weaviate/client/v1/rbac/model/RbacAction.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/RbacAction.java
@@ -24,6 +24,19 @@ package io.weaviate.client.v1.rbac.model;
 interface RbacAction {
   String getValue();
 
+  /**
+   * Returns true if the action is hard deprecated.
+   *
+   * <p>
+   * Override default return for a deprecated enum value like so:
+   *
+   * <pre>{@code
+   * OLD_ACTION("old_action") {
+   *  &#64;Override
+   *  public boolean isDeprecated() { return true; }
+   * };
+   * }</pre>
+   */
   default boolean isDeprecated() {
     return false;
   }

--- a/src/main/java/io/weaviate/client/v1/rbac/model/RbacAction.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/RbacAction.java
@@ -1,0 +1,44 @@
+package io.weaviate.client.v1.rbac.model;
+
+/**
+ * RbacAction is a utility interface to allow retrieving concrete enum values
+ * from their underlying string representations.
+ *
+ * <p>
+ * Usage:
+ *
+ * <pre>
+ * enum MyAction implements RbacAction {
+ *   FOO("do_foo"),
+ *   BAR("do_bar");
+ *
+ *   @Getter
+ *   private String value;
+ * }
+ * </pre>
+ *
+ * <p>
+ * Then {@code MyAction.FOO} can be retrieved from "do_foo" using
+ * {@link #fromString}.
+ */
+interface RbacAction {
+  String getValue();
+
+  static <E extends Enum<E> & RbacAction> E fromString(Class<E> enumClass, String value) {
+    for (E action : enumClass.getEnumConstants()) {
+      if (action.getValue().equals(value)) {
+        return action;
+      }
+    }
+    throw new IllegalArgumentException("No enum constant for value: " + value);
+  }
+
+  static <A extends RbacAction> boolean isValid(Class<A> enumClass, String value) {
+    for (RbacAction action : enumClass.getEnumConstants()) {
+      if (action.getValue().equals(value)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/model/RbacAction.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/RbacAction.java
@@ -24,7 +24,8 @@ package io.weaviate.client.v1.rbac.model;
 interface RbacAction {
   String getValue();
 
-  static <E extends Enum<E> & RbacAction> E fromString(Class<E> enumClass, String value) {
+  static <E extends Enum<E> & RbacAction> E fromString(Class<E> enumClass, String value)
+      throws IllegalArgumentException {
     for (E action : enumClass.getEnumConstants()) {
       if (action.getValue().equals(value)) {
         return action;

--- a/src/main/java/io/weaviate/client/v1/rbac/model/RbacAction.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/RbacAction.java
@@ -24,6 +24,10 @@ package io.weaviate.client.v1.rbac.model;
 interface RbacAction {
   String getValue();
 
+  default boolean isDeprecated() {
+    return false;
+  }
+
   static <E extends Enum<E> & RbacAction> E fromString(Class<E> enumClass, String value)
       throws IllegalArgumentException {
     for (E action : enumClass.getEnumConstants()) {

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Role.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Role.java
@@ -1,15 +1,22 @@
 package io.weaviate.client.v1.rbac.model;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public class Role {
   public final String name;
-  public final List<Permission<?>> permissions;
+  public List<? extends Permission<?>> permissions = new ArrayList<>();
 
-  public Role(String name, Permission<?>... permissions) {
-    this.name = name;
-    this.permissions = Arrays.asList(permissions);
+  public String toString() {
+    return String.format(
+        "Role<name='%s', permissions=[%s]>",
+        this.name, permissions.isEmpty()
+            ? "none"
+            : String.join(", ", permissions.stream().map(Permission::getAction).toList()));
   }
-
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Role.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Role.java
@@ -2,6 +2,7 @@ package io.weaviate.client.v1.rbac.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -19,6 +20,7 @@ public class Role {
         "Role<name='%s', permissions=[%s]>",
         this.name, permissions.isEmpty()
             ? "none"
-            : String.join(", ", permissions.stream().map(Permission::getAction).toList()));
+            : String.join(", ", permissions.stream().map(Permission::getAction)
+                .collect(Collectors.toList())));
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Role.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Role.java
@@ -20,7 +20,7 @@ public class Role {
         "Role<name='%s', permissions=[%s]>",
         this.name, permissions.isEmpty()
             ? "none"
-            : String.join(", ", permissions.stream().map(Permission::getAction)
+            : String.join(",\n", permissions.stream().map(Permission::toString)
                 .collect(Collectors.toList())));
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Role.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Role.java
@@ -4,10 +4,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@EqualsAndHashCode
 public class Role {
   public final String name;
   public List<? extends Permission<?>> permissions = new ArrayList<>();

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Role.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Role.java
@@ -1,0 +1,15 @@
+package io.weaviate.client.v1.rbac.model;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class Role {
+  public final String name;
+  public final List<Permission<?>> permissions;
+
+  public Role(String name, Permission<?>... permissions) {
+    this.name = name;
+    this.permissions = Arrays.asList(permissions);
+  }
+
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
@@ -45,20 +45,15 @@ public class RolesPermission extends Permission<RolesPermission> {
      * and should only be used internally to read legacy permissions.
      */
     @Deprecated
-    MANAGE("manage_roles", true);
-
-    Action(String value) {
-      this(value, false);
-    }
+    MANAGE("manage_roles") {
+      @Override
+      public boolean isDeprecated() {
+        return true;
+      };
+    };
 
     @Getter
     private final String value;
-
-    private final boolean deprecated;
-
-    public boolean isDeprecated() {
-      return deprecated;
-    }
   }
 
   public enum Scope {

--- a/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
@@ -16,7 +16,7 @@ public class RolesPermission extends Permission<RolesPermission> {
   }
 
   RolesPermission(String role, String action) {
-    this(role, CustomAction.fromString(Action.class, action));
+    this(role, RbacAction.fromString(Action.class, action));
   }
 
   @Override
@@ -25,7 +25,7 @@ public class RolesPermission extends Permission<RolesPermission> {
   }
 
   @AllArgsConstructor
-  public enum Action implements CustomAction {
+  public enum Action implements RbacAction {
     READ("read_roles"),
     MANAGE("manage_roles");
 

--- a/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
@@ -45,10 +45,20 @@ public class RolesPermission extends Permission<RolesPermission> {
      * and should only be used internally to read legacy permissions.
      */
     @Deprecated
-    MANAGE("manage_roles");
+    MANAGE("manage_roles", true);
+
+    Action(String value) {
+      this(value, false);
+    }
 
     @Getter
     private final String value;
+
+    private final boolean deprecated;
+
+    public boolean isDeprecated() {
+      return deprecated;
+    }
   }
 
   public enum Scope {

--- a/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
@@ -1,5 +1,7 @@
 package io.weaviate.client.v1.rbac.model;
 
+import com.google.gson.annotations.SerializedName;
+
 import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -9,14 +11,20 @@ import lombok.Getter;
 @EqualsAndHashCode(callSuper = true)
 public class RolesPermission extends Permission<RolesPermission> {
   final String role;
+  final Scope scope;
 
   public RolesPermission(String role, Action action) {
-    super(action);
-    this.role = role;
+    this(role, null, action);
   }
 
-  RolesPermission(String role, String action) {
-    this(role, RbacAction.fromString(Action.class, action));
+  public RolesPermission(String role, Scope scope, Action action) {
+    super(action);
+    this.role = role;
+    this.scope = scope;
+  }
+
+  RolesPermission(String role, Scope scope, String action) {
+    this(role, scope, RbacAction.fromString(Action.class, action));
   }
 
   @Override
@@ -26,10 +34,23 @@ public class RolesPermission extends Permission<RolesPermission> {
 
   @AllArgsConstructor
   public enum Action implements RbacAction {
+    CREATE("create_roles"),
     READ("read_roles"),
+    UPDATE("update_roles"),
+    DELETE("delete_roles"),
+
+    /* Backward compatibility with 1.28. */
+    @Deprecated
     MANAGE("manage_roles");
 
     @Getter
     private final String value;
+  }
+
+  public enum Scope {
+    @SerializedName("all")
+    ALL,
+    @SerializedName("match")
+    MATCH;
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
@@ -4,6 +4,7 @@ import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@Getter
 public class RolesPermission implements Permission<RolesPermission> {
   final transient String action;
   final String role;
@@ -13,18 +14,17 @@ public class RolesPermission implements Permission<RolesPermission> {
     this.role = role;
   }
 
+  RolesPermission(String action, String role) {
+    this(CustomAction.fromString(Action.class, action), role);
+  }
+
   @Override
   public WeaviatePermission toWeaviate() {
     return new WeaviatePermission(this.action, this);
   }
 
-  @Override
-  public RolesPermission fromWeaviate(WeaviatePermission perm) {
-    return null;
-  }
-
   @AllArgsConstructor
-  public enum Action {
+  public enum Action implements CustomAction {
     READ("read_roles"),
     MANAGE("manage_roles");
 

--- a/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
@@ -10,13 +10,13 @@ import lombok.Getter;
 public class RolesPermission extends Permission<RolesPermission> {
   final String role;
 
-  public RolesPermission(Action action, String role) {
+  public RolesPermission(String role, Action action) {
     super(action);
     this.role = role;
   }
 
-  RolesPermission(String action, String role) {
-    this(CustomAction.fromString(Action.class, action), role);
+  RolesPermission(String role, String action) {
+    this(role, CustomAction.fromString(Action.class, action));
   }
 
   @Override

--- a/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
@@ -1,0 +1,34 @@
+package io.weaviate.client.v1.rbac.model;
+
+import io.weaviate.client.v1.rbac.api.WeaviatePermission;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class RolesPermission implements Permission<RolesPermission> {
+  final transient String action;
+  final String role;
+
+  public RolesPermission(Action action, String role) {
+    this.action = action.getValue();
+    this.role = role;
+  }
+
+  @Override
+  public WeaviatePermission toWeaviate() {
+    return new WeaviatePermission(this.action, this);
+  }
+
+  @Override
+  public RolesPermission fromWeaviate(WeaviatePermission perm) {
+    return null;
+  }
+
+  @AllArgsConstructor
+  public enum Action {
+    READ("read_roles"),
+    MANAGE("manage_roles");
+
+    @Getter
+    private final String value;
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
@@ -2,7 +2,6 @@ package io.weaviate.client.v1.rbac.model;
 
 import com.google.gson.annotations.SerializedName;
 
-import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -25,11 +24,6 @@ public class RolesPermission extends Permission<RolesPermission> {
 
   RolesPermission(String role, Scope scope, String action) {
     this(role, scope, RbacAction.fromString(Action.class, action));
-  }
-
-  @Override
-  public WeaviatePermission toWeaviate() {
-    return new WeaviatePermission(this.action, this);
   }
 
   @AllArgsConstructor

--- a/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
@@ -2,9 +2,11 @@ package io.weaviate.client.v1.rbac.model;
 
 import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
+@EqualsAndHashCode(callSuper = true)
 public class RolesPermission extends Permission<RolesPermission> {
   final String role;
 

--- a/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
@@ -39,7 +39,11 @@ public class RolesPermission extends Permission<RolesPermission> {
     UPDATE("update_roles"),
     DELETE("delete_roles"),
 
-    /* Backward compatibility with 1.28. */
+    /*
+     * DO NOT CREATE NEW PERMISSIONS WITH THIS ACTION.
+     * It is preserved for backward compatibility with 1.28
+     * and should only be used internally to read legacy permissions.
+     */
     @Deprecated
     MANAGE("manage_roles");
 

--- a/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
@@ -5,12 +5,11 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-public class RolesPermission implements Permission<RolesPermission> {
-  final transient String action;
+public class RolesPermission extends Permission<RolesPermission> {
   final String role;
 
   public RolesPermission(Action action, String role) {
-    this.action = action.getValue();
+    super(action);
     this.role = role;
   }
 

--- a/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/RolesPermission.java
@@ -12,12 +12,12 @@ public class RolesPermission extends Permission<RolesPermission> {
   final String role;
   final Scope scope;
 
-  public RolesPermission(String role, Action action) {
-    this(role, null, action);
+  public RolesPermission(String role, Action... actions) {
+    this(role, null, actions);
   }
 
-  public RolesPermission(String role, Scope scope, Action action) {
-    super(action);
+  public RolesPermission(String role, Scope scope, Action... actions) {
+    super(actions);
     this.role = role;
     this.scope = scope;
   }

--- a/src/main/java/io/weaviate/client/v1/rbac/model/TenantsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/TenantsPermission.java
@@ -13,6 +13,10 @@ public class TenantsPermission implements Permission<TenantsPermission> {
     this(action, "*");
   }
 
+  TenantsPermission(String action) {
+    this(CustomAction.fromString(Action.class, action));
+  }
+
   private TenantsPermission(Action action, String tenant) {
     this.action = action.getValue();
     this.tenant = tenant;
@@ -23,13 +27,8 @@ public class TenantsPermission implements Permission<TenantsPermission> {
     return new WeaviatePermission(this.action, this);
   }
 
-  @Override
-  public TenantsPermission fromWeaviate(WeaviatePermission perm) {
-    return null;
-  }
-
   @AllArgsConstructor
-  public enum Action {
+  public enum Action implements CustomAction {
     CREATE("create_tenants"),
     READ("read_tenants"),
     UPDATE("update_tenants"),

--- a/src/main/java/io/weaviate/client/v1/rbac/model/TenantsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/TenantsPermission.java
@@ -5,8 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-public class TenantsPermission implements Permission<TenantsPermission> {
-  final transient String action;
+public class TenantsPermission extends Permission<TenantsPermission> {
   final String tenant;
 
   public TenantsPermission(Action action) {
@@ -18,7 +17,7 @@ public class TenantsPermission implements Permission<TenantsPermission> {
   }
 
   private TenantsPermission(Action action, String tenant) {
-    this.action = action.getValue();
+    super(action);
     this.tenant = tenant;
   }
 

--- a/src/main/java/io/weaviate/client/v1/rbac/model/TenantsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/TenantsPermission.java
@@ -8,8 +8,8 @@ import lombok.Getter;
 @EqualsAndHashCode(callSuper = true)
 public class TenantsPermission extends Permission<TenantsPermission> {
 
-  public TenantsPermission(Action action) {
-    super(action);
+  public TenantsPermission(Action... actions) {
+    super(actions);
   }
 
   TenantsPermission(String action) {

--- a/src/main/java/io/weaviate/client/v1/rbac/model/TenantsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/TenantsPermission.java
@@ -1,0 +1,41 @@
+package io.weaviate.client.v1.rbac.model;
+
+import io.weaviate.client.v1.rbac.api.WeaviatePermission;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+public class TenantsPermission implements Permission<TenantsPermission> {
+  final transient String action;
+  final String tenant;
+
+  public TenantsPermission(Action action) {
+    this(action, "*");
+  }
+
+  private TenantsPermission(Action action, String tenant) {
+    this.action = action.getValue();
+    this.tenant = tenant;
+  }
+
+  @Override
+  public WeaviatePermission toWeaviate() {
+    return new WeaviatePermission(this.action, this);
+  }
+
+  @Override
+  public TenantsPermission fromWeaviate(WeaviatePermission perm) {
+    return null;
+  }
+
+  @AllArgsConstructor
+  public enum Action {
+    CREATE("create_tenants"),
+    READ("read_tenants"),
+    UPDATE("update_tenants"),
+    DELETE("delete_tenants");
+
+    @Getter
+    private final String value;
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/model/TenantsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/TenantsPermission.java
@@ -1,6 +1,5 @@
 package io.weaviate.client.v1.rbac.model;
 
-import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -15,11 +14,6 @@ public class TenantsPermission extends Permission<TenantsPermission> {
 
   TenantsPermission(String action) {
     this(RbacAction.fromString(Action.class, action));
-  }
-
-  @Override
-  public WeaviatePermission toWeaviate() {
-    return new WeaviatePermission(this.action, this);
   }
 
   @AllArgsConstructor

--- a/src/main/java/io/weaviate/client/v1/rbac/model/TenantsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/TenantsPermission.java
@@ -2,9 +2,11 @@ package io.weaviate.client.v1.rbac.model;
 
 import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
+@EqualsAndHashCode(callSuper = true)
 public class TenantsPermission extends Permission<TenantsPermission> {
   final String tenant;
 

--- a/src/main/java/io/weaviate/client/v1/rbac/model/TenantsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/TenantsPermission.java
@@ -15,7 +15,7 @@ public class TenantsPermission extends Permission<TenantsPermission> {
   }
 
   TenantsPermission(String action) {
-    this(CustomAction.fromString(Action.class, action));
+    this(RbacAction.fromString(Action.class, action));
   }
 
   private TenantsPermission(Action action, String tenant) {
@@ -29,7 +29,7 @@ public class TenantsPermission extends Permission<TenantsPermission> {
   }
 
   @AllArgsConstructor
-  public enum Action implements CustomAction {
+  public enum Action implements RbacAction {
     CREATE("create_tenants"),
     READ("read_tenants"),
     UPDATE("update_tenants"),

--- a/src/main/java/io/weaviate/client/v1/rbac/model/TenantsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/TenantsPermission.java
@@ -8,19 +8,13 @@ import lombok.Getter;
 @Getter
 @EqualsAndHashCode(callSuper = true)
 public class TenantsPermission extends Permission<TenantsPermission> {
-  final String tenant;
 
   public TenantsPermission(Action action) {
-    this(action, "*");
+    super(action);
   }
 
   TenantsPermission(String action) {
     this(RbacAction.fromString(Action.class, action));
-  }
-
-  private TenantsPermission(Action action, String tenant) {
-    super(action);
-    this.tenant = tenant;
   }
 
   @Override

--- a/src/main/java/io/weaviate/client/v1/rbac/model/UsersPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/UsersPermission.java
@@ -16,7 +16,7 @@ class UsersPermission extends Permission<UsersPermission> {
   }
 
   UsersPermission(String action) {
-    this(CustomAction.fromString(Action.class, action));
+    this(RbacAction.fromString(Action.class, action));
   }
 
   @Override
@@ -25,7 +25,7 @@ class UsersPermission extends Permission<UsersPermission> {
   }
 
   @AllArgsConstructor
-  public enum Action implements CustomAction {
+  public enum Action implements RbacAction {
     MANAGE("manage_users");
 
     @Getter

--- a/src/main/java/io/weaviate/client/v1/rbac/model/UsersPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/UsersPermission.java
@@ -5,8 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 public class UsersPermission extends Permission<UsersPermission> {
-  public UsersPermission(Action action) {
-    super(action);
+  public UsersPermission(Action... actions) {
+    super(actions);
   }
 
   UsersPermission(String action) {

--- a/src/main/java/io/weaviate/client/v1/rbac/model/UsersPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/UsersPermission.java
@@ -5,12 +5,7 @@ import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-/**
- * UsersPermission controls access to dynamic user management capabilities.
- * These will be introduced in v1.30. Until then the class will remain
- * package-private.
- */
-class UsersPermission extends Permission<UsersPermission> {
+public class UsersPermission extends Permission<UsersPermission> {
   public UsersPermission(Action action) {
     super(action);
   }
@@ -26,7 +21,8 @@ class UsersPermission extends Permission<UsersPermission> {
 
   @AllArgsConstructor
   public enum Action implements RbacAction {
-    MANAGE("manage_users");
+    READ("read_users"),
+    ASSIGN_AND_REVOKE("assign_and_revoke_users");
 
     @Getter
     private final String value;

--- a/src/main/java/io/weaviate/client/v1/rbac/model/UsersPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/UsersPermission.java
@@ -1,0 +1,32 @@
+
+package io.weaviate.client.v1.rbac.model;
+
+import io.weaviate.client.v1.rbac.api.WeaviatePermission;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class UsersPermission implements Permission<UsersPermission> {
+  final String action;
+
+  public UsersPermission(Action action) {
+    this.action = action.getValue();
+  }
+
+  @Override
+  public WeaviatePermission toWeaviate() {
+    return new WeaviatePermission(this.action);
+  }
+
+  @Override
+  public UsersPermission fromWeaviate(WeaviatePermission perm) {
+    return null;
+  }
+
+  @AllArgsConstructor
+  public enum Action {
+    MANAGE("manage_users");
+
+    @Getter
+    private final String value;
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/model/UsersPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/UsersPermission.java
@@ -5,11 +5,14 @@ import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-public class UsersPermission implements Permission<UsersPermission> {
-  final String action;
-
+/**
+ * UsersPermission controls access to dynamic user management capabilities.
+ * These will be introduced in v1.30. Until then the class will remain
+ * package-private.
+ */
+class UsersPermission extends Permission<UsersPermission> {
   public UsersPermission(Action action) {
-    this.action = action.getValue();
+    super(action);
   }
 
   UsersPermission(String action) {

--- a/src/main/java/io/weaviate/client/v1/rbac/model/UsersPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/UsersPermission.java
@@ -1,7 +1,6 @@
 
 package io.weaviate.client.v1.rbac.model;
 
-import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -12,11 +11,6 @@ public class UsersPermission extends Permission<UsersPermission> {
 
   UsersPermission(String action) {
     this(RbacAction.fromString(Action.class, action));
-  }
-
-  @Override
-  public WeaviatePermission toWeaviate() {
-    return new WeaviatePermission(this.action);
   }
 
   @AllArgsConstructor

--- a/src/main/java/io/weaviate/client/v1/rbac/model/UsersPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/UsersPermission.java
@@ -12,18 +12,17 @@ public class UsersPermission implements Permission<UsersPermission> {
     this.action = action.getValue();
   }
 
+  UsersPermission(String action) {
+    this(CustomAction.fromString(Action.class, action));
+  }
+
   @Override
   public WeaviatePermission toWeaviate() {
     return new WeaviatePermission(this.action);
   }
 
-  @Override
-  public UsersPermission fromWeaviate(WeaviatePermission perm) {
-    return null;
-  }
-
   @AllArgsConstructor
-  public enum Action {
+  public enum Action implements CustomAction {
     MANAGE("manage_users");
 
     @Getter

--- a/src/main/java/io/weaviate/client/v1/users/Users.java
+++ b/src/main/java/io/weaviate/client/v1/users/Users.java
@@ -1,0 +1,30 @@
+package io.weaviate.client.v1.users;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.users.api.RoleAssigner;
+import io.weaviate.client.v1.users.api.RoleRevoker;
+import io.weaviate.client.v1.users.api.UserRolesGetter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class Users {
+
+  private final HttpClient httpClient;
+  private final Config config;
+
+  /** Get roles assigned to a user. */
+  public UserRolesGetter userRolesGetter() {
+    return new UserRolesGetter(httpClient, config);
+  };
+
+  /** Assign a role to a user. Note that 'root' cannot be assigned. */
+  public RoleAssigner assigner() {
+    return new RoleAssigner(httpClient, config);
+  }
+
+  /** Revoke a role from a user. Note that 'root' cannot be revoked. */
+  public RoleRevoker revoker() {
+    return new RoleRevoker(httpClient, config);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/users/Users.java
+++ b/src/main/java/io/weaviate/client/v1/users/Users.java
@@ -2,6 +2,7 @@ package io.weaviate.client.v1.users;
 
 import io.weaviate.client.Config;
 import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.users.api.MyUserGetter;
 import io.weaviate.client.v1.users.api.RoleAssigner;
 import io.weaviate.client.v1.users.api.RoleRevoker;
 import io.weaviate.client.v1.users.api.UserRolesGetter;
@@ -12,6 +13,11 @@ public class Users {
 
   private final HttpClient httpClient;
   private final Config config;
+
+  /** Get information about the current user. */
+  public MyUserGetter myUserGetter() {
+    return new MyUserGetter(httpClient, config);
+  };
 
   /** Get roles assigned to a user. */
   public UserRolesGetter userRolesGetter() {

--- a/src/main/java/io/weaviate/client/v1/users/api/MyUserGetter.java
+++ b/src/main/java/io/weaviate/client/v1/users/api/MyUserGetter.java
@@ -1,0 +1,24 @@
+package io.weaviate.client.v1.users.api;
+
+import java.util.Optional;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Response;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.users.model.User;
+
+public class MyUserGetter extends BaseClient<WeaviateUser> implements ClientResult<User> {
+  public MyUserGetter(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  @Override
+  public Result<User> run() {
+    Response<WeaviateUser> resp = sendGetRequest("/users/own-info", WeaviateUser.class);
+    User user = Optional.ofNullable(resp.getBody()).map(WeaviateUser::toUser).orElse(null);
+    return new Result<>(resp.getStatusCode(), user, resp.getErrors());
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/users/api/RoleAssigner.java
+++ b/src/main/java/io/weaviate/client/v1/users/api/RoleAssigner.java
@@ -13,15 +13,15 @@ import io.weaviate.client.base.http.HttpClient;
 import lombok.AllArgsConstructor;
 
 public class RoleAssigner extends BaseClient<Void> implements ClientResult<Boolean> {
-  private String user;
+  private String userId;
   private List<String> roles = new ArrayList<>();
 
   public RoleAssigner(HttpClient httpClient, Config config) {
     super(httpClient, config);
   }
 
-  public RoleAssigner withUser(String user) {
-    this.user = user;
+  public RoleAssigner withUserId(String id) {
+    this.userId = id;
     return this;
   }
 
@@ -44,6 +44,6 @@ public class RoleAssigner extends BaseClient<Void> implements ClientResult<Boole
   }
 
   private String path() {
-    return String.format("/authz/users/%s/assign", this.user);
+    return String.format("/authz/users/%s/assign", this.userId);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/users/api/RoleAssigner.java
+++ b/src/main/java/io/weaviate/client/v1/users/api/RoleAssigner.java
@@ -1,32 +1,32 @@
-package io.weaviate.client.v1.rbac.api;
+package io.weaviate.client.v1.users.api;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import io.weaviate.client.Config;
 import io.weaviate.client.base.BaseClient;
 import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Response;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.base.http.HttpClient;
 import lombok.AllArgsConstructor;
 
-public class RoleRevoker extends BaseClient<Void> implements ClientResult<Boolean> {
+public class RoleAssigner extends BaseClient<Void> implements ClientResult<Boolean> {
   private String user;
   private List<String> roles = new ArrayList<>();
 
-  public RoleRevoker(HttpClient httpClient, Config config) {
+  public RoleAssigner(HttpClient httpClient, Config config) {
     super(httpClient, config);
   }
 
-  public RoleRevoker withUser(String user) {
+  public RoleAssigner withUser(String user) {
     this.user = user;
     return this;
   }
 
-  public RoleRevoker witRoles(String... roles) {
-    this.roles = Collections.unmodifiableList(Arrays.asList(roles));
+  public RoleAssigner witRoles(String... roles) {
+    this.roles = Arrays.asList(roles);
     return this;
   }
 
@@ -38,10 +38,12 @@ public class RoleRevoker extends BaseClient<Void> implements ClientResult<Boolea
 
   @Override
   public Result<Boolean> run() {
-    return Result.voidToBoolean(sendPostRequest(path(), new Body(this.roles), Void.class));
+    Response<Void> resp = sendPostRequest(path(), new Body(this.roles), Void.class);
+    int status = resp.getStatusCode();
+    return new Result<Boolean>(status, status == 200, resp.getErrors());
   }
 
   private String path() {
-    return String.format("/authz/users/%s/revoke", this.user);
+    return String.format("/authz/users/%s/assign", this.user);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/users/api/RoleRevoker.java
+++ b/src/main/java/io/weaviate/client/v1/users/api/RoleRevoker.java
@@ -1,32 +1,32 @@
-package io.weaviate.client.v1.rbac.api;
+package io.weaviate.client.v1.users.api;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import io.weaviate.client.Config;
 import io.weaviate.client.base.BaseClient;
 import io.weaviate.client.base.ClientResult;
-import io.weaviate.client.base.Response;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.base.http.HttpClient;
 import lombok.AllArgsConstructor;
 
-public class RoleAssigner extends BaseClient<Void> implements ClientResult<Boolean> {
+public class RoleRevoker extends BaseClient<Void> implements ClientResult<Boolean> {
   private String user;
   private List<String> roles = new ArrayList<>();
 
-  public RoleAssigner(HttpClient httpClient, Config config) {
+  public RoleRevoker(HttpClient httpClient, Config config) {
     super(httpClient, config);
   }
 
-  public RoleAssigner withUser(String user) {
+  public RoleRevoker withUser(String user) {
     this.user = user;
     return this;
   }
 
-  public RoleAssigner witRoles(String... roles) {
-    this.roles = Arrays.asList(roles);
+  public RoleRevoker witRoles(String... roles) {
+    this.roles = Collections.unmodifiableList(Arrays.asList(roles));
     return this;
   }
 
@@ -38,12 +38,10 @@ public class RoleAssigner extends BaseClient<Void> implements ClientResult<Boole
 
   @Override
   public Result<Boolean> run() {
-    Response<Void> resp = sendPostRequest(path(), new Body(this.roles), Void.class);
-    int status = resp.getStatusCode();
-    return new Result<Boolean>(status, status == 200, resp.getErrors());
+    return Result.voidToBoolean(sendPostRequest(path(), new Body(this.roles), Void.class));
   }
 
   private String path() {
-    return String.format("/authz/users/%s/assign", this.user);
+    return String.format("/authz/users/%s/revoke", this.user);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/users/api/RoleRevoker.java
+++ b/src/main/java/io/weaviate/client/v1/users/api/RoleRevoker.java
@@ -13,15 +13,15 @@ import io.weaviate.client.base.http.HttpClient;
 import lombok.AllArgsConstructor;
 
 public class RoleRevoker extends BaseClient<Void> implements ClientResult<Boolean> {
-  private String user;
+  private String userId;
   private List<String> roles = new ArrayList<>();
 
   public RoleRevoker(HttpClient httpClient, Config config) {
     super(httpClient, config);
   }
 
-  public RoleRevoker withUser(String user) {
-    this.user = user;
+  public RoleRevoker withUserId(String id) {
+    this.userId = id;
     return this;
   }
 
@@ -42,6 +42,6 @@ public class RoleRevoker extends BaseClient<Void> implements ClientResult<Boolea
   }
 
   private String path() {
-    return String.format("/authz/users/%s/revoke", this.user);
+    return String.format("/authz/users/%s/revoke", this.userId);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/users/api/UserRolesGetter.java
+++ b/src/main/java/io/weaviate/client/v1/users/api/UserRolesGetter.java
@@ -1,4 +1,4 @@
-package io.weaviate.client.v1.rbac.api;
+package io.weaviate.client.v1.users.api;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -11,6 +11,7 @@ import io.weaviate.client.base.ClientResult;
 import io.weaviate.client.base.Response;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.rbac.api.WeaviateRole;
 import io.weaviate.client.v1.rbac.model.Role;
 
 public class UserRolesGetter extends BaseClient<WeaviateRole[]> implements ClientResult<List<Role>> {
@@ -28,8 +29,7 @@ public class UserRolesGetter extends BaseClient<WeaviateRole[]> implements Clien
 
   @Override
   public Result<List<Role>> run() {
-    String path = this.user == null ? "/authz/users/own-roles" : this.path();
-    Response<WeaviateRole[]> resp = sendGetRequest(path, WeaviateRole[].class);
+    Response<WeaviateRole[]> resp = sendGetRequest(path(), WeaviateRole[].class);
     List<Role> roles = Optional.ofNullable(resp.getBody())
         .map(Arrays::asList)
         .orElse(new ArrayList<>())

--- a/src/main/java/io/weaviate/client/v1/users/api/UserRolesGetter.java
+++ b/src/main/java/io/weaviate/client/v1/users/api/UserRolesGetter.java
@@ -16,15 +16,15 @@ import io.weaviate.client.v1.rbac.api.WeaviateRole;
 import io.weaviate.client.v1.rbac.model.Role;
 
 public class UserRolesGetter extends BaseClient<WeaviateRole[]> implements ClientResult<List<Role>> {
-  private String user;
+  private String userId;
 
   public UserRolesGetter(HttpClient httpClient, Config config) {
     super(httpClient, config);
   }
 
   /** Leave unset to fetch roles assigned to the current user. */
-  public UserRolesGetter withUser(String user) {
-    this.user = user;
+  public UserRolesGetter withUserId(String id) {
+    this.userId = id;
     return this;
   }
 
@@ -41,6 +41,6 @@ public class UserRolesGetter extends BaseClient<WeaviateRole[]> implements Clien
   }
 
   private String path() {
-    return String.format("/authz/users/%s/roles", this.user);
+    return String.format("/authz/users/%s/roles", this.userId);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/users/api/UserRolesGetter.java
+++ b/src/main/java/io/weaviate/client/v1/users/api/UserRolesGetter.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import io.weaviate.client.Config;
 import io.weaviate.client.base.BaseClient;
@@ -35,7 +36,7 @@ public class UserRolesGetter extends BaseClient<WeaviateRole[]> implements Clien
         .orElse(new ArrayList<>())
         .stream()
         .map(w -> w.toRole())
-        .toList();
+        .collect(Collectors.toList());
     return new Result<>(resp.getStatusCode(), roles, resp.getErrors());
   }
 

--- a/src/main/java/io/weaviate/client/v1/users/api/WeaviateUser.java
+++ b/src/main/java/io/weaviate/client/v1/users/api/WeaviateUser.java
@@ -1,17 +1,26 @@
 package io.weaviate.client.v1.users.api;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import com.google.gson.annotations.SerializedName;
 
 import io.weaviate.client.v1.rbac.api.WeaviateRole;
 import io.weaviate.client.v1.users.model.User;
 
 public class WeaviateUser {
-  String name;
+  @SerializedName("username")
+  String username;
+
+  @SerializedName("user_id")
   String id;
-  List<WeaviateRole> roles;
+
+  @SerializedName("roles")
+  List<WeaviateRole> roles = new ArrayList<>();
 
   public User toUser() {
-    return new User(name, id, roles.stream().map(WeaviateRole::toRole).collect(Collectors.toList()));
+    return new User(id != null ? id : username,
+        roles.stream().map(WeaviateRole::toRole).collect(Collectors.toList()));
   }
 }

--- a/src/main/java/io/weaviate/client/v1/users/api/WeaviateUser.java
+++ b/src/main/java/io/weaviate/client/v1/users/api/WeaviateUser.java
@@ -1,6 +1,7 @@
 package io.weaviate.client.v1.users.api;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import io.weaviate.client.v1.rbac.api.WeaviateRole;
 import io.weaviate.client.v1.users.model.User;
@@ -11,6 +12,6 @@ public class WeaviateUser {
   List<WeaviateRole> roles;
 
   public User toUser() {
-    return new User(name, id, roles.stream().map(WeaviateRole::toRole).toList());
+    return new User(name, id, roles.stream().map(WeaviateRole::toRole).collect(Collectors.toList()));
   }
 }

--- a/src/main/java/io/weaviate/client/v1/users/api/WeaviateUser.java
+++ b/src/main/java/io/weaviate/client/v1/users/api/WeaviateUser.java
@@ -1,0 +1,16 @@
+package io.weaviate.client.v1.users.api;
+
+import java.util.List;
+
+import io.weaviate.client.v1.rbac.api.WeaviateRole;
+import io.weaviate.client.v1.users.model.User;
+
+public class WeaviateUser {
+  String name;
+  String id;
+  List<WeaviateRole> roles;
+
+  public User toUser() {
+    return new User(name, id, roles.stream().map(WeaviateRole::toRole).toList());
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/users/model/User.java
+++ b/src/main/java/io/weaviate/client/v1/users/model/User.java
@@ -1,0 +1,21 @@
+package io.weaviate.client.v1.users.model;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import io.weaviate.client.v1.rbac.model.Role;
+import lombok.Getter;
+
+@Getter
+public class User {
+  String name;
+  String userId;
+  Map<String, Role> roles;
+
+  public User(String name, String id, List<Role> roles) {
+    this.name = name;
+    this.userId = id;
+    this.roles = roles.stream().collect(Collectors.toMap(Role::getName, r -> r));
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/users/model/User.java
+++ b/src/main/java/io/weaviate/client/v1/users/model/User.java
@@ -1,5 +1,6 @@
 package io.weaviate.client.v1.users.model;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -9,12 +10,10 @@ import lombok.Getter;
 
 @Getter
 public class User {
-  String name;
   String userId;
-  Map<String, Role> roles;
+  Map<String, Role> roles = new HashMap<>();
 
-  public User(String name, String id, List<Role> roles) {
-    this.name = name;
+  public User(String id, List<Role> roles) {
     this.userId = id;
     this.roles = roles.stream().collect(Collectors.toMap(Role::getName, r -> r));
   }

--- a/src/test/java/io/weaviate/client/v1/rbac/api/WeaviatePermissionTest.java
+++ b/src/test/java/io/weaviate/client/v1/rbac/api/WeaviatePermissionTest.java
@@ -1,0 +1,101 @@
+package io.weaviate.client.v1.rbac.api;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import org.junit.Test;
+
+import io.weaviate.client.v1.rbac.model.BackupsPermission;
+import io.weaviate.client.v1.rbac.model.ClusterPermission;
+import io.weaviate.client.v1.rbac.model.CollectionsPermission;
+import io.weaviate.client.v1.rbac.model.DataPermission;
+import io.weaviate.client.v1.rbac.model.NodesPermission;
+import io.weaviate.client.v1.rbac.model.Permission;
+import io.weaviate.client.v1.rbac.model.Role;
+import io.weaviate.client.v1.rbac.model.RolesPermission;
+import io.weaviate.client.v1.rbac.model.TenantsPermission;
+import io.weaviate.client.v1.rbac.model.UsersPermission;
+
+public class WeaviatePermissionTest {
+  /**
+   * When serialized to the API request body, permissions must be "flattened",
+   * i.e. a single action per permission. When the response is deserialised,
+   * permissions with for the same resource should be grouped together.
+   */
+  @Test
+  public void testMergedPermissions() {
+    WeaviatePermission[] apiPermissions = {
+        // Manage Pizza backups
+        new WeaviatePermission("manage_backups", new BackupsPermission("Pizza")),
+
+        // Manage and read Pizza data
+        new WeaviatePermission("manage_data", new DataPermission("Pizza")),
+        new WeaviatePermission("read_data", new DataPermission("Pizza")),
+
+        // Update and delete Songs data
+        new WeaviatePermission("update_data", new DataPermission("Songs")),
+        new WeaviatePermission("delete_data", new DataPermission("Songs")),
+
+        // Read nodes with Pizza collection
+        new WeaviatePermission("read_nodes", new NodesPermission("Pizza")),
+
+        // Read nodes for any collection with verbosity="verbose"
+        new WeaviatePermission("read_nodes", new NodesPermission(NodesPermission.Verbosity.VERBOSE)),
+
+        // Read Reader role
+        new WeaviatePermission("read_roles", new RolesPermission("Reader")),
+
+        // Create and update CreatorUpdater role
+        new WeaviatePermission("create_roles", new RolesPermission("CreatorUpdater", RolesPermission.Scope.ALL)),
+        new WeaviatePermission("update_roles", new RolesPermission("CreatorUpdater", RolesPermission.Scope.ALL)),
+
+        // Delete and update Pizza collection definition
+        new WeaviatePermission("delete_collections", new CollectionsPermission("Pizza")),
+        new WeaviatePermission("update_collections", new CollectionsPermission("Pizza")),
+
+        // Read Songs collection definition
+        new WeaviatePermission("read_collections", new CollectionsPermission("Songs")),
+
+        // Read clusters
+        new WeaviatePermission("read_cluster", new ClusterPermission()),
+
+        // Create and update tenants
+        new WeaviatePermission("create_tenants", new TenantsPermission()),
+        new WeaviatePermission("update_tenants", new TenantsPermission()),
+
+        // Read and delete users
+        new WeaviatePermission("read_users", new UsersPermission()),
+        new WeaviatePermission("assign_and_revoke_users", new UsersPermission()),
+    };
+
+    Permission<?>[] libraryPermissions = {
+        new BackupsPermission("Pizza", BackupsPermission.Action.MANAGE),
+        new DataPermission("Pizza", DataPermission.Action.MANAGE, DataPermission.Action.READ),
+        new DataPermission("Songs", DataPermission.Action.UPDATE, DataPermission.Action.DELETE),
+        new NodesPermission("Pizza", NodesPermission.Action.READ),
+        new NodesPermission(NodesPermission.Verbosity.VERBOSE, NodesPermission.Action.READ),
+        new RolesPermission("Reader", RolesPermission.Action.READ),
+        new RolesPermission("CreatorUpdater", RolesPermission.Scope.ALL,
+            RolesPermission.Action.CREATE, RolesPermission.Action.UPDATE),
+        new CollectionsPermission("Pizza", CollectionsPermission.Action.DELETE, CollectionsPermission.Action.UPDATE),
+        new CollectionsPermission("Songs", CollectionsPermission.Action.READ),
+        new ClusterPermission(ClusterPermission.Action.READ),
+        new TenantsPermission(TenantsPermission.Action.CREATE, TenantsPermission.Action.UPDATE),
+        new UsersPermission(UsersPermission.Action.READ, UsersPermission.Action.ASSIGN_AND_REVOKE),
+    };
+
+    // {
+    // WeaviateRole role = new WeaviateRole("TestRole",
+    // Arrays.asList(libraryPermissions));
+    // WeaviatePermission[] got = role.getPermissions().toArray(new
+    // WeaviatePermission[] {});
+    // assertArrayEquals(apiPermissions, got, "lib -> api conversion");
+    // }
+
+    {
+      WeaviateRole role = new WeaviateRole("TestRole", apiPermissions);
+      Role libRole = role.toRole();
+      Permission<?>[] got = libRole.permissions.toArray(new Permission<?>[] {});
+      assertArrayEquals(libraryPermissions, got, "api -> lib conversion");
+    }
+  }
+}

--- a/src/test/java/io/weaviate/client/v1/rbac/api/WeaviatePermissionTest.java
+++ b/src/test/java/io/weaviate/client/v1/rbac/api/WeaviatePermissionTest.java
@@ -2,6 +2,8 @@ package io.weaviate.client.v1.rbac.api;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
+import java.util.Arrays;
+
 import org.junit.Test;
 
 import io.weaviate.client.v1.rbac.model.BackupsPermission;
@@ -83,13 +85,12 @@ public class WeaviatePermissionTest {
         new UsersPermission(UsersPermission.Action.READ, UsersPermission.Action.ASSIGN_AND_REVOKE),
     };
 
-    // {
-    // WeaviateRole role = new WeaviateRole("TestRole",
-    // Arrays.asList(libraryPermissions));
-    // WeaviatePermission[] got = role.getPermissions().toArray(new
-    // WeaviatePermission[] {});
-    // assertArrayEquals(apiPermissions, got, "lib -> api conversion");
-    // }
+    {
+      WeaviateRole role = new WeaviateRole("TestRole",
+          Arrays.asList(libraryPermissions));
+      WeaviatePermission[] got = role.getPermissions().toArray(new WeaviatePermission[] {});
+      assertArrayEquals(apiPermissions, got, "lib -> api conversion");
+    }
 
     {
       WeaviateRole role = new WeaviateRole("TestRole", apiPermissions);

--- a/src/test/java/io/weaviate/client/v1/rbac/model/PermissionTest.java
+++ b/src/test/java/io/weaviate/client/v1/rbac/model/PermissionTest.java
@@ -1,10 +1,8 @@
 package io.weaviate.client.v1.rbac.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.junit.Test;
@@ -13,7 +11,6 @@ import org.testcontainers.shaded.org.hamcrest.Matcher;
 import org.testcontainers.shaded.org.hamcrest.MatcherAssert;
 import org.testcontainers.shaded.org.hamcrest.beans.SamePropertyValuesAs;
 
-import com.google.gson.Gson;
 import com.jparams.junit4.JParamsTestRunner;
 import com.jparams.junit4.data.DataMethod;
 
@@ -28,7 +25,7 @@ public class PermissionTest {
     DataPermission data = new DataPermission(DataPermission.Action.MANAGE, "Pizza");
     NodesPermission nodes = new NodesPermission(NodesPermission.Action.READ, Verbosity.MINIMAL, "Pizza");
     RolesPermission roles = new RolesPermission(RolesPermission.Action.MANAGE, "TestWriter");
-    CollectionsPermission collections = new CollectionsPermission(CollectionsPermission.Action.MANAGE, "Pizza");
+    CollectionsPermission collections = new CollectionsPermission(CollectionsPermission.Action.CREATE, "Pizza");
     ClusterPermission cluster = new ClusterPermission(ClusterPermission.Action.READ);
     TenantsPermission tenants = new TenantsPermission(TenantsPermission.Action.READ);
 
@@ -98,7 +95,7 @@ public class PermissionTest {
 
   @Test
   public void testDefaultCollectionsPermission() {
-    CollectionsPermission perm = new CollectionsPermission(CollectionsPermission.Action.MANAGE, "Pizza");
+    CollectionsPermission perm = new CollectionsPermission(CollectionsPermission.Action.CREATE, "Pizza");
     assertThat(perm).as("collection permission must have tenant=*")
         .returns("*", CollectionsPermission::getTenant);
   }

--- a/src/test/java/io/weaviate/client/v1/rbac/model/PermissionTest.java
+++ b/src/test/java/io/weaviate/client/v1/rbac/model/PermissionTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.function.Supplier;
 
 import org.junit.Test;
@@ -17,6 +16,7 @@ import org.testcontainers.shaded.org.hamcrest.beans.SamePropertyValuesAs;
 
 import com.jparams.junit4.JParamsTestRunner;
 import com.jparams.junit4.data.DataMethod;
+import com.jparams.junit4.description.Name;
 
 import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 
@@ -71,17 +71,18 @@ public class PermissionTest {
         {
             "users permission",
             (Supplier<Permission<?>>) () -> users,
-            new WeaviatePermission("read_users"),
+            new WeaviatePermission("read_users", users),
         },
     };
   }
 
   @DataMethod(source = PermissionTest.class, method = "serializationTestCases")
+  @Name("{0}")
   @Test
-  public void testToWeaviate(String name, Supplier<Permission<?>> permFunc, WeaviatePermission expected)
+  public void testFirstToWeaviate(String name, Supplier<Permission<?>> permFunc, WeaviatePermission expected)
       throws Exception {
     Permission<?> perm = permFunc.get();
-    MatcherAssert.assertThat(name, perm.toWeaviate(), sameAs(expected));
+    MatcherAssert.assertThat(name, perm.firstToWeaviate(), sameAs(expected));
   }
 
   private static <T> Matcher<T> sameAs(T expected) {
@@ -103,6 +104,7 @@ public class PermissionTest {
   }
 
   @DataMethod(source = PermissionTest.class, method = "serializationTestCases")
+  @Name("{0}")
   @Test
   public void testFromWeaviate(String name,
       Supplier<Permission<?>> expectedFunc, WeaviatePermission input)
@@ -156,9 +158,10 @@ public class PermissionTest {
   }
 
   @DataMethod(source = PermissionTest.class, method = "groupedConstructors")
+  @Name("{0}")
   @Test
-  public void testGroupedConstructors(Permission<? extends Permission<?>>[] permissions, String[] expectedActions) {
-    Object[] actualActions = Arrays.stream(permissions).map(Permission::getAction).toArray();
+  public void testGroupedConstructors(Permission<? extends Permission<?>> permission, String[] expectedActions) {
+    Object[] actualActions = permission.getActions().toArray();
     assertArrayEquals(expectedActions, actualActions, "set of allowed actions do not match");
   }
 

--- a/src/test/java/io/weaviate/client/v1/rbac/model/PermissionTest.java
+++ b/src/test/java/io/weaviate/client/v1/rbac/model/PermissionTest.java
@@ -58,7 +58,7 @@ public class PermissionTest {
         {
             "collections permission",
             (Supplier<Permission<?>>) () -> collections,
-            new WeaviatePermission("manage_collections", collections),
+            new WeaviatePermission("create_collections", collections),
         },
         {
             "cluster permission",

--- a/src/test/java/io/weaviate/client/v1/rbac/model/PermissionTest.java
+++ b/src/test/java/io/weaviate/client/v1/rbac/model/PermissionTest.java
@@ -89,21 +89,6 @@ public class PermissionTest {
   }
 
   @Test
-  public void testDefaultDataPermission() {
-    DataPermission perm = new DataPermission("Pizza", DataPermission.Action.MANAGE);
-    assertThat(perm).as("data permission must have object=* and tenant=*")
-        .returns("*", DataPermission::getObject)
-        .returns("*", DataPermission::getTenant);
-  }
-
-  @Test
-  public void testDefaultCollectionsPermission() {
-    CollectionsPermission perm = new CollectionsPermission("Pizza", CollectionsPermission.Action.CREATE);
-    assertThat(perm).as("collection permission must have tenant=*")
-        .returns("*", CollectionsPermission::getTenant);
-  }
-
-  @Test
   public void testDefaultNodesPermission() {
     NodesPermission perm = new NodesPermission(NodesPermission.Verbosity.MINIMAL, NodesPermission.Action.READ);
     assertThat(perm).as("nodes permission should affect all collections if one is not specified")
@@ -111,16 +96,9 @@ public class PermissionTest {
   }
 
   @Test
-  public void testDefaultTenantsPermission() {
-    TenantsPermission perm = new TenantsPermission(TenantsPermission.Action.READ);
-    assertThat(perm).as("tenants permission must have tenant=*")
-        .returns("*", TenantsPermission::getTenant);
-  }
-
-  @Test
   public void testDefaultRolesPermission() {
     RolesPermission perm = new RolesPermission("ExampleRole", RolesPermission.Action.READ);
-    assertThat(perm).as("tenants permission must have scope=null")
+    assertThat(perm).as("roles permission must have scope=null")
         .returns(null, RolesPermission::getScope);
   }
 

--- a/src/test/java/io/weaviate/client/v1/users/api/WeaviateUserTest.java
+++ b/src/test/java/io/weaviate/client/v1/users/api/WeaviateUserTest.java
@@ -1,0 +1,46 @@
+package io.weaviate.client.v1.users.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.jparams.junit4.JParamsTestRunner;
+import com.jparams.junit4.data.DataMethod;
+
+import io.weaviate.client.base.Serializer;
+import io.weaviate.client.v1.users.model.User;
+
+@RunWith(JParamsTestRunner.class)
+public class WeaviateUserTest {
+  private final Serializer ser = new Serializer();
+
+  public static Object[][] deserializationTestCases() {
+    return new Object[][] {
+        {
+            "has username, no user_id",
+            "{\"username\": \"John Doe\"}",
+            new User("John Doe", new ArrayList<>()),
+        },
+        {
+            "has user_id, no username",
+            "{\"user_id\": \"john_doe\"}",
+            new User("john_doe", new ArrayList<>()),
+        },
+        {
+            "has both user_id and username",
+            "{\"user_id\": \"john_doe\", \"username\": \"John Doe\"}",
+            new User("john_doe", new ArrayList<>()),
+        },
+    };
+  }
+
+  @DataMethod(source = WeaviateUserTest.class, method = "deserializationTestCases")
+  @Test
+  public void testToUser(String name, String json, User want) {
+    User got = ser.toResponse(json, WeaviateUser.class).toUser();
+    assertEquals(want.getUserId(), got.getUserId(), "user id");
+  }
+}

--- a/src/test/java/io/weaviate/integration/client/WeaviateDockerCompose.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateDockerCompose.java
@@ -2,6 +2,7 @@ package io.weaviate.integration.client;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -84,7 +85,6 @@ public class WeaviateDockerCompose implements TestRule {
       withEnv("AUTHORIZATION_RBAC_ENABLED", "true");
       withEnv("AUTHENTICATION_APIKEY_USERS", adminUser);
       withEnv("AUTHENTICATION_APIKEY_ALLOWED_KEYS", makeSecret(adminUser));
-      withEnv("AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED", "false");
       withEnv("AUTHORIZATION_ADMIN_USERS", adminUser);
     }
 

--- a/src/test/java/io/weaviate/integration/client/WeaviateDockerCompose.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateDockerCompose.java
@@ -13,32 +13,40 @@ import org.testcontainers.weaviate.WeaviateContainer;
 
 public class WeaviateDockerCompose implements TestRule {
 
+  /** Weaviate Docker image to create a container from. */
   private final String weaviateVersion;
   private final boolean withOffloadS3;
-  private final boolean localServer;
+
+  /** Username of the admin user for instances using RBAC. */
+  private final String adminUser;
 
   public WeaviateDockerCompose() {
     this.weaviateVersion = WeaviateDockerImage.WEAVIATE_DOCKER_IMAGE;
     this.withOffloadS3 = false;
-    this.localServer = false;
-  }
-
-  public WeaviateDockerCompose(boolean localServer) {
-    this.weaviateVersion = WeaviateDockerImage.WEAVIATE_DOCKER_IMAGE;
-    this.withOffloadS3 = false;
-    this.localServer = localServer;
+    this.adminUser = null;
   }
 
   public WeaviateDockerCompose(String version) {
     this.weaviateVersion = String.format("semitechnologies/weaviate:%s", version);
     this.withOffloadS3 = false;
-    this.localServer = false;
+    this.adminUser = null;
   }
 
   public WeaviateDockerCompose(String version, boolean withOffloadS3) {
     this.weaviateVersion = String.format("semitechnologies/weaviate:%s", version);
     this.withOffloadS3 = withOffloadS3;
-    this.localServer = false;
+    this.adminUser = null;
+  }
+
+  public WeaviateDockerCompose(String version, String adminUser) {
+    this.weaviateVersion = WeaviateDockerImage.WEAVIATE_DOCKER_IMAGE;
+    this.withOffloadS3 = false;
+    this.adminUser = adminUser;
+  }
+
+  /** Create docker-compose deployment with auth and RBAC-authz enabled. */
+  public static WeaviateDockerCompose rbac(String adminUser) {
+    return new WeaviateDockerCompose(WeaviateDockerImage.WEAVIATE_DOCKER_IMAGE, adminUser);
   }
 
   public static class Weaviate extends WeaviateContainer {
@@ -66,6 +74,28 @@ public class WeaviateDockerCompose implements TestRule {
       withEnv("PERSISTENCE_FLUSH_IDLE_MEMTABLES_AFTER", "1");
       withEnv("ENABLE_MODULES", String.join(",", enableModules));
       withCreateContainerCmdModifier(cmd -> cmd.withHostName("weaviate"));
+    }
+
+    /** Create Weaviate container with RBAC authz and an admin user. */
+    public Weaviate(String dockerImageName, boolean withOffloadS3, String adminUser) {
+      this(dockerImageName, withOffloadS3);
+      withEnv("AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED", "false");
+      withEnv("AUTHENTICATION_APIKEY_ENABLED", "true");
+      withEnv("AUTHORIZATION_RBAC_ENABLED", "true");
+      withEnv("AUTHENTICATION_APIKEY_USERS", adminUser);
+      withEnv("AUTHENTICATION_APIKEY_ALLOWED_KEYS", makeSecret(adminUser));
+      withEnv("AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED", "false");
+      withEnv("AUTHORIZATION_ADMIN_USERS", adminUser);
+    }
+
+    /**
+     * Generate API secret for a username. When running an instance with
+     * authentication enabled, {@link Weaviate} will use this method to generate
+     * secrets for all users.
+     * Use this method to get a valid API key for a test client.
+     */
+    public static String makeSecret(String user) {
+      return user + "-secret";
     }
   }
 
@@ -108,30 +138,24 @@ public class WeaviateDockerCompose implements TestRule {
     }
     contextionary = new Contextionary();
     contextionary.start();
-    weaviate = new Weaviate(this.weaviateVersion, withOffloadS3);
-    if (!localServer) {
-      weaviate.start();
+    if (adminUser == null) {
+      weaviate = new Weaviate(this.weaviateVersion, this.withOffloadS3);
+    } else {
+      weaviate = new Weaviate(this.weaviateVersion, this.withOffloadS3, this.adminUser);
     }
+    weaviate.start();
   }
 
   public String getHttpHostAddress() {
-    if (localServer) {
-      return "127.0.0.1:8080";
-    }
     return weaviate.getHttpHostAddress();
   }
 
   public String getGrpcHostAddress() {
-    if (localServer) {
-      return "127.0.0.1:50051";
-    }
     return weaviate.getGrpcHostAddress();
   }
 
   public void stop() {
-    if (!localServer) {
-      weaviate.stop();
-    }
+    weaviate.stop();
     contextionary.stop();
     if (withOffloadS3) {
       minio.stop();

--- a/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
@@ -3,12 +3,12 @@ package io.weaviate.integration.client;
 public class WeaviateVersion {
 
   // docker image version
-  public static final String WEAVIATE_IMAGE = "1.27.7-8f0e033";
+  public static final String WEAVIATE_IMAGE = "1.28.3-f73fcee";
 
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_VERSION = "1.27.7";
+  public static final String EXPECTED_WEAVIATE_VERSION = "1.28.3-f73fcee";
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_GIT_HASH = "8f0e033";
+  public static final String EXPECTED_WEAVIATE_GIT_HASH = "34bb9ae";
 
   private WeaviateVersion() {
   }

--- a/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
@@ -3,12 +3,12 @@ package io.weaviate.integration.client;
 public class WeaviateVersion {
 
   // docker image version
-  public static final String WEAVIATE_IMAGE = "1.28.3-f73fcee";
+  public static final String WEAVIATE_IMAGE = "1.28.6-660c1fa";
 
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_VERSION = "1.28.3";
+  public static final String EXPECTED_WEAVIATE_VERSION = "1.28.6";
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_GIT_HASH = "f73fcee";
+  public static final String EXPECTED_WEAVIATE_GIT_HASH = "660c1fa";
 
   private WeaviateVersion() {
   }

--- a/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
@@ -8,7 +8,7 @@ public class WeaviateVersion {
   // to be set according to weaviate docker image
   public static final String EXPECTED_WEAVIATE_VERSION = "1.28.3";
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_GIT_HASH = "34bb9ae";
+  public static final String EXPECTED_WEAVIATE_GIT_HASH = "f73fcee";
 
   private WeaviateVersion() {
   }

--- a/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
@@ -8,7 +8,7 @@ public class WeaviateVersion {
   // to be set according to weaviate docker image
   public static final String EXPECTED_WEAVIATE_VERSION = "1.29.0";
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_GIT_HASH = "8f0e033";
+  public static final String EXPECTED_WEAVIATE_GIT_HASH = "35d800d";
 
   private WeaviateVersion() {
   }

--- a/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
@@ -6,7 +6,7 @@ public class WeaviateVersion {
   public static final String WEAVIATE_IMAGE = "1.28.3-f73fcee";
 
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_VERSION = "1.28.3-f73fcee";
+  public static final String EXPECTED_WEAVIATE_VERSION = "1.28.3";
   // to be set according to weaviate docker image
   public static final String EXPECTED_WEAVIATE_GIT_HASH = "34bb9ae";
 

--- a/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
@@ -3,12 +3,12 @@ package io.weaviate.integration.client;
 public class WeaviateVersion {
 
   // docker image version
-  public static final String WEAVIATE_IMAGE = "1.28.6-660c1fa";
+  public static final String WEAVIATE_IMAGE = "1.29.0";
 
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_VERSION = "1.28.6";
+  public static final String EXPECTED_WEAVIATE_VERSION = "1.29.0";
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_GIT_HASH = "660c1fa";
+  public static final String EXPECTED_WEAVIATE_GIT_HASH = "8f0e033";
 
   private WeaviateVersion() {
   }

--- a/src/test/java/io/weaviate/integration/client/WeaviateWithRbacContainer.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateWithRbacContainer.java
@@ -1,0 +1,36 @@
+package io.weaviate.integration.client;
+
+import org.testcontainers.weaviate.WeaviateContainer;
+
+public class WeaviateWithRbacContainer extends WeaviateContainer {
+
+  public WeaviateWithRbacContainer(String dockerImageName, String admin, String... viewers) {
+    super(dockerImageName);
+
+    withEnv("AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED", "false");
+    withEnv("AUTHENTICATION_APIKEY_ENABLED", "true");
+    withEnv("AUTHORIZATION_RBAC_ENABLED", "true");
+    withEnv("AUTHENTICATION_APIKEY_ALLOWED_KEYS", makeSecret(admin));
+    withEnv("AUTHENTICATION_APIKEY_USERS", admin);
+    withEnv("AUTHORIZATION_ADMIN_USERS", admin);
+    withEnv("PERSISTENCE_DATA_PATH", "./data");
+    withEnv("BACKUP_FILESYSTEM_PATH", "/tmp/backups");
+    withEnv("ENABLE_MODULES", "backup-filesystem");
+    withEnv("CLUSTER_GOSSIP_BIND_PORT", "7100");
+    withEnv("CLUSTER_DATA_BIND_PORT", "7101");
+
+    if (viewers.length > 0) {
+      withEnv("AUTHORIZATION_VIEWER_USERS", String.join(",", viewers));
+    }
+  }
+
+  /**
+   * Generate API secret for a username. When running an instance with
+   * authentication enabled, {@link WeaviateWithRbacContainer} will use this
+   * method to generate secrets for all users.
+   * Use this method to get a valid API key for a test client.
+   */
+  public static String makeSecret(String user) {
+    return user + "-secret";
+  }
+}

--- a/src/test/java/io/weaviate/integration/client/async/rbac/ClientRbacTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/rbac/ClientRbacTest.java
@@ -2,6 +2,7 @@ package io.weaviate.integration.client.async.rbac;
 
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
 
 import io.weaviate.client.Config;
 import io.weaviate.client.WeaviateAuthClient;
@@ -11,6 +12,7 @@ import io.weaviate.client.v1.auth.exception.AuthException;
 import io.weaviate.client.v1.rbac.model.Permission;
 import io.weaviate.client.v1.rbac.model.Role;
 import io.weaviate.integration.tests.rbac.ClientRbacTestSuite;
+import io.weaviate.integration.tests.users.ClientUsersTestSuite;
 
 /**
  * ClientRbacTest is a {@link ClientRbacTestSuite.Rbac} implementation and a
@@ -29,13 +31,14 @@ public class ClientRbacTest implements ClientRbacTestSuite.Rbac {
   }
 
   /**
-   * Rethrow any exception as a RuntimeException to allow calling AsyncClient
-   * methods without clashing with {@link ClientRbacTestSuite.Rbac} method
-   * signatures.
+   * Get Future result and rethrow any exception as a RuntimeException
+   * to allow calling AsyncClient methods without clashing with
+   * {@link ClientRbacTestSuite.Rbac} and {@link ClientUsersTestSuite.Users}
+   * method signatures.
    */
-  protected <T> T rethrow(Callable<T> c) {
+  protected <T> T rethrow(Callable<Future<T>> c) {
     try {
-      return c.call();
+      return c.call().get();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -43,61 +46,61 @@ public class ClientRbacTest implements ClientRbacTestSuite.Rbac {
 
   @Override
   public Result<Role> getRole(String role) {
-    return rethrow(() -> roles.getter().withName(role).run().get());
+    return rethrow(() -> roles.getter().withName(role).run());
   }
 
   @Override
   public Result<List<Role>> getAll() {
-    return rethrow(() -> roles.allGetter().run().get());
+    return rethrow(() -> roles.allGetter().run());
   }
 
   @Override
   public Result<List<String>> getAssignedUsers(String role) {
-    return rethrow(() -> roles.assignedUsersGetter().withRole(role).run().get());
+    return rethrow(() -> roles.assignedUsersGetter().withRole(role).run());
   }
 
   @Override
   public void createRole(String role, Permission<?>... permissions) {
-    rethrow(() -> roles.creator().withName(role).withPermissions(permissions).run().get());
+    rethrow(() -> roles.creator().withName(role).withPermissions(permissions).run());
   }
 
   @Override
   public void createRole(String role, Permission<?>[]... permissions) {
-    rethrow(() -> roles.creator().withName(role).withPermissions(permissions).run().get());
+    rethrow(() -> roles.creator().withName(role).withPermissions(permissions).run());
   }
 
   @Override
   public void deleteRole(String role) {
-    rethrow(() -> roles.deleter().withName(role).run().get());
+    rethrow(() -> roles.deleter().withName(role).run());
   }
 
   @Override
   public Result<Boolean> hasPermission(String role, Permission<?> perm) {
-    return rethrow(() -> roles.permissionChecker().withRole(role).withPermission(perm).run().get());
+    return rethrow(() -> roles.permissionChecker().withRole(role).withPermission(perm).run());
   }
 
   @Override
   public Result<Boolean> exists(String role) {
-    return rethrow(() -> roles.exists().withName(role).run().get());
+    return rethrow(() -> roles.exists().withName(role).run());
   }
 
   @Override
   public Result<?> addPermissions(String role, Permission<?>... permissions) {
-    return rethrow(() -> roles.permissionAdder().withRole(role).withPermissions(permissions).run().get());
+    return rethrow(() -> roles.permissionAdder().withRole(role).withPermissions(permissions).run());
   }
 
   @Override
   public Result<?> addPermissions(String role, Permission<?>[]... permissions) {
-    return rethrow(() -> roles.permissionAdder().withRole(role).withPermissions(permissions).run().get());
+    return rethrow(() -> roles.permissionAdder().withRole(role).withPermissions(permissions).run());
   }
 
   @Override
   public Result<?> removePermissions(String role, Permission<?>... permissions) {
-    return rethrow(() -> roles.permissionRemover().withRole(role).withPermissions(permissions).run().get());
+    return rethrow(() -> roles.permissionRemover().withRole(role).withPermissions(permissions).run());
   }
 
   @Override
   public Result<?> removePermissions(String role, Permission<?>[]... permissions) {
-    return rethrow(() -> roles.permissionRemover().withRole(role).withPermissions(permissions).run().get());
+    return rethrow(() -> roles.permissionRemover().withRole(role).withPermissions(permissions).run());
   }
 }

--- a/src/test/java/io/weaviate/integration/client/async/rbac/ClientRbacTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/rbac/ClientRbacTest.java
@@ -60,13 +60,13 @@ public class ClientRbacTest implements ClientRbacTestSuite.Rbac {
   }
 
   @Override
-  public void createRole(String role, Permission<?>... permissions) {
-    rethrow(() -> roles.creator().withName(role).withPermissions(permissions).run());
+  public Result<Boolean> createRole(String role, Permission<?>... permissions) {
+    return rethrow(() -> roles.creator().withName(role).withPermissions(permissions).run());
   }
 
   @Override
-  public void createRole(String role, Permission<?>[]... permissions) {
-    rethrow(() -> roles.creator().withName(role).withPermissions(permissions).run());
+  public Result<Boolean> createRole(String role, Permission<?>[]... permissions) {
+    return rethrow(() -> roles.creator().withName(role).withPermissions(permissions).run());
   }
 
   @Override

--- a/src/test/java/io/weaviate/integration/client/async/rbac/ClientRbacTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/rbac/ClientRbacTest.java
@@ -1,0 +1,108 @@
+package io.weaviate.integration.client.async.rbac;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.WeaviateAuthClient;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.async.rbac.Roles;
+import io.weaviate.client.v1.auth.exception.AuthException;
+import io.weaviate.client.v1.rbac.model.Permission;
+import io.weaviate.client.v1.rbac.model.Role;
+import io.weaviate.integration.tests.rbac.ClientRbacTestSuite;
+
+/**
+ * ClientRbacTest is a {@link ClientRbacTestSuite.Rbac} implementation and a
+ * wrapper around WeaviateAsyncClient.Roles client which allows the latter to
+ * be used in the ClientRbacTestSuite.
+ */
+public class ClientRbacTest implements ClientRbacTestSuite.Rbac {
+  private Roles roles;
+
+  public ClientRbacTest(Config config, String apiKey) {
+    try {
+      this.roles = WeaviateAuthClient.apiKey(config, apiKey).async().roles();
+    } catch (AuthException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Rethrow any exception as a RuntimeException to allow calling AsyncClient
+   * methods without clashing with {@link ClientRbacTestSuite.Rbac} method
+   * signatures.
+   */
+  private <T> T rethrow(Callable<T> c) {
+    try {
+      return c.call();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public Result<Role> getRole(String role) {
+    return rethrow(() -> roles.getter().withName(role).run().get());
+  }
+
+  @Override
+  public Result<List<Role>> getAll() {
+    return rethrow(() -> roles.allGetter().run().get());
+  }
+
+  @Override
+  public Result<List<Role>> getUserRoles() {
+    return rethrow(() -> roles.userRolesGetter().run().get());
+  }
+
+  @Override
+  public Result<List<Role>> getUserRoles(String user) {
+    return rethrow(() -> roles.userRolesGetter().withUser(user).run().get());
+  }
+
+  @Override
+  public Result<List<String>> getAssignedUsers(String role) {
+    return rethrow(() -> roles.assignedUsersGetter().withRole(role).run().get());
+  }
+
+  @Override
+  public void createRole(String role, Permission<?>... permissions) {
+    rethrow(() -> roles.creator().withName(role).withPermissions(permissions).run().get());
+  }
+
+  @Override
+  public void deleteRole(String role) {
+    rethrow(() -> roles.deleter().withName(role).run().get());
+  }
+
+  @Override
+  public Result<Boolean> hasPermission(String role, Permission<?> perm) {
+    return rethrow(() -> roles.permissionChecker().withRole(role).withPermission(perm).run().get());
+  }
+
+  @Override
+  public Result<Boolean> exists(String role) {
+    return rethrow(() -> roles.exists().withName(role).run().get());
+  }
+
+  @Override
+  public Result<?> addPermissions(String role, Permission<?>... permissions) {
+    return rethrow(() -> roles.permissionAdder().withRole(role).withPermissions(permissions).run().get());
+  }
+
+  @Override
+  public Result<?> removePermissions(String role, Permission<?>... permissions) {
+    return rethrow(() -> roles.permissionRemover().withRole(role).withPermissions(permissions).run().get());
+  }
+
+  @Override
+  public Result<?> assignRoles(String user, String... roles) {
+    return rethrow(() -> this.roles.assigner().withUser(user).witRoles(roles).run().get());
+  }
+
+  @Override
+  public Result<?> revokeRoles(String user, String... roles) {
+    return rethrow(() -> this.roles.revoker().withUser(user).witRoles(roles).run().get());
+  }
+}

--- a/src/test/java/io/weaviate/integration/client/async/rbac/ClientRbacTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/rbac/ClientRbacTest.java
@@ -33,7 +33,7 @@ public class ClientRbacTest implements ClientRbacTestSuite.Rbac {
    * methods without clashing with {@link ClientRbacTestSuite.Rbac} method
    * signatures.
    */
-  private <T> T rethrow(Callable<T> c) {
+  protected <T> T rethrow(Callable<T> c) {
     try {
       return c.call();
     } catch (Exception e) {
@@ -49,16 +49,6 @@ public class ClientRbacTest implements ClientRbacTestSuite.Rbac {
   @Override
   public Result<List<Role>> getAll() {
     return rethrow(() -> roles.allGetter().run().get());
-  }
-
-  @Override
-  public Result<List<Role>> getUserRoles() {
-    return rethrow(() -> roles.userRolesGetter().run().get());
-  }
-
-  @Override
-  public Result<List<Role>> getUserRoles(String user) {
-    return rethrow(() -> roles.userRolesGetter().withUser(user).run().get());
   }
 
   @Override
@@ -109,15 +99,5 @@ public class ClientRbacTest implements ClientRbacTestSuite.Rbac {
   @Override
   public Result<?> removePermissions(String role, Permission<?>[]... permissions) {
     return rethrow(() -> roles.permissionRemover().withRole(role).withPermissions(permissions).run().get());
-  }
-
-  @Override
-  public Result<?> assignRoles(String user, String... roles) {
-    return rethrow(() -> this.roles.assigner().withUser(user).witRoles(roles).run().get());
-  }
-
-  @Override
-  public Result<?> revokeRoles(String user, String... roles) {
-    return rethrow(() -> this.roles.revoker().withUser(user).witRoles(roles).run().get());
   }
 }

--- a/src/test/java/io/weaviate/integration/client/async/rbac/ClientRbacTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/rbac/ClientRbacTest.java
@@ -65,11 +65,6 @@ public class ClientRbacTest implements ClientRbacTestSuite.Rbac {
   }
 
   @Override
-  public Result<Boolean> createRole(String role, Permission<?>[]... permissions) {
-    return rethrow(() -> roles.creator().withName(role).withPermissions(permissions).run());
-  }
-
-  @Override
   public void deleteRole(String role) {
     rethrow(() -> roles.deleter().withName(role).run());
   }
@@ -90,17 +85,7 @@ public class ClientRbacTest implements ClientRbacTestSuite.Rbac {
   }
 
   @Override
-  public Result<?> addPermissions(String role, Permission<?>[]... permissions) {
-    return rethrow(() -> roles.permissionAdder().withRole(role).withPermissions(permissions).run());
-  }
-
-  @Override
   public Result<?> removePermissions(String role, Permission<?>... permissions) {
-    return rethrow(() -> roles.permissionRemover().withRole(role).withPermissions(permissions).run());
-  }
-
-  @Override
-  public Result<?> removePermissions(String role, Permission<?>[]... permissions) {
     return rethrow(() -> roles.permissionRemover().withRole(role).withPermissions(permissions).run());
   }
 }

--- a/src/test/java/io/weaviate/integration/client/async/rbac/ClientRbacTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/rbac/ClientRbacTest.java
@@ -72,6 +72,11 @@ public class ClientRbacTest implements ClientRbacTestSuite.Rbac {
   }
 
   @Override
+  public void createRole(String role, Permission<?>[]... permissions) {
+    rethrow(() -> roles.creator().withName(role).withPermissions(permissions).run().get());
+  }
+
+  @Override
   public void deleteRole(String role) {
     rethrow(() -> roles.deleter().withName(role).run().get());
   }
@@ -92,7 +97,17 @@ public class ClientRbacTest implements ClientRbacTestSuite.Rbac {
   }
 
   @Override
+  public Result<?> addPermissions(String role, Permission<?>[]... permissions) {
+    return rethrow(() -> roles.permissionAdder().withRole(role).withPermissions(permissions).run().get());
+  }
+
+  @Override
   public Result<?> removePermissions(String role, Permission<?>... permissions) {
+    return rethrow(() -> roles.permissionRemover().withRole(role).withPermissions(permissions).run().get());
+  }
+
+  @Override
+  public Result<?> removePermissions(String role, Permission<?>[]... permissions) {
     return rethrow(() -> roles.permissionRemover().withRole(role).withPermissions(permissions).run().get());
   }
 

--- a/src/test/java/io/weaviate/integration/client/async/schema/ClientSchemaTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/schema/ClientSchemaTest.java
@@ -468,7 +468,7 @@ public class ClientSchemaTest {
       //then
       assertResultTrue(createStatus);
 
-      assertResultError("tokenization in body should be one of [word lowercase whitespace field trigram gse kagome_kr]", notExistingTokenizationCreateStatus);
+      assertResultError("tokenization in body should be one of [word lowercase whitespace field trigram gse kagome_kr kagome_ja]", notExistingTokenizationCreateStatus);
       assertResultError("Tokenization is not allowed for data type 'int'", notSupportedTokenizationForIntCreateStatus);
     }
   }

--- a/src/test/java/io/weaviate/integration/client/async/users/ClientUsersTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/users/ClientUsersTest.java
@@ -36,16 +36,16 @@ public class ClientUsersTest extends ClientRbacTest implements ClientUsersTestSu
 
   @Override
   public Result<List<Role>> getUserRoles(String user) {
-    return rethrow(() -> users.userRolesGetter().withUser(user).run());
+    return rethrow(() -> users.userRolesGetter().withUserId(user).run());
   }
 
   @Override
   public Result<?> assignRoles(String user, String... roles) {
-    return rethrow(() -> this.users.assigner().withUser(user).witRoles(roles).run());
+    return rethrow(() -> this.users.assigner().withUserId(user).witRoles(roles).run());
   }
 
   @Override
   public Result<?> revokeRoles(String user, String... roles) {
-    return rethrow(() -> this.users.revoker().withUser(user).witRoles(roles).run());
+    return rethrow(() -> this.users.revoker().withUserId(user).witRoles(roles).run());
   }
 }

--- a/src/test/java/io/weaviate/integration/client/async/users/ClientUsersTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/users/ClientUsersTest.java
@@ -1,0 +1,45 @@
+package io.weaviate.integration.client.async.users;
+
+import java.util.List;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.WeaviateAuthClient;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.async.users.Users;
+import io.weaviate.client.v1.auth.exception.AuthException;
+import io.weaviate.client.v1.rbac.model.Role;
+import io.weaviate.integration.client.async.rbac.ClientRbacTest;
+import io.weaviate.integration.tests.users.ClientUsersTestSuite;
+
+/**
+ * ClientUsersTest is a {@link ClientUsersTestSuite.Users} implementation and a
+ * wrapper around WeaviateAsyncClient.Roles client which allows the latter to be
+ * used in the ClientUsersTestSuite.
+ */
+public class ClientUsersTest extends ClientRbacTest implements ClientUsersTestSuite.Users {
+  private Users users;
+
+  public ClientUsersTest(Config config, String apiKey) {
+    super(config, apiKey);
+    try {
+      this.users = WeaviateAuthClient.apiKey(config, apiKey).async().users();
+    } catch (AuthException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public Result<List<Role>> getUserRoles(String user) {
+    return rethrow(() -> users.userRolesGetter().withUser(user).run().get());
+  }
+
+  @Override
+  public Result<?> assignRoles(String user, String... roles) {
+    return rethrow(() -> this.users.assigner().withUser(user).witRoles(roles).run().get());
+  }
+
+  @Override
+  public Result<?> revokeRoles(String user, String... roles) {
+    return rethrow(() -> this.users.revoker().withUser(user).witRoles(roles).run().get());
+  }
+}

--- a/src/test/java/io/weaviate/integration/client/async/users/ClientUsersTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/users/ClientUsersTest.java
@@ -8,6 +8,7 @@ import io.weaviate.client.base.Result;
 import io.weaviate.client.v1.async.users.Users;
 import io.weaviate.client.v1.auth.exception.AuthException;
 import io.weaviate.client.v1.rbac.model.Role;
+import io.weaviate.client.v1.users.model.User;
 import io.weaviate.integration.client.async.rbac.ClientRbacTest;
 import io.weaviate.integration.tests.users.ClientUsersTestSuite;
 
@@ -29,17 +30,22 @@ public class ClientUsersTest extends ClientRbacTest implements ClientUsersTestSu
   }
 
   @Override
+  public Result<User> getMyUser() {
+    return rethrow(() -> users.myUserGetter().run());
+  }
+
+  @Override
   public Result<List<Role>> getUserRoles(String user) {
-    return rethrow(() -> users.userRolesGetter().withUser(user).run().get());
+    return rethrow(() -> users.userRolesGetter().withUser(user).run());
   }
 
   @Override
   public Result<?> assignRoles(String user, String... roles) {
-    return rethrow(() -> this.users.assigner().withUser(user).witRoles(roles).run().get());
+    return rethrow(() -> this.users.assigner().withUser(user).witRoles(roles).run());
   }
 
   @Override
   public Result<?> revokeRoles(String user, String... roles) {
-    return rethrow(() -> this.users.revoker().withUser(user).witRoles(roles).run().get());
+    return rethrow(() -> this.users.revoker().withUser(user).witRoles(roles).run());
   }
 }

--- a/src/test/java/io/weaviate/integration/client/rbac/ClientRbacTest.java
+++ b/src/test/java/io/weaviate/integration/client/rbac/ClientRbacTest.java
@@ -43,11 +43,6 @@ public class ClientRbacTest implements ClientRbacTestSuite.Rbac {
   }
 
   @Override
-  public Result<Boolean> createRole(String role, Permission<?>[]... permissions) {
-    return roles.creator().withName(role).withPermissions(permissions).run();
-  }
-
-  @Override
   public void deleteRole(String role) {
     roles.deleter().withName(role).run();
   }
@@ -68,17 +63,7 @@ public class ClientRbacTest implements ClientRbacTestSuite.Rbac {
   }
 
   @Override
-  public Result<?> addPermissions(String role, Permission<?>[]... permissions) {
-    return roles.permissionAdder().withRole(role).withPermissions(permissions).run();
-  }
-
-  @Override
   public Result<?> removePermissions(String role, Permission<?>... permissions) {
-    return roles.permissionRemover().withRole(role).withPermissions(permissions).run();
-  }
-
-  @Override
-  public Result<?> removePermissions(String role, Permission<?>[]... permissions) {
     return roles.permissionRemover().withRole(role).withPermissions(permissions).run();
   }
 }

--- a/src/test/java/io/weaviate/integration/client/rbac/ClientRbacTest.java
+++ b/src/test/java/io/weaviate/integration/client/rbac/ClientRbacTest.java
@@ -33,16 +33,6 @@ public class ClientRbacTest implements ClientRbacTestSuite.Rbac {
   }
 
   @Override
-  public Result<List<Role>> getUserRoles() {
-    return roles.userRolesGetter().run();
-  }
-
-  @Override
-  public Result<List<Role>> getUserRoles(String user) {
-    return roles.userRolesGetter().withUser(user).run();
-  }
-
-  @Override
   public Result<List<String>> getAssignedUsers(String role) {
     return roles.assignedUsersGetter().withRole(role).run();
   }
@@ -90,15 +80,5 @@ public class ClientRbacTest implements ClientRbacTestSuite.Rbac {
   @Override
   public Result<?> removePermissions(String role, Permission<?>[]... permissions) {
     return roles.permissionRemover().withRole(role).withPermissions(permissions).run();
-  }
-
-  @Override
-  public Result<?> assignRoles(String user, String... roles) {
-    return this.roles.assigner().withUser(user).witRoles(roles).run();
-  }
-
-  @Override
-  public Result<?> revokeRoles(String user, String... roles) {
-    return this.roles.revoker().withUser(user).witRoles(roles).run();
   }
 }

--- a/src/test/java/io/weaviate/integration/client/rbac/ClientRbacTest.java
+++ b/src/test/java/io/weaviate/integration/client/rbac/ClientRbacTest.java
@@ -28,10 +28,12 @@ import io.weaviate.client.v1.rbac.model.Role;
 import io.weaviate.client.v1.rbac.model.RolesPermission;
 import io.weaviate.client.v1.rbac.model.TenantsPermission;
 import io.weaviate.integration.client.WeaviateDockerCompose;
+import io.weaviate.integration.client.WeaviateDockerCompose.Weaviate;
 
 public class ClientRbacTest {
   private static final String adminRole = "admin";
   private static final String viewerRole = "viewer";
+  private static final String adminUser = "john-doe";
 
   private Roles roles;
 
@@ -39,12 +41,12 @@ public class ClientRbacTest {
   public TestName currentTest = new TestName();
 
   @ClassRule
-  public static WeaviateDockerCompose compose = new WeaviateDockerCompose(true);
+  public static WeaviateDockerCompose compose = WeaviateDockerCompose.rbac(adminUser);
 
   @Before
   public void before() throws AuthException {
     Config config = new Config("http", compose.getHttpHostAddress());
-    roles = WeaviateAuthClient.apiKey(config, "jp-secret-key").roles();
+    roles = WeaviateAuthClient.apiKey(config, Weaviate.makeSecret(adminUser)).roles();
   }
 
   public static Object[][] rolesToCreate() {
@@ -78,7 +80,6 @@ public class ClientRbacTest {
     try {
       // Arrange
       roles.deleter().withName(myRole).run();
-
       roles.creator().withName(myRole)
           .withPermissions(
               Permission.backups(BackupsPermission.Action.MANAGE, myCollection),

--- a/src/test/java/io/weaviate/integration/client/rbac/ClientRbacTest.java
+++ b/src/test/java/io/weaviate/integration/client/rbac/ClientRbacTest.java
@@ -53,6 +53,11 @@ public class ClientRbacTest implements ClientRbacTestSuite.Rbac {
   }
 
   @Override
+  public void createRole(String role, Permission<?>[]... permissions) {
+    roles.creator().withName(role).withPermissions(permissions).run();
+  }
+
+  @Override
   public void deleteRole(String role) {
     roles.deleter().withName(role).run();
   }
@@ -73,7 +78,17 @@ public class ClientRbacTest implements ClientRbacTestSuite.Rbac {
   }
 
   @Override
+  public Result<?> addPermissions(String role, Permission<?>[]... permissions) {
+    return roles.permissionAdder().withRole(role).withPermissions(permissions).run();
+  }
+
+  @Override
   public Result<?> removePermissions(String role, Permission<?>... permissions) {
+    return roles.permissionRemover().withRole(role).withPermissions(permissions).run();
+  }
+
+  @Override
+  public Result<?> removePermissions(String role, Permission<?>[]... permissions) {
     return roles.permissionRemover().withRole(role).withPermissions(permissions).run();
   }
 

--- a/src/test/java/io/weaviate/integration/client/rbac/ClientRbacTest.java
+++ b/src/test/java/io/weaviate/integration/client/rbac/ClientRbacTest.java
@@ -38,13 +38,13 @@ public class ClientRbacTest implements ClientRbacTestSuite.Rbac {
   }
 
   @Override
-  public void createRole(String role, Permission<?>... permissions) {
-    roles.creator().withName(role).withPermissions(permissions).run();
+  public Result<Boolean> createRole(String role, Permission<?>... permissions) {
+    return roles.creator().withName(role).withPermissions(permissions).run();
   }
 
   @Override
-  public void createRole(String role, Permission<?>[]... permissions) {
-    roles.creator().withName(role).withPermissions(permissions).run();
+  public Result<Boolean> createRole(String role, Permission<?>[]... permissions) {
+    return roles.creator().withName(role).withPermissions(permissions).run();
   }
 
   @Override

--- a/src/test/java/io/weaviate/integration/client/rbac/ClientRbacTest.java
+++ b/src/test/java/io/weaviate/integration/client/rbac/ClientRbacTest.java
@@ -1,0 +1,121 @@
+package io.weaviate.integration.client.rbac;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.list;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.WeaviateAuthClient;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.auth.exception.AuthException;
+import io.weaviate.client.v1.rbac.Roles;
+import io.weaviate.client.v1.rbac.model.BackupsPermission;
+import io.weaviate.client.v1.rbac.model.ClusterPermission;
+import io.weaviate.client.v1.rbac.model.CollectionsPermission;
+import io.weaviate.client.v1.rbac.model.DataPermission;
+import io.weaviate.client.v1.rbac.model.NodesPermission;
+import io.weaviate.client.v1.rbac.model.NodesPermission.Verbosity;
+import io.weaviate.client.v1.rbac.model.Permission;
+import io.weaviate.client.v1.rbac.model.Role;
+import io.weaviate.client.v1.rbac.model.RolesPermission;
+import io.weaviate.client.v1.rbac.model.TenantsPermission;
+import io.weaviate.integration.client.WeaviateDockerCompose;
+
+public class ClientRbacTest {
+  private static final String adminRole = "admin";
+  private static final String viewerRole = "viewer";
+
+  private Roles roles;
+
+  @Rule
+  public TestName currentTest = new TestName();
+
+  @ClassRule
+  public static WeaviateDockerCompose compose = new WeaviateDockerCompose(true);
+
+  @Before
+  public void before() throws AuthException {
+    Config config = new Config("http", compose.getHttpHostAddress());
+    roles = WeaviateAuthClient.apiKey(config, "jp-secret-key").roles();
+  }
+
+  public static Object[][] rolesToCreate() {
+    return new Object[][] {
+    };
+  }
+
+  /**
+   * By default the admin user which we use to run the tests
+   * will have 'admin' and 'viewer' roles.
+   */
+  @Test
+  public void testGetAll() {
+    Result<List<Role>> response = roles.allGetter().run();
+    List<Role> all = response.getResult();
+
+    assertThat(response.getError()).as("result had errors").isNull();
+    assertThat(all).hasSize(2).as("wrong number of roles");
+    assertThat(all.get(0)).returns(adminRole, Role::getName);
+    assertThat(all.get(1)).returns(viewerRole, Role::getName);
+  }
+
+  // TODO: check if I can create a role with a name that's not a valid URL
+  // paramter
+
+  @Test
+  public void testCreateAndList() {
+    String myRole = roleName("VectorOwner");
+    String myCollection = "Pizza";
+
+    try {
+      // Arrange
+      roles.deleter().withName(myRole).run();
+
+      roles.creator().withName(myRole)
+          .withPermissions(
+              Permission.backups(BackupsPermission.Action.MANAGE, myCollection),
+              Permission.cluster(ClusterPermission.Action.READ),
+              Permission.nodes(NodesPermission.Action.READ, Verbosity.MINIMAL, myCollection),
+              Permission.roles(RolesPermission.Action.MANAGE, viewerRole),
+              Permission.collections(CollectionsPermission.Action.CREATE, myCollection),
+              Permission.data(DataPermission.Action.UPDATE, myCollection),
+              Permission.tenants(TenantsPermission.Action.DELETE))
+          .run();
+
+      Result<Role> response = roles.getter().withName(myRole).run();
+      Role role = response.getResult();
+      assertThat(response.getError()).as("result had errors").isNull();
+      assertThat(role).as("wrong role name").returns(myRole, Role::getName);
+
+      List<? extends Permission<?>> permissions = role.getPermissions();
+      assertTrue(hasPermissionWithAction(permissions, BackupsPermission.Action.MANAGE.getValue()));
+      assertTrue(hasPermissionWithAction(permissions, ClusterPermission.Action.READ.getValue()));
+      assertTrue(hasPermissionWithAction(permissions, NodesPermission.Action.READ.getValue()));
+      assertTrue(hasPermissionWithAction(permissions, RolesPermission.Action.MANAGE.getValue()));
+      assertTrue(hasPermissionWithAction(permissions, CollectionsPermission.Action.CREATE.getValue()));
+      assertTrue(hasPermissionWithAction(permissions, DataPermission.Action.UPDATE.getValue()));
+      assertTrue(hasPermissionWithAction(permissions, TenantsPermission.Action.DELETE.getValue()));
+    } finally {
+      roles.deleter().withName(myRole).run();
+    }
+  }
+
+  /** Prefix the role with the name of the current test for easier debugging */
+  private String roleName(String name) {
+    return String.format("%s-%s", currentTest.getMethodName(), name);
+  }
+
+  private boolean hasPermissionWithAction(List<? extends Permission<?>> permissions, String action) {
+    return permissions.stream()
+        .filter(perm -> perm.getAction().equals(action))
+        .findFirst().isPresent();
+  }
+}

--- a/src/test/java/io/weaviate/integration/client/rbac/ClientRbacTest.java
+++ b/src/test/java/io/weaviate/integration/client/rbac/ClientRbacTest.java
@@ -1,249 +1,89 @@
 package io.weaviate.integration.client.rbac;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
-
 import java.util.List;
-
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
-import org.junit.rules.TestName;
 
 import io.weaviate.client.Config;
 import io.weaviate.client.WeaviateAuthClient;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.v1.auth.exception.AuthException;
 import io.weaviate.client.v1.rbac.Roles;
-import io.weaviate.client.v1.rbac.model.BackupsPermission;
-import io.weaviate.client.v1.rbac.model.ClusterPermission;
-import io.weaviate.client.v1.rbac.model.CollectionsPermission;
-import io.weaviate.client.v1.rbac.model.DataPermission;
-import io.weaviate.client.v1.rbac.model.NodesPermission;
-import io.weaviate.client.v1.rbac.model.NodesPermission.Verbosity;
 import io.weaviate.client.v1.rbac.model.Permission;
 import io.weaviate.client.v1.rbac.model.Role;
-import io.weaviate.client.v1.rbac.model.RolesPermission;
-import io.weaviate.client.v1.rbac.model.TenantsPermission;
-import io.weaviate.integration.client.WeaviateDockerCompose;
-import io.weaviate.integration.client.WeaviateDockerCompose.Weaviate;
+import io.weaviate.integration.tests.rbac.ClientRbacTestSuite;
 
-public class ClientRbacTest {
-  private static final String adminRole = "admin";
-  private static final String viewerRole = "viewer";
-  private static final String adminUser = "john-doe";
-
+public class ClientRbacTest implements ClientRbacTestSuite.Rbac {
   private Roles roles;
 
-  @Rule
-  public TestName currentTest = new TestName();
-
-  @ClassRule
-  public static WeaviateDockerCompose compose = WeaviateDockerCompose.rbac(adminUser);
-
-  @Before
-  public void before() throws AuthException {
-    Config config = new Config("http", compose.getHttpHostAddress());
-    roles = WeaviateAuthClient.apiKey(config, Weaviate.makeSecret(adminUser)).roles();
-  }
-
-  public static Object[][] rolesToCreate() {
-    return new Object[][] {
-    };
-  }
-
-  /**
-   * By default the admin user which we use to run the tests
-   * will have 'admin' and 'viewer' roles.
-   */
-  @Test
-  public void testGetAll() {
-    Result<List<Role>> response = roles.allGetter().run();
-    List<Role> all = response.getResult();
-
-    assertThat(response.getError()).as("get all roles error").isNull();
-    assertThat(all).hasSize(2).as("wrong number of roles");
-    assertThat(all.get(0)).returns(adminRole, Role::getName);
-    assertThat(all.get(1)).returns(viewerRole, Role::getName);
-  }
-
-  @Test
-  public void testGetUserRoles() {
-    Result<List<Role>> responseCurrent = roles.userRolesGetter().run();
-    assertThat(responseCurrent.getError()).as("get roles for current user error").isNull();
-    Result<List<Role>> responseAdminUser = roles.userRolesGetter().withUser(adminUser).run();
-    assertThat(responseAdminUser.getError()).as("get roles for user error").isNull();
-
-    List<Role> currentRoles = responseCurrent.getResult();
-    List<Role> adminRoles = responseAdminUser.getResult();
-
-    Assertions.assertArrayEquals(currentRoles.toArray(), adminRoles.toArray(), "expect same set of roles");
-  }
-
-  public void testGetAssignedUsers() {
-    Result<List<String>> response = roles.assignedUsersGetter().withRole(adminRole).run();
-    assertThat(response.getError()).as("get assigned users error").isNull();
-
-    List<String> users = response.getResult();
-    assertThat(users).as("users assigned to " + adminRole + " role").hasSize(1);
-    assertEquals(adminUser, users.get(0), "wrong user assinged to " + adminRole + " role");
-  }
-
-  // TODO: check if I can create a role with a name that's not a valid URL
-  // paramter
-
-  @Test
-  public void testCreate() {
-    String myRole = roleName("VectorOwner");
-    String myCollection = "Pizza";
-
-    Permission<?>[] wantPermissions = new Permission<?>[] {
-        Permission.backups(BackupsPermission.Action.MANAGE, myCollection),
-        Permission.cluster(ClusterPermission.Action.READ),
-        Permission.nodes(NodesPermission.Action.READ, Verbosity.MINIMAL, myCollection),
-        Permission.roles(RolesPermission.Action.MANAGE, viewerRole),
-        Permission.collections(CollectionsPermission.Action.CREATE, myCollection),
-        Permission.data(DataPermission.Action.UPDATE, myCollection),
-        Permission.tenants(TenantsPermission.Action.DELETE),
-    };
-
+  public ClientRbacTest(Config config, String apiKey) {
     try {
-      // Arrange
-      deleteRole(myRole);
-
-      // Act
-      createRole(myRole, wantPermissions);
-
-      Result<Role> response = roles.getter().withName(myRole).run();
-      Role role = response.getResult();
-      assertNull("error fetching a role", response.getError());
-      assertThat(role).as("wrong role name").returns(myRole, Role::getName);
-
-      for (int i = 0; i < wantPermissions.length; i++) {
-        Permission<?> perm = wantPermissions[i];
-        assertTrue("should have permission " + perm, checkHasPermission(myRole, perm));
-      }
-    } finally {
-      deleteRole(myRole);
+      this.roles = WeaviateAuthClient.apiKey(config, apiKey).roles();
+    } catch (AuthException e) {
+      throw new RuntimeException(e);
     }
   }
 
-  @Test
-  public void testAddPermissions() {
-    String myRole = roleName("VectorOwner");
-    Permission<?> toAdd = Permission.cluster(ClusterPermission.Action.READ);
-    try {
-      // Arrange
-      createRole(myRole, Permission.tenants(TenantsPermission.Action.DELETE));
-
-      // Act
-      Result<?> response = roles.permissionAdder().withRole(myRole)
-          .withPermissions(toAdd)
-          .run();
-      assertNull("add-permissions operation error", response.getError());
-
-      // Assert
-      assertTrue("should have permission " + toAdd, checkHasPermission(myRole, toAdd));
-    } finally {
-      deleteRole(myRole);
-    }
+  @Override
+  public Result<Role> getRole(String role) {
+    return roles.getter().withName(role).run();
   }
 
-  @Test
-  public void testRemovePermissions() {
-    String myRole = roleName("VectorOwner");
-    Permission<?> toRemove = Permission.tenants(TenantsPermission.Action.DELETE);
-    try {
-      // Arrange
-      createRole(myRole,
-          Permission.cluster(ClusterPermission.Action.READ),
-          Permission.tenants(TenantsPermission.Action.DELETE));
-
-      // Act
-      Result<?> response = roles.permissionRemover().withRole(myRole)
-          .withPermissions(toRemove)
-          .run();
-      assertNull("remove-permissions operation error", response.getError());
-
-      // Assert
-      assertFalse("should not have permission " + toRemove, checkHasPermission(myRole, toRemove));
-    } finally {
-      deleteRole(myRole);
-    }
+  @Override
+  public Result<List<Role>> getAll() {
+    return roles.allGetter().run();
   }
 
-  @Test
-  public void testRevokeRole() {
-    String myRole = roleName("VectorOwner");
-    try {
-      // Arrange
-      createRole(myRole, Permission.tenants(TenantsPermission.Action.DELETE));
-      roles.assigner().withUser(adminUser).witRoles(myRole).run();
-      assumeTrue(checkHasRole(adminUser, myRole), adminUser + " should have the assigned role");
-
-      // Act
-      Result<?> response = roles.revoker().withUser(adminUser).witRoles(myRole).run();
-      assertNull("revoke operation error", response.getError());
-
-      // Assert
-      assertFalse("should not have " + myRole + "role", checkHasRole(adminUser, myRole));
-    } finally {
-      deleteRole(myRole);
-    }
+  @Override
+  public Result<List<Role>> getUserRoles() {
+    return roles.userRolesGetter().run();
   }
 
-  @Test
-  public void testAssignRole() {
-    String myRole = roleName("VectorOwner");
-    try {
-      // Arrange
-      createRole(myRole, Permission.tenants(TenantsPermission.Action.DELETE));
-      assumeFalse(checkHasRole(adminUser, myRole), adminUser + " should not have the new role");
-
-      // Act
-      Result<?> response = roles.assigner().withUser(adminUser).witRoles(myRole).run();
-      assertNull("assign operation error", response.getError());
-
-      // Assert
-      assertTrue("should have " + myRole + "role", checkHasRole(adminUser, myRole));
-    } finally {
-      deleteRole(myRole);
-    }
+  @Override
+  public Result<List<Role>> getUserRoles(String user) {
+    return roles.userRolesGetter().withUser(user).run();
   }
 
-  /** Prefix the role with the name of the current test for easier debugging */
-  private String roleName(String name) {
-    return String.format("%s-%s", currentTest.getMethodName(), name);
+  @Override
+  public Result<List<String>> getAssignedUsers(String role) {
+    return roles.assignedUsersGetter().withRole(role).run();
   }
 
-  private boolean checkHasPermission(String role, Permission<? extends Permission<?>> perm) {
-    return roles.permissionChecker().withRole(role).withPermission(perm).run().getResult();
-  }
-
-  private boolean checkRoleExists(String role) {
-    return roles.exists().withName(role).run().getResult();
-  }
-
-  private boolean checkHasRole(String user, String role) {
-    return roles.assignedUsersGetter().withRole(role).run().getResult().contains(user);
-  }
-
-  private void createRole(String role, Permission<?>... permissions) {
+  @Override
+  public void createRole(String role, Permission<?>... permissions) {
     roles.creator().withName(role).withPermissions(permissions).run();
-    assumeTrue(checkRoleExists(role), "role should exist after creation");
-
   }
 
-  private void deleteRole(String role) {
+  @Override
+  public void deleteRole(String role) {
     roles.deleter().withName(role).run();
-    assertFalse("role should not exist after deletion", checkRoleExists(role));
+  }
 
+  @Override
+  public Result<Boolean> hasPermission(String role, Permission<?> perm) {
+    return roles.permissionChecker().withRole(role).withPermission(perm).run();
+  }
+
+  @Override
+  public Result<Boolean> exists(String role) {
+    return roles.exists().withName(role).run();
+  }
+
+  @Override
+  public Result<?> addPermissions(String role, Permission<?>... permissions) {
+    return roles.permissionAdder().withRole(role).withPermissions(permissions).run();
+  }
+
+  @Override
+  public Result<?> removePermissions(String role, Permission<?>... permissions) {
+    return roles.permissionRemover().withRole(role).withPermissions(permissions).run();
+  }
+
+  @Override
+  public Result<?> assignRoles(String user, String... roles) {
+    return this.roles.assigner().withUser(user).witRoles(roles).run();
+  }
+
+  @Override
+  public Result<?> revokeRoles(String user, String... roles) {
+    return this.roles.revoker().withUser(user).witRoles(roles).run();
   }
 }

--- a/src/test/java/io/weaviate/integration/client/rbac/ClientRbacTest.java
+++ b/src/test/java/io/weaviate/integration/client/rbac/ClientRbacTest.java
@@ -1,11 +1,11 @@
 package io.weaviate.integration.client.rbac;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.InstanceOfAssertFactories.list;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.util.List;
@@ -19,7 +19,6 @@ import org.junit.rules.TestName;
 
 import io.weaviate.client.Config;
 import io.weaviate.client.WeaviateAuthClient;
-import io.weaviate.client.WeaviateClient;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.v1.auth.exception.AuthException;
 import io.weaviate.client.v1.rbac.Roles;
@@ -69,7 +68,7 @@ public class ClientRbacTest {
     Result<List<Role>> response = roles.allGetter().run();
     List<Role> all = response.getResult();
 
-    assertThat(response.getError()).as("result had errors").isNull();
+    assertThat(response.getError()).as("get all roles error").isNull();
     assertThat(all).hasSize(2).as("wrong number of roles");
     assertThat(all.get(0)).returns(adminRole, Role::getName);
     assertThat(all.get(1)).returns(viewerRole, Role::getName);
@@ -78,14 +77,23 @@ public class ClientRbacTest {
   @Test
   public void testGetUserRoles() {
     Result<List<Role>> responseCurrent = roles.userRolesGetter().run();
-    assertThat(responseCurrent.getError()).as("result had errors").isNull();
+    assertThat(responseCurrent.getError()).as("get roles for current user error").isNull();
     Result<List<Role>> responseAdminUser = roles.userRolesGetter().withUser(adminUser).run();
-    assertThat(responseAdminUser.getError()).as("result had errors").isNull();
+    assertThat(responseAdminUser.getError()).as("get roles for user error").isNull();
 
     List<Role> currentRoles = responseCurrent.getResult();
     List<Role> adminRoles = responseAdminUser.getResult();
 
     Assertions.assertArrayEquals(currentRoles.toArray(), adminRoles.toArray(), "expect same set of roles");
+  }
+
+  public void testGetAssignedUsers() {
+    Result<List<String>> response = roles.assignedUsersGetter().withRole(adminRole).run();
+    assertThat(response.getError()).as("get assigned users error").isNull();
+
+    List<String> users = response.getResult();
+    assertThat(users).as("users assigned to " + adminRole + " role").hasSize(1);
+    assertEquals(adminUser, users.get(0), "wrong user assinged to " + adminRole + " role");
   }
 
   // TODO: check if I can create a role with a name that's not a valid URL
@@ -127,7 +135,7 @@ public class ClientRbacTest {
       }
     } finally {
       roles.deleter().withName(myRole).run();
-      assertFalse("should not exist after deletion", checkRoleExists(myRole));
+      assertFalse("role should not exist after deletion", checkRoleExists(myRole));
     }
   }
 
@@ -143,16 +151,16 @@ public class ClientRbacTest {
       assumeTrue(checkRoleExists(myRole), "role should exist after creation");
 
       // Act
-      Result<?> addResult = roles.permissionAdder().withRole(myRole)
+      Result<?> response = roles.permissionAdder().withRole(myRole)
           .withPermissions(toAdd)
           .run();
-      assertNull("add-permissions operation error", addResult.getError());
+      assertNull("add-permissions operation error", response.getError());
 
       // Assert
       assertTrue("should have permission " + toAdd, checkHasPermission(myRole, toAdd));
     } finally {
       roles.deleter().withName(myRole).run();
-      assertFalse("should not exist after deletion", checkRoleExists(myRole));
+      assertFalse("role should not exist after deletion", checkRoleExists(myRole));
     }
   }
 
@@ -170,16 +178,64 @@ public class ClientRbacTest {
       assumeTrue(checkRoleExists(myRole), "role should exist after creation");
 
       // Act
-      Result<?> addResult = roles.permissionRemover().withRole(myRole)
+      Result<?> response = roles.permissionRemover().withRole(myRole)
           .withPermissions(toRemove)
           .run();
-      assertNull("remove-permissions operation error", addResult.getError());
+      assertNull("remove-permissions operation error", response.getError());
 
       // Assert
       assertFalse("should not have permission " + toRemove, checkHasPermission(myRole, toRemove));
     } finally {
       roles.deleter().withName(myRole).run();
-      assertFalse("should not exist after deletion", checkRoleExists(myRole));
+      assertFalse("role should not exist after deletion", checkRoleExists(myRole));
+    }
+  }
+
+  @Test
+  public void testRevokeRole() {
+    String myRole = roleName("VectorOwner");
+    try {
+      // Arrange
+      roles.creator().withName(myRole)
+          .withPermissions(Permission.tenants(TenantsPermission.Action.DELETE))
+          .run();
+      assumeTrue(checkRoleExists(myRole), "role should exist after creation");
+
+      roles.assigner().withUser(adminUser).witRoles(myRole).run();
+      assumeTrue(checkHasRole(adminUser, myRole), adminUser + " should have the assigned role");
+
+      // Act
+      Result<?> response = roles.revoker().withUser(adminUser).witRoles(myRole).run();
+      assertNull("revoke operation error", response.getError());
+
+      // Assert
+      assertFalse("should not have " + myRole + "role", checkHasRole(adminUser, myRole));
+    } finally {
+      roles.deleter().withName(myRole).run();
+      assertFalse("role should not exist after deletion", checkRoleExists(myRole));
+    }
+  }
+
+  @Test
+  public void testAssignRole() {
+    String myRole = roleName("VectorOwner");
+    try {
+      // Arrange
+      roles.creator().withName(myRole)
+          .withPermissions(Permission.tenants(TenantsPermission.Action.DELETE))
+          .run();
+      assumeTrue(checkRoleExists(myRole), "role should exist after creation");
+      assumeFalse(checkHasRole(adminUser, myRole), adminUser + " should not have the new role");
+
+      // Act
+      Result<?> response = roles.assigner().withUser(adminUser).witRoles(myRole).run();
+      assertNull("assign operation error", response.getError());
+
+      // Assert
+      assertTrue("should have " + myRole + "role", checkHasRole(adminUser, myRole));
+    } finally {
+      roles.deleter().withName(myRole).run();
+      assertFalse("role should not exist after deletion", checkRoleExists(myRole));
     }
   }
 
@@ -194,5 +250,9 @@ public class ClientRbacTest {
 
   private boolean checkRoleExists(String role) {
     return roles.exists().withName(role).run().getResult();
+  }
+
+  private boolean checkHasRole(String user, String role) {
+    return roles.assignedUsersGetter().withRole(role).run().getResult().contains(user);
   }
 }

--- a/src/test/java/io/weaviate/integration/client/schema/ClientSchemaTest.java
+++ b/src/test/java/io/weaviate/integration/client/schema/ClientSchemaTest.java
@@ -361,7 +361,7 @@ public class ClientSchemaTest {
     //then
     assertResultTrue(createStatus);
 
-    assertResultError("tokenization in body should be one of [word lowercase whitespace field trigram gse kagome_kr]", notExistingTokenizationCreateStatus);
+    assertResultError("tokenization in body should be one of [word lowercase whitespace field trigram gse kagome_kr kagome_ja]", notExistingTokenizationCreateStatus);
     assertResultError("Tokenization is not allowed for data type 'int'", notSupportedTokenizationForIntCreateStatus);
   }
 

--- a/src/test/java/io/weaviate/integration/client/users/ClientUsersTest.java
+++ b/src/test/java/io/weaviate/integration/client/users/ClientUsersTest.java
@@ -1,0 +1,40 @@
+package io.weaviate.integration.client.users;
+
+import java.util.List;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.WeaviateAuthClient;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.auth.exception.AuthException;
+import io.weaviate.client.v1.rbac.model.Role;
+import io.weaviate.client.v1.users.Users;
+import io.weaviate.integration.client.rbac.ClientRbacTest;
+import io.weaviate.integration.tests.users.ClientUsersTestSuite;
+
+public class ClientUsersTest extends ClientRbacTest implements ClientUsersTestSuite.Users {
+  private Users users;
+
+  public ClientUsersTest(Config config, String apiKey) {
+    super(config, apiKey);
+    try {
+      this.users = WeaviateAuthClient.apiKey(config, apiKey).users();
+    } catch (AuthException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public Result<List<Role>> getUserRoles(String user) {
+    return users.userRolesGetter().withUser(user).run();
+  }
+
+  @Override
+  public Result<?> assignRoles(String user, String... roles) {
+    return this.users.assigner().withUser(user).witRoles(roles).run();
+  }
+
+  @Override
+  public Result<?> revokeRoles(String user, String... roles) {
+    return this.users.revoker().withUser(user).witRoles(roles).run();
+  }
+}

--- a/src/test/java/io/weaviate/integration/client/users/ClientUsersTest.java
+++ b/src/test/java/io/weaviate/integration/client/users/ClientUsersTest.java
@@ -8,6 +8,7 @@ import io.weaviate.client.base.Result;
 import io.weaviate.client.v1.auth.exception.AuthException;
 import io.weaviate.client.v1.rbac.model.Role;
 import io.weaviate.client.v1.users.Users;
+import io.weaviate.client.v1.users.model.User;
 import io.weaviate.integration.client.rbac.ClientRbacTest;
 import io.weaviate.integration.tests.users.ClientUsersTestSuite;
 
@@ -21,6 +22,11 @@ public class ClientUsersTest extends ClientRbacTest implements ClientUsersTestSu
     } catch (AuthException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Override
+  public Result<User> getMyUser() {
+    return users.myUserGetter().run();
   }
 
   @Override

--- a/src/test/java/io/weaviate/integration/client/users/ClientUsersTest.java
+++ b/src/test/java/io/weaviate/integration/client/users/ClientUsersTest.java
@@ -31,16 +31,16 @@ public class ClientUsersTest extends ClientRbacTest implements ClientUsersTestSu
 
   @Override
   public Result<List<Role>> getUserRoles(String user) {
-    return users.userRolesGetter().withUser(user).run();
+    return users.userRolesGetter().withUserId(user).run();
   }
 
   @Override
   public Result<?> assignRoles(String user, String... roles) {
-    return this.users.assigner().withUser(user).witRoles(roles).run();
+    return this.users.assigner().withUserId(user).witRoles(roles).run();
   }
 
   @Override
   public Result<?> revokeRoles(String user, String... roles) {
-    return this.users.revoker().withUser(user).witRoles(roles).run();
+    return this.users.revoker().withUserId(user).witRoles(roles).run();
   }
 }

--- a/src/test/java/io/weaviate/integration/tests/rbac/ClientRbacTestSuite.java
+++ b/src/test/java/io/weaviate/integration/tests/rbac/ClientRbacTestSuite.java
@@ -1,0 +1,286 @@
+package io.weaviate.integration.tests.rbac;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+
+import com.jparams.junit4.JParamsTestRunner;
+import com.jparams.junit4.data.DataMethod;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.auth.exception.AuthException;
+import io.weaviate.client.v1.rbac.model.BackupsPermission;
+import io.weaviate.client.v1.rbac.model.ClusterPermission;
+import io.weaviate.client.v1.rbac.model.CollectionsPermission;
+import io.weaviate.client.v1.rbac.model.DataPermission;
+import io.weaviate.client.v1.rbac.model.NodesPermission;
+import io.weaviate.client.v1.rbac.model.NodesPermission.Verbosity;
+import io.weaviate.client.v1.rbac.model.Permission;
+import io.weaviate.client.v1.rbac.model.Role;
+import io.weaviate.client.v1.rbac.model.RolesPermission;
+import io.weaviate.client.v1.rbac.model.TenantsPermission;
+import io.weaviate.integration.client.WeaviateDockerCompose;
+import io.weaviate.integration.client.WeaviateDockerCompose.Weaviate;
+
+@RunWith(JParamsTestRunner.class)
+public class ClientRbacTestSuite {
+
+  private static final String adminRole = "admin";
+  private static final String viewerRole = "viewer";
+  private static final String adminUser = "john-doe";
+  private static final String API_KEY = Weaviate.makeSecret(adminUser);
+
+  @Rule
+  public TestName currentTest = new TestName();
+
+  @ClassRule
+  public static WeaviateDockerCompose compose = WeaviateDockerCompose.rbac(adminUser);
+
+  public static Config config() {
+    return new Config("http", compose.getHttpHostAddress());
+  }
+
+  public static Object[][] clients() {
+    try {
+      Object[][] r = new Object[][] {
+          {
+              (Supplier<Rbac>) () -> new io.weaviate.integration.client.rbac.ClientRbacTest(config(), API_KEY) },
+      };
+      return r;
+    } catch (Exception e) {
+      System.out.println(e.getMessage());
+      return null;
+    }
+  }
+
+  /**
+   * By default the admin user which we use to run the tests
+   * will have 'admin' and 'viewer' roles.
+   */
+  @DataMethod(source = ClientRbacTestSuite.class, method = "clients")
+  @Test
+  public void testGetAll(Supplier<Rbac> rbac) {
+    Rbac roles = rbac.get();
+    Result<List<Role>> response = roles.getAll();
+    List<Role> all = response.getResult();
+
+    assertThat(response.getError()).as("get all roles error").isNull();
+    assertThat(all).hasSize(2).as("wrong number of roles");
+    assertThat(all.get(0)).returns(adminRole, Role::getName);
+    assertThat(all.get(1)).returns(viewerRole, Role::getName);
+  }
+
+  /**
+   * Roles retrieved for "current user" should be identical to the ones
+   * retrieved for them explicitly (by passing the username).
+   */
+  @DataMethod(source = ClientRbacTestSuite.class, method = "clients")
+  @Test
+  public void testGetUserRoles(Supplier<Rbac> rbac) {
+    Rbac roles = rbac.get();
+    Result<List<Role>> responseCurrent = roles.getUserRoles();
+    assertThat(responseCurrent.getError()).as("get roles for current user error").isNull();
+    Result<List<Role>> responseAdminUser = roles.getUserRoles(adminUser);
+    assertThat(responseAdminUser.getError()).as("get roles for user error").isNull();
+
+    List<Role> currentRoles = responseCurrent.getResult();
+    List<Role> adminRoles = responseAdminUser.getResult();
+
+    Assertions.assertArrayEquals(currentRoles.toArray(), adminRoles.toArray(), "expect same set of roles");
+  }
+
+  /** Admin user should have the admin role assigned to them. */
+  public void testGetAssignedUsers(Supplier<Rbac> rbac) {
+    Rbac roles = rbac.get();
+    Result<List<String>> response = roles.getAssignedUsers(adminRole);
+    assertThat(response.getError()).as("get assigned users error").isNull();
+
+    List<String> users = response.getResult();
+    assertThat(users).as("users assigned to " + adminRole + " role").hasSize(1);
+    assertEquals(adminUser, users.get(0), "wrong user assinged to " + adminRole + " role");
+  }
+
+  // TODO: check if I can create a role with a name that's not a valid URL
+  // paramter
+
+  /**
+   * Created role should have all of the permissions it was created with.
+   * Tests addition and fetching the role to.
+   */
+  @DataMethod(source = ClientRbacTestSuite.class, method = "clients")
+  @Test
+  public void testCreate(Supplier<Rbac> rbac) {
+    Rbac roles = rbac.get();
+    String myRole = roleName("VectorOwner");
+    String myCollection = "Pizza";
+
+    Permission<?>[] wantPermissions = new Permission<?>[] {
+        Permission.backups(BackupsPermission.Action.MANAGE, myCollection),
+        Permission.cluster(ClusterPermission.Action.READ),
+        Permission.nodes(NodesPermission.Action.READ, Verbosity.MINIMAL, myCollection),
+        Permission.roles(RolesPermission.Action.MANAGE, viewerRole),
+        Permission.collections(CollectionsPermission.Action.CREATE, myCollection),
+        Permission.data(DataPermission.Action.UPDATE, myCollection),
+        Permission.tenants(TenantsPermission.Action.DELETE),
+    };
+
+    try {
+      // Arrange
+      roles.deleteRole(myRole);
+
+      // Act
+      roles.createRole(myRole, wantPermissions);
+
+      Result<Role> response = roles.getRole(myRole);
+      Role role = response.getResult();
+      assertNull("error fetching a role", response.getError());
+      assertThat(role).as("wrong role name").returns(myRole, Role::getName);
+
+      for (int i = 0; i < wantPermissions.length; i++) {
+        Permission<?> perm = wantPermissions[i];
+        assertTrue("should have permission " + perm, checkHasPermission(roles, myRole, perm));
+      }
+    } finally {
+      roles.deleteRole(myRole);
+    }
+  }
+
+  /**
+   * Role can be extended with new permissions. We do not test the "upsert"
+   * behavior because it is the server's responsibility.
+   */
+  @DataMethod(source = ClientRbacTestSuite.class, method = "clients")
+  @Test
+  public void testAddPermissions(Supplier<Rbac> rbac) {
+    Rbac roles = rbac.get();
+    String myRole = roleName("VectorOwner");
+    Permission<?> toAdd = Permission.cluster(ClusterPermission.Action.READ);
+    try {
+      // Arrange
+      roles.createRole(myRole, Permission.tenants(TenantsPermission.Action.DELETE));
+
+      // Act
+      Result<?> response = roles.addPermissions(myRole, toAdd);
+      assertNull("add-permissions operation error", response.getError());
+
+      // Assert
+      assertTrue("should have permission " + toAdd, checkHasPermission(roles, myRole, toAdd));
+    } finally {
+      roles.deleteRole(myRole);
+    }
+  }
+
+  /**
+   * Permissions can be removed from a role.
+   * We do not test the "downsert" behavior, because it is the server's
+   * responsibility.
+   */
+  @DataMethod(source = ClientRbacTestSuite.class, method = "clients")
+  @Test
+  public void testRemovePermissions(Supplier<Rbac> rbac) {
+    Rbac roles = rbac.get();
+    String myRole = roleName("VectorOwner");
+    Permission<?> toRemove = Permission.tenants(TenantsPermission.Action.DELETE);
+    try {
+      // Arrange
+      roles.createRole(myRole,
+          Permission.cluster(ClusterPermission.Action.READ),
+          Permission.tenants(TenantsPermission.Action.DELETE));
+
+      // Act
+      Result<?> response = roles.removePermissions(myRole, toRemove);
+      assertNull("remove-permissions operation error", response.getError());
+
+      // Assert
+      assertFalse("should not have permission " + toRemove, checkHasPermission(roles, myRole, toRemove));
+    } finally {
+      roles.deleteRole(myRole);
+    }
+  }
+
+  /** User can be assigned a role and the role can be revoked. */
+  @DataMethod(source = ClientRbacTestSuite.class, method = "clients")
+  @Test
+  public void testAssignRevokeRole(Supplier<Rbac> rbac) {
+    Rbac roles = rbac.get();
+    String myRole = roleName("VectorOwner");
+    try {
+      // Arrange
+      roles.createRole(myRole, Permission.tenants(TenantsPermission.Action.DELETE));
+
+      // Act: Assign
+      roles.assignRoles(adminUser, myRole);
+      assumeTrue(checkHasRole(roles, adminUser, myRole), adminUser + " should have the assigned role");
+
+      // Act: Revoke
+      Result<?> response = roles.revokeRoles(adminUser, myRole);
+      assertNull("revoke operation error", response.getError());
+
+      // Assert
+      assertFalse("should not have " + myRole + " role", checkHasRole(roles, adminUser, myRole));
+    } finally {
+      roles.deleteRole(myRole);
+    }
+  }
+
+  /** Prefix the role with the name of the current test for easier debugging */
+  private String roleName(String name) {
+    return String.format("%s-%s", currentTest.getMethodName(), name);
+  }
+
+  private boolean checkHasPermission(Rbac roles, String role, Permission<? extends Permission<?>> perm) {
+    return roles.hasPermission(role, perm).getResult();
+  }
+
+  private boolean checkHasRole(Rbac roles, String user, String role) {
+    return roles.getAssignedUsers(role).getResult().contains(user);
+  }
+
+  /**
+   * Sync and async test suits should provide an implementation of this interface.
+   * This way the test suite can be written once with very little
+   * boilerplate/overhead.
+   */
+  public interface Rbac {
+    Result<Role> getRole(String role);
+
+    Result<List<Role>> getAll();
+
+    Result<List<Role>> getUserRoles();
+
+    Result<List<Role>> getUserRoles(String user);
+
+    Result<List<String>> getAssignedUsers(String role);
+
+    void createRole(String role, Permission<?>... permissions);
+
+    void deleteRole(String role);
+
+    Result<Boolean> hasPermission(String role, Permission<?> perm);
+
+    Result<Boolean> exists(String role);
+
+    Result<?> addPermissions(String role, Permission<?>... permissions);
+
+    Result<?> removePermissions(String role, Permission<?>... permissions);
+
+    Result<?> assignRoles(String user, String... roles);
+
+    Result<?> revokeRoles(String user, String... roles);
+  }
+
+}

--- a/src/test/java/io/weaviate/integration/tests/rbac/ClientRbacTestSuite.java
+++ b/src/test/java/io/weaviate/integration/tests/rbac/ClientRbacTestSuite.java
@@ -114,7 +114,7 @@ public class ClientRbacTestSuite {
     String myCollection = "Pizza";
 
     Permission<?>[][] wantPermissions = new Permission<?>[][] {
-        Permission.backups(BackupsPermission.Action.MANAGE, myCollection),
+        Permission.backups(myCollection, BackupsPermission.Action.MANAGE),
         Permission.cluster(ClusterPermission.Action.READ),
         Permission.nodes(myCollection, NodesPermission.Action.READ),
         Permission.roles(viewerRole, RolesPermission.Action.CREATE),

--- a/src/test/java/io/weaviate/integration/tests/rbac/ClientRbacTestSuite.java
+++ b/src/test/java/io/weaviate/integration/tests/rbac/ClientRbacTestSuite.java
@@ -22,7 +22,6 @@ import com.jparams.junit4.data.DataMethod;
 
 import io.weaviate.client.Config;
 import io.weaviate.client.base.Result;
-import io.weaviate.client.v1.auth.exception.AuthException;
 import io.weaviate.client.v1.rbac.model.BackupsPermission;
 import io.weaviate.client.v1.rbac.model.ClusterPermission;
 import io.weaviate.client.v1.rbac.model.CollectionsPermission;
@@ -56,14 +55,12 @@ public class ClientRbacTestSuite {
 
   public static Object[][] clients() {
     try {
-      Object[][] r = new Object[][] {
-          {
-              (Supplier<Rbac>) () -> new io.weaviate.integration.client.rbac.ClientRbacTest(config(), API_KEY) },
+      return new Object[][] {
+          { (Supplier<Rbac>) () -> new io.weaviate.integration.client.rbac.ClientRbacTest(config(), API_KEY) },
+          { (Supplier<Rbac>) () -> new io.weaviate.integration.client.async.rbac.ClientRbacTest(config(), API_KEY) }
       };
-      return r;
     } catch (Exception e) {
-      System.out.println(e.getMessage());
-      return null;
+      throw new RuntimeException(e);
     }
   }
 

--- a/src/test/java/io/weaviate/integration/tests/rbac/ClientRbacTestSuite.java
+++ b/src/test/java/io/weaviate/integration/tests/rbac/ClientRbacTestSuite.java
@@ -101,6 +101,8 @@ public class ClientRbacTestSuite {
   }
 
   /** Admin user should have the admin role assigned to them. */
+  @DataMethod(source = ClientRbacTestSuite.class, method = "clients")
+  @Test
   public void testGetAssignedUsers(Supplier<Rbac> rbac) {
     Rbac roles = rbac.get();
     Result<List<String>> response = roles.getAssignedUsers(adminRole);
@@ -227,6 +229,8 @@ public class ClientRbacTestSuite {
     try {
       // Arrange
       roles.createRole(myRole,
+          // Create an extra permission so that the role would not be
+          // deleted with its otherwise only permission is removed.
           Permission.cluster(ClusterPermission.Action.READ),
           Permission.tenants(TenantsPermission.Action.DELETE));
 

--- a/src/test/java/io/weaviate/integration/tests/rbac/ClientRbacTestSuite.java
+++ b/src/test/java/io/weaviate/integration/tests/rbac/ClientRbacTestSuite.java
@@ -130,7 +130,7 @@ public class ClientRbacTestSuite {
     Permission<?>[][] wantPermissions = new Permission<?>[][] {
         Permission.backups(BackupsPermission.Action.MANAGE, myCollection),
         Permission.cluster(ClusterPermission.Action.READ),
-        Permission.nodes(myCollection, Verbosity.MINIMAL, NodesPermission.Action.READ),
+        Permission.nodes(myCollection, NodesPermission.Action.READ),
         Permission.roles(viewerRole, RolesPermission.Action.MANAGE),
         Permission.collections(myCollection, CollectionsPermission.Action.CREATE),
         Permission.data(myCollection, DataPermission.Action.UPDATE),

--- a/src/test/java/io/weaviate/integration/tests/users/ClientUsersTestSuite.java
+++ b/src/test/java/io/weaviate/integration/tests/users/ClientUsersTestSuite.java
@@ -1,0 +1,132 @@
+package io.weaviate.integration.tests.users;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.testcontainers.weaviate.WeaviateContainer;
+
+import com.jparams.junit4.JParamsTestRunner;
+import com.jparams.junit4.data.DataMethod;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.rbac.model.Permission;
+import io.weaviate.client.v1.rbac.model.Role;
+import io.weaviate.client.v1.rbac.model.TenantsPermission;
+import io.weaviate.integration.client.WeaviateDockerImage;
+import io.weaviate.integration.client.WeaviateWithRbacContainer;
+import io.weaviate.integration.tests.rbac.ClientRbacTestSuite;
+
+@RunWith(JParamsTestRunner.class)
+public class ClientUsersTestSuite {
+
+  private static final String adminUser = "john-doe";
+  private static final String API_KEY = WeaviateWithRbacContainer.makeSecret(adminUser);
+
+  @Rule
+  public TestName currentTest = new TestName();
+
+  @ClassRule
+  public static WeaviateContainer weaviate = new WeaviateWithRbacContainer(
+      WeaviateDockerImage.WEAVIATE_DOCKER_IMAGE,
+      adminUser);
+
+  public static Config config() {
+    return new Config("http", weaviate.getHttpHostAddress());
+  }
+
+  public static Object[][] clients() {
+    try {
+      return new Object[][] {
+          { (Supplier<Users>) () -> new io.weaviate.integration.client.users.ClientUsersTest(config(), API_KEY) },
+          { (Supplier<Users>) () -> new io.weaviate.integration.client.async.users.ClientUsersTest(config(), API_KEY) }
+      };
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Roles retrieved for "current user" should be identical to the ones
+   * retrieved for them explicitly (by passing the username).
+   */
+  @Ignore // wip
+  @DataMethod(source = ClientUsersTestSuite.class, method = "clients")
+  @Test
+  public void testGetUserRoles(Supplier<Users> rbac) {
+    Users roles = rbac.get();
+    // Result<List<Role>> responseCurrent = roles.getUserRoles();
+    // assertThat(responseCurrent.getError()).as("get roles for current user
+    // error").isNull();
+    // Result<List<Role>> responseAdminUser = roles.getUserRoles(adminUser);
+    // assertThat(responseAdminUser.getError()).as("get roles for user
+    // error").isNull();
+    //
+    // List<Role> currentRoles = responseCurrent.getResult();
+    // List<Role> adminRoles = responseAdminUser.getResult();
+    //
+    // Assertions.assertArrayEquals(currentRoles.toArray(), adminRoles.toArray(),
+    // "expect same set of roles");
+  }
+
+  /** User can be assigned a role and the role can be revoked. */
+  @DataMethod(source = ClientUsersTestSuite.class, method = "clients")
+  @Test
+  public void testAssignRevokeRole(Supplier<Users> rbac) {
+    Users roles = rbac.get();
+    String myRole = roleName("VectorOwner");
+    try {
+      // Arrange
+      roles.createRole(myRole, Permission.tenants(TenantsPermission.Action.DELETE));
+
+      // Act: Assign
+      roles.assignRoles(adminUser, myRole);
+      assumeTrue(checkHasRole(roles, adminUser, myRole), adminUser + " should have the assigned role");
+
+      // Act: Revoke
+      Result<?> response = roles.revokeRoles(adminUser, myRole);
+      assertNull("revoke operation error", response.getError());
+
+      // Assert
+      assertFalse("should not have " + myRole + " role", checkHasRole(roles, adminUser, myRole));
+    } finally {
+      roles.deleteRole(myRole);
+    }
+  }
+
+  /** Prefix the role with the name of the current test for easier debugging */
+  private String roleName(String name) {
+    return String.format("%s-%s", currentTest.getMethodName(), name);
+  }
+
+  private boolean checkHasRole(Users roles, String user, String role) {
+    return roles.getAssignedUsers(role).getResult().contains(user);
+  }
+
+  /**
+   * Sync and async test suits should provide an implementation of this interface.
+   * This way the test suite can be written once with very little
+   * boilerplate/overhead.
+   *
+   * Extends {@link ClientRbacTestSuite.Rbac} because many tests require the
+   * functionality for creating / deleting / verifying roles.
+   */
+  public interface Users extends ClientRbacTestSuite.Rbac {
+    Result<List<Role>> getUserRoles(String user);
+
+    Result<?> assignRoles(String user, String... roles);
+
+    Result<?> revokeRoles(String user, String... roles);
+  }
+
+}

--- a/src/test/java/io/weaviate/integration/tests/users/ClientUsersTestSuite.java
+++ b/src/test/java/io/weaviate/integration/tests/users/ClientUsersTestSuite.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.util.List;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -70,7 +71,7 @@ public class ClientUsersTestSuite {
     Result<List<Role>> responseAdminUser = users.getUserRoles(adminUser);
     assertNull("get roles for user error", responseAdminUser.getError());
 
-    List<Role> currentRoles = myUser.getResult().getRoles().values().stream().toList();
+    List<Role> currentRoles = myUser.getResult().getRoles().values().stream().collect(Collectors.toList());
     List<Role> adminRoles = responseAdminUser.getResult();
 
     Assertions.assertArrayEquals(currentRoles.toArray(), adminRoles.toArray(),


### PR DESCRIPTION
Related to https://github.com/weaviate/java-client/issues/343.

This PR is the first iteration of that story, adding RBAC support to the sync client.
Initially it drew a lot on the Python's client, but I ended up re-organizing things to be consistent with the current client.

- Adds support for RBAC endpoints via `client.async().roles()` 
- Unified integration test suite for sync and async clients -- would love to hear your opinion on that.

Files to pay attention to (have denser logic):

Permission.java
WeaviatePermission.java
Role.java
WeaviateRole.java
ClientRbacTestSuite.java
