### PR TITLE
fix: migrate actions/upload-artifact and actions/download-artifact to v4

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -27,7 +27,7 @@ jobs:
           mvn -DskipTests clean package
           mvn -s settings.xml deploy
       - name: Archive artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jar-files
           path: "target/*.jar"
@@ -39,7 +39,7 @@ jobs:
     needs: [ release ]
     steps:
       - name: Download artifacts to append to release
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: jar-files
           path: target


### PR DESCRIPTION
[`create-release` job is failing](https://github.com/weaviate/java-client/actions/runs/13413826836) because v3 support has been discontinued and we need to migrate `actions/upload-artifact` and `actions/download-artifact` to v4.

One major change in v4 is that, with artifacts now being immutable, multiple jobs cannot write to the same artifact location (same goes for jobs parametrized by a matrix). That is not the case for us, so this should be as simple as upgrading the version.

[Migration guide](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#multiple-uploads-to-the-same-named-artifact) for reference.