### PR TITLE
feat(ColBERT): Create, update, batch insert, and query objects with multi-vector indices 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -345,6 +345,8 @@
           </executions>
           <configuration>
             <sourcepath>${project.build.directory}/delombok</sourcepath>
+            <!--Disable warnings about missing docstrings.-->
+            <doclint>all,-missing</doclint>
           </configuration>
         </plugin>
         <plugin>

--- a/src/main/java/io/weaviate/client/base/BaseClient.java
+++ b/src/main/java/io/weaviate/client/base/BaseClient.java
@@ -46,6 +46,10 @@ public abstract class BaseClient<T> {
       HttpResponse response = this.sendHttpRequest(endpoint, payload, method);
       int statusCode = response.getStatusCode();
       String responseBody = response.getBody();
+
+      if (endpoint.contains("objects")) {
+        System.out.printf("%s %s:\n\t%s\n", method, endpoint, responseBody);
+      }
       if (statusCode < 399) {
         T body = toResponse(responseBody, classOfT);
         return new Response<>(statusCode, body, null);

--- a/src/main/java/io/weaviate/client/base/BaseClient.java
+++ b/src/main/java/io/weaviate/client/base/BaseClient.java
@@ -46,10 +46,6 @@ public abstract class BaseClient<T> {
       HttpResponse response = this.sendHttpRequest(endpoint, payload, method);
       int statusCode = response.getStatusCode();
       String responseBody = response.getBody();
-
-      if (endpoint.contains("objects")) {
-        System.out.printf("%s %s:\n\t%s\n", method, endpoint, responseBody);
-      }
       if (statusCode < 399) {
         T body = toResponse(responseBody, classOfT);
         return new Response<>(statusCode, body, null);

--- a/src/main/java/io/weaviate/client/base/Serializer.java
+++ b/src/main/java/io/weaviate/client/base/Serializer.java
@@ -1,27 +1,33 @@
 package io.weaviate.client.base;
 
+import java.lang.reflect.Type;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
+
 import io.weaviate.client.base.util.GroupHitDeserializer;
+import io.weaviate.client.v1.data.model.WeaviateObject;
 import io.weaviate.client.v1.graphql.model.GraphQLGetBaseObject;
 import io.weaviate.client.v1.graphql.model.GraphQLTypedResponse;
-import java.lang.reflect.Type;
 
 public class Serializer {
   private Gson gson;
 
   public Serializer() {
-    this.gson = new GsonBuilder().disableHtmlEscaping().create();
+    this.gson = new GsonBuilder()
+        .disableHtmlEscaping()
+        .registerTypeAdapter(WeaviateObject.class, WeaviateObject.Adapter.INSTANCE)
+        .create();
   }
 
   public <C> GraphQLTypedResponse<C> toGraphQLTypedResponse(String response, Class<C> classOfT) {
     Gson gsonTyped = new GsonBuilder()
-      .disableHtmlEscaping()
-      .registerTypeAdapter(GraphQLGetBaseObject.Additional.Group.GroupHit.class, new GroupHitDeserializer())
-      .create();
+        .disableHtmlEscaping()
+        .registerTypeAdapter(GraphQLGetBaseObject.Additional.Group.GroupHit.class, new GroupHitDeserializer())
+        .create();
     return gsonTyped.fromJson(response,
-      TypeToken.getParameterized(GraphQLTypedResponse.class, classOfT).getType());
+        TypeToken.getParameterized(GraphQLTypedResponse.class, classOfT).getType());
   }
 
   public <C> C toResponse(String response, Type typeOfT) {

--- a/src/main/java/io/weaviate/client/v1/async/data/api/ObjectCreator.java
+++ b/src/main/java/io/weaviate/client/v1/async/data/api/ObjectCreator.java
@@ -1,5 +1,13 @@
 package io.weaviate.client.v1.async.data.api;
 
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Future;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+
 import io.weaviate.client.Config;
 import io.weaviate.client.base.AsyncBaseClient;
 import io.weaviate.client.base.AsyncClientResult;
@@ -7,12 +15,6 @@ import io.weaviate.client.base.Result;
 import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 import io.weaviate.client.v1.data.model.WeaviateObject;
 import io.weaviate.client.v1.data.util.ObjectsPath;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.Future;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
-import org.apache.hc.core5.concurrent.FutureCallback;
 
 public class ObjectCreator extends AsyncBaseClient<WeaviateObject> implements AsyncClientResult<WeaviateObject> {
   private final ObjectsPath objectsPath;
@@ -24,7 +26,8 @@ public class ObjectCreator extends AsyncBaseClient<WeaviateObject> implements As
   private Float[] vector;
   private Map<String, Float[]> vectors;
 
-  public ObjectCreator(CloseableHttpAsyncClient client, Config config, AccessTokenProvider tokenProvider, ObjectsPath objectsPath) {
+  public ObjectCreator(CloseableHttpAsyncClient client, Config config, AccessTokenProvider tokenProvider,
+      ObjectsPath objectsPath) {
     super(client, config, tokenProvider);
     this.objectsPath = objectsPath;
   }
@@ -74,16 +77,16 @@ public class ObjectCreator extends AsyncBaseClient<WeaviateObject> implements As
   @Override
   public Future<Result<WeaviateObject>> run(FutureCallback<Result<WeaviateObject>> callback) {
     String path = objectsPath.buildCreate(ObjectsPath.Params.builder()
-      .consistencyLevel(consistencyLevel)
-      .build());
+        .consistencyLevel(consistencyLevel)
+        .build());
     WeaviateObject obj = WeaviateObject.builder()
-      .className(className)
-      .properties(properties)
-      .vector(vector)
-      .vectors(vectors)
-      .id(getID())
-      .tenant(tenant)
-      .build();
+        .className(className)
+        .properties(properties)
+        .vector(vector)
+        .vectors(vectors)
+        .id(getID())
+        .tenant(tenant)
+        .build();
     return sendPostRequest(path, obj, WeaviateObject.class, callback);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/async/data/api/ObjectCreator.java
+++ b/src/main/java/io/weaviate/client/v1/async/data/api/ObjectCreator.java
@@ -25,6 +25,7 @@ public class ObjectCreator extends AsyncBaseClient<WeaviateObject> implements As
   private Map<String, Object> properties;
   private Float[] vector;
   private Map<String, Float[]> vectors;
+  private Map<String, Float[][]> multiVectors;
 
   public ObjectCreator(CloseableHttpAsyncClient client, Config config, AccessTokenProvider tokenProvider,
       ObjectsPath objectsPath) {
@@ -67,6 +68,11 @@ public class ObjectCreator extends AsyncBaseClient<WeaviateObject> implements As
     return this;
   }
 
+  public ObjectCreator withMultiVectors(Map<String, Float[][]> multiVectors) {
+    this.multiVectors = multiVectors;
+    return this;
+  }
+
   private String getID() {
     if (StringUtils.isEmpty(id)) {
       return UUID.randomUUID().toString();
@@ -84,6 +90,7 @@ public class ObjectCreator extends AsyncBaseClient<WeaviateObject> implements As
         .properties(properties)
         .vector(vector)
         .vectors(vectors)
+        .multiVectors(multiVectors)
         .id(getID())
         .tenant(tenant)
         .build();

--- a/src/main/java/io/weaviate/client/v1/batch/model/ObjectGetResponse.java
+++ b/src/main/java/io/weaviate/client/v1/batch/model/ObjectGetResponse.java
@@ -1,15 +1,16 @@
 package io.weaviate.client.v1.batch.model;
 
+import java.util.Map;
+
 import com.google.gson.annotations.SerializedName;
+
+import io.weaviate.client.v1.data.model.Deprecation;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.FieldDefaults;
-import io.weaviate.client.v1.data.model.Deprecation;
-
-import java.util.Map;
 
 @Getter
 @Setter
@@ -25,6 +26,9 @@ public class ObjectGetResponse {
   Map<String, Object> properties;
   Map<String, Object> additional;
   Float[] vector;
+  Float[][] multiVector;
+  Map<String, Float[]> vectors;
+  Map<String, Float[][]> multiVectors;
   Object vectorWeights;
   String tenant;
 

--- a/src/main/java/io/weaviate/client/v1/data/api/ObjectCreator.java
+++ b/src/main/java/io/weaviate/client/v1/data/api/ObjectCreator.java
@@ -24,7 +24,6 @@ public class ObjectCreator extends BaseClient<WeaviateObject> implements ClientR
   private String tenant;
   private Map<String, Object> properties;
   private Float[] vector;
-  private Float[][] multiVector;
   private Map<String, Float[]> vectors;
   private Map<String, Float[][]> multiVectors;
 
@@ -60,11 +59,6 @@ public class ObjectCreator extends BaseClient<WeaviateObject> implements ClientR
 
   public ObjectCreator withVector(Float[] vector) {
     this.vector = vector;
-    return this;
-  }
-
-  public ObjectCreator withMultiVector(Float[][] multiVector) {
-    this.multiVector = multiVector;
     return this;
   }
 

--- a/src/main/java/io/weaviate/client/v1/data/api/ObjectCreator.java
+++ b/src/main/java/io/weaviate/client/v1/data/api/ObjectCreator.java
@@ -1,12 +1,11 @@
 package io.weaviate.client.v1.data.api;
 
-import io.weaviate.client.v1.data.util.ObjectsPath;
-
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
+
 import io.weaviate.client.Config;
 import io.weaviate.client.base.BaseClient;
 import io.weaviate.client.base.ClientResult;
@@ -14,6 +13,7 @@ import io.weaviate.client.base.Response;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.base.http.HttpClient;
 import io.weaviate.client.v1.data.model.WeaviateObject;
+import io.weaviate.client.v1.data.util.ObjectsPath;
 
 public class ObjectCreator extends BaseClient<WeaviateObject> implements ClientResult<WeaviateObject> {
 
@@ -24,7 +24,9 @@ public class ObjectCreator extends BaseClient<WeaviateObject> implements ClientR
   private String tenant;
   private Map<String, Object> properties;
   private Float[] vector;
+  private Float[][] multiVector;
   private Map<String, Float[]> vectors;
+  private Map<String, Float[][]> multiVectors;
 
   public ObjectCreator(HttpClient httpClient, Config config, ObjectsPath objectsPath) {
     super(httpClient, config);
@@ -61,8 +63,18 @@ public class ObjectCreator extends BaseClient<WeaviateObject> implements ClientR
     return this;
   }
 
+  public ObjectCreator withMultiVector(Float[][] multiVector) {
+    this.multiVector = multiVector;
+    return this;
+  }
+
   public ObjectCreator withVectors(Map<String, Float[]> vectors) {
     this.vectors = vectors;
+    return this;
+  }
+
+  public ObjectCreator withMultiVectors(Map<String, Float[][]> multiVectors) {
+    this.multiVectors = multiVectors;
     return this;
   }
 
@@ -76,16 +88,17 @@ public class ObjectCreator extends BaseClient<WeaviateObject> implements ClientR
   @Override
   public Result<WeaviateObject> run() {
     String path = objectsPath.buildCreate(ObjectsPath.Params.builder()
-      .consistencyLevel(consistencyLevel)
-      .build());
+        .consistencyLevel(consistencyLevel)
+        .build());
     WeaviateObject obj = WeaviateObject.builder()
-      .className(className)
-      .properties(properties)
-      .vector(vector)
-      .vectors(vectors)
-      .id(getID())
-      .tenant(tenant)
-      .build();
+        .className(className)
+        .properties(properties)
+        .vector(vector)
+        .vectors(vectors)
+        .multiVectors(multiVectors)
+        .id(getID())
+        .tenant(tenant)
+        .build();
     Response<WeaviateObject> resp = sendPostRequest(path, obj, WeaviateObject.class);
     return new Result<>(resp);
   }

--- a/src/main/java/io/weaviate/client/v1/data/api/ObjectsGetter.java
+++ b/src/main/java/io/weaviate/client/v1/data/api/ObjectsGetter.java
@@ -1,6 +1,5 @@
 package io.weaviate.client.v1.data.api;
 
-import io.weaviate.client.v1.data.util.ObjectsPath;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -8,14 +7,16 @@ import java.util.List;
 import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
+
 import io.weaviate.client.Config;
 import io.weaviate.client.base.BaseClient;
 import io.weaviate.client.base.ClientResult;
 import io.weaviate.client.base.Response;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.base.http.HttpClient;
-import io.weaviate.client.v1.data.model.WeaviateObject;
 import io.weaviate.client.v1.data.model.ObjectsListResponse;
+import io.weaviate.client.v1.data.model.WeaviateObject;
+import io.weaviate.client.v1.data.util.ObjectsPath;
 
 public class ObjectsGetter extends BaseClient<ObjectsListResponse> implements ClientResult<List<WeaviateObject>> {
 
@@ -29,6 +30,7 @@ public class ObjectsGetter extends BaseClient<ObjectsListResponse> implements Cl
   private String consistencyLevel;
   private String tenant;
   private String nodeName;
+
   private class ObjectGetter extends BaseClient<WeaviateObject> implements ClientResult<List<WeaviateObject>> {
     private String path;
 
@@ -46,8 +48,8 @@ public class ObjectsGetter extends BaseClient<ObjectsListResponse> implements Cl
       Response<WeaviateObject> resp = sendGetRequest(path, WeaviateObject.class);
       WeaviateObject object = resp.getBody();
       List<WeaviateObject> objects = object == null
-        ? null
-        : Collections.singletonList(object);
+          ? null
+          : Collections.singletonList(object);
       return new Result<>(resp.getStatusCode(), objects, resp.getErrors());
     }
   }
@@ -114,23 +116,24 @@ public class ObjectsGetter extends BaseClient<ObjectsListResponse> implements Cl
   @Override
   public Result<List<WeaviateObject>> run() {
     ObjectsPath.Params params = ObjectsPath.Params.builder()
-            .id(id)
-            .className(className)
-            .limit(limit)
-            .offset(offset)
-            .after(after)
-            .additional(additional.toArray(new String[0]))
-            .consistencyLevel(consistencyLevel)
-            .tenant(tenant)
-            .nodeName(nodeName)
-            .build();
+        .id(id)
+        .className(className)
+        .limit(limit)
+        .offset(offset)
+        .after(after)
+        .additional(additional.toArray(new String[0]))
+        .consistencyLevel(consistencyLevel)
+        .tenant(tenant)
+        .nodeName(nodeName)
+        .build();
     if (StringUtils.isNotBlank(id)) {
       return this.objectGetter.withPath(objectsPath.buildGetOne(params)).run();
     }
     Response<ObjectsListResponse> resp = sendGetRequest(objectsPath.buildGet(params), ObjectsListResponse.class);
     List<WeaviateObject> objects = resp.getBody() == null
-      ? null
-      : Arrays.asList(resp.getBody().getObjects());
+        ? null
+        : Arrays.asList(resp.getBody().getObjects());
+
     return new Result<>(resp.getStatusCode(), objects, resp.getErrors());
   }
 }

--- a/src/main/java/io/weaviate/client/v1/data/model/WeaviateObject.java
+++ b/src/main/java/io/weaviate/client/v1/data/model/WeaviateObject.java
@@ -3,16 +3,22 @@ package io.weaviate.client.v1.data.model;
 import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.TypeAdapterFactory;
 import com.google.gson.annotations.SerializedName;
 
+import io.weaviate.client.v1.graphql.query.util.Serializer;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -54,15 +60,35 @@ public class WeaviateObject {
   Object vectorWeights;
   String tenant;
 
-  public static class Adapter implements JsonDeserializer<WeaviateObject> {
+  public static class Adapter implements JsonSerializer<WeaviateObject>, JsonDeserializer<WeaviateObject> {
     public static final Adapter INSTANCE = new Adapter();
 
     /**
      * This Gson instance does not have the {@link Adapter} registerred allowing us
      * to deserialize remaining {@link WeaviateObject} fields in a standard manner
      * without causing an infinite recursion.
+     *
+     * Mimicking {@link Serializer}, we disable HTML escaping to produce identical
+     * results. Thankfully, its configuration is not too involved, so we can
+     * tolerate this duplication. In the future, {@link Adapter} should be rewritten
+     * to implement {@link TypeAdapterFactory}, so that the singleton instance can
+     * be re-used in this context too.
      */
-    private static final Gson gson = new Gson();
+    private static final Gson gson = new GsonBuilder().disableHtmlEscaping().create();
+
+    @Override
+    public JsonElement serialize(WeaviateObject src, Type typeOfSrc, JsonSerializationContext ctx) {
+      JsonObject result = gson.toJsonTree(src).getAsJsonObject();
+      JsonObject vectors = result.getAsJsonObject("vectors");
+
+      // Add multi-vectors to the named vectors map.
+      for (Entry<String, Float[][]> entry : src.multiVectors.entrySet()) {
+        String name = entry.getKey();
+        JsonElement vector = gson.toJsonTree(entry.getValue());
+        vectors.add(name, vector);
+      }
+      return result;
+    }
 
     @Override
     public WeaviateObject deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext ctx)
@@ -70,7 +96,10 @@ public class WeaviateObject {
       JsonObject jsonObject = json.getAsJsonObject();
 
       // Handle polymorphic "vectors" separately from the rest of the fields.
-      JsonObject vectorsField = jsonObject.remove("vectors").getAsJsonObject();
+      Map<String, JsonElement> vectorsMap = new HashMap<>();
+      if (jsonObject.has("vectors")) {
+        vectorsMap = jsonObject.remove("vectors").getAsJsonObject().asMap();
+      }
       WeaviateObject result = gson.fromJson(jsonObject, WeaviateObject.class);
 
       if (result.vectors == null) {
@@ -80,19 +109,18 @@ public class WeaviateObject {
         result.multiVectors = new HashMap<>();
       }
 
-      vectorsField.asMap().entrySet().stream()
-          .forEach(entry -> {
-            String name = entry.getKey();
-            JsonElement el = entry.getValue();
-            if (el.isJsonArray()) {
-              JsonArray array = el.getAsJsonArray();
-              if (array.size() > 0 && array.get(0).isJsonArray()) {
-                result.multiVectors.put(name, ctx.deserialize(array, Float[][].class));
-              } else {
-                result.vectors.put(name, ctx.deserialize(array, Float[].class));
-              }
-            }
-          });
+      for (Entry<String, JsonElement> entry : vectorsMap.entrySet()) {
+        String name = entry.getKey();
+        JsonElement el = entry.getValue();
+        if (el.isJsonArray()) {
+          JsonArray array = el.getAsJsonArray();
+          if (array.size() > 0 && array.get(0).isJsonArray()) {
+            result.multiVectors.put(name, ctx.deserialize(array, Float[][].class));
+          } else {
+            result.vectors.put(name, ctx.deserialize(array, Float[].class));
+          }
+        }
+      }
 
       return result;
     }

--- a/src/main/java/io/weaviate/client/v1/data/model/WeaviateObject.java
+++ b/src/main/java/io/weaviate/client/v1/data/model/WeaviateObject.java
@@ -1,6 +1,18 @@
 package io.weaviate.client.v1.data.model;
 
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 import com.google.gson.annotations.SerializedName;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -8,8 +20,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.FieldDefaults;
-
-import java.util.Map;
 
 @Getter
 @Setter
@@ -25,8 +35,66 @@ public class WeaviateObject {
   Long lastUpdateTimeUnix;
   Map<String, Object> properties;
   Map<String, Object> additional;
+
+  /**
+   * Unnamed (default) vector.
+   * <p>
+   * This field will be deprecated in later versions.
+   * Prefer using {@link #vectors} for collections storing a single vector only.
+   */
   Float[] vector;
-  Map<String, Float[]> vectors;
+
+  /** Named vectors. */
+  @Builder.Default
+  Map<String, Float[]> vectors = new HashMap<>();
+
+  /** Named multivectors. */
+  @Builder.Default
+  transient Map<String, Float[][]> multiVectors = new HashMap<>();
   Object vectorWeights;
   String tenant;
+
+  public static class Adapter implements JsonDeserializer<WeaviateObject> {
+    public static final Adapter INSTANCE = new Adapter();
+
+    /**
+     * This Gson instance does not have the {@link Adapter} registerred allowing us
+     * to deserialize remaining {@link WeaviateObject} fields in a standard manner
+     * without causing an infinite recursion.
+     */
+    private static final Gson gson = new Gson();
+
+    @Override
+    public WeaviateObject deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext ctx)
+        throws JsonParseException {
+      JsonObject jsonObject = json.getAsJsonObject();
+
+      // Handle polymorphic "vectors" separately from the rest of the fields.
+      JsonObject vectorsField = jsonObject.remove("vectors").getAsJsonObject();
+      WeaviateObject result = gson.fromJson(jsonObject, WeaviateObject.class);
+
+      if (result.vectors == null) {
+        result.vectors = new HashMap<>();
+      }
+      if (result.multiVectors == null) {
+        result.multiVectors = new HashMap<>();
+      }
+
+      vectorsField.asMap().entrySet().stream()
+          .forEach(entry -> {
+            String name = entry.getKey();
+            JsonElement el = entry.getValue();
+            if (el.isJsonArray()) {
+              JsonArray array = el.getAsJsonArray();
+              if (array.size() > 0 && array.get(0).isJsonArray()) {
+                result.multiVectors.put(name, ctx.deserialize(array, Float[][].class));
+              } else {
+                result.vectors.put(name, ctx.deserialize(array, Float[].class));
+              }
+            }
+          });
+
+      return result;
+    }
+  }
 }

--- a/src/main/java/io/weaviate/client/v1/data/model/WeaviateObject.java
+++ b/src/main/java/io/weaviate/client/v1/data/model/WeaviateObject.java
@@ -79,13 +79,19 @@ public class WeaviateObject {
     @Override
     public JsonElement serialize(WeaviateObject src, Type typeOfSrc, JsonSerializationContext ctx) {
       JsonObject result = gson.toJsonTree(src).getAsJsonObject();
-      JsonObject vectors = result.getAsJsonObject("vectors");
 
       // Add multi-vectors to the named vectors map.
-      for (Entry<String, Float[][]> entry : src.multiVectors.entrySet()) {
-        String name = entry.getKey();
-        JsonElement vector = gson.toJsonTree(entry.getValue());
-        vectors.add(name, vector);
+      if (src.multiVectors != null) {
+        if (!result.has("vectors")) {
+          result.add("vectors", new JsonObject());
+        }
+        JsonObject vectors = result.getAsJsonObject("vectors");
+
+        for (Entry<String, Float[][]> entry : src.multiVectors.entrySet()) {
+          String name = entry.getKey();
+          JsonElement vector = gson.toJsonTree(entry.getValue());
+          vectors.add(name, vector);
+        }
       }
       return result;
     }

--- a/src/main/java/io/weaviate/client/v1/graphql/query/argument/NearVectorArgument.java
+++ b/src/main/java/io/weaviate/client/v1/graphql/query/argument/NearVectorArgument.java
@@ -26,7 +26,7 @@ public class NearVectorArgument implements Argument {
   /** One-dimensional search vector. */
   Float[] vector;
   /** Multi-dimensional search vector. */
-  Float[][] vectors;
+  Float[][] multiVector;
   Float certainty;
   Float distance;
   String[] targetVectors;
@@ -39,8 +39,8 @@ public class NearVectorArgument implements Argument {
 
     if (vector != null) {
       arg.add(String.format("vector:%s", Serializer.array(vector)));
-    } else if (vectors != null) {
-      arg.add(String.format("vector:%s", Serializer.array(vectors)));
+    } else if (multiVector != null) {
+      arg.add(String.format("vector:%s", Serializer.array(multiVector)));
     }
     if (certainty != null) {
       arg.add(String.format("certainty:%s", certainty));
@@ -124,13 +124,13 @@ public class NearVectorArgument implements Argument {
       return this;
     }
 
-    public NearVectorArgumentBuilder vector(Float[][] vectors) {
-      this.vectors = vectors;
+    public NearVectorArgumentBuilder vector(Float[][] multiVector) {
+      this.multiVector = multiVector;
       return this;
     }
 
     /** Hide this method to promote the overloaded {@link #vector(Float[][])}. */
-    private NearVectorArgumentBuilder vectors(Float[][] _vectors) {
+    private NearVectorArgumentBuilder multiVector(Float[][] _vectors) {
       return this;
     }
   }

--- a/src/main/java/io/weaviate/client/v1/graphql/query/argument/NearVectorArgument.java
+++ b/src/main/java/io/weaviate/client/v1/graphql/query/argument/NearVectorArgument.java
@@ -1,19 +1,21 @@
 package io.weaviate.client.v1.graphql.query.argument;
 
-import io.weaviate.client.v1.graphql.query.util.Serializer;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import io.weaviate.client.v1.graphql.query.util.Serializer;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.experimental.FieldDefaults;
-import org.apache.commons.lang3.ArrayUtils;
 
 @Getter
 @Builder
@@ -21,7 +23,10 @@ import org.apache.commons.lang3.ArrayUtils;
 @EqualsAndHashCode
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public class NearVectorArgument implements Argument {
+  /** One-dimensional search vector. */
   Float[] vector;
+  /** Multi-dimensional search vector. */
+  Float[][] vectors;
   Float certainty;
   Float distance;
   String[] targetVectors;
@@ -34,6 +39,8 @@ public class NearVectorArgument implements Argument {
 
     if (vector != null) {
       arg.add(String.format("vector:%s", Serializer.array(vector)));
+    } else if (vectors != null) {
+      arg.add(String.format("vector:%s", Serializer.array(vectors)));
     }
     if (certainty != null) {
       arg.add(String.format("certainty:%s", certainty));
@@ -48,7 +55,8 @@ public class NearVectorArgument implements Argument {
       Set<String> vectorPerTargetArg = new LinkedHashSet<>();
       for (Map.Entry<String, Float[][]> e : vectorsPerTarget.entrySet()) {
         Float[][] vectors = e.getValue();
-        vectorPerTargetArg.add(String.format("%s:%s", e.getKey(), vectors.length == 1 ? Serializer.array(vectors[0]) : Serializer.array(vectors)));
+        vectorPerTargetArg.add(String.format("%s:%s", e.getKey(),
+            vectors.length == 1 ? Serializer.array(vectors[0]) : Serializer.array(vectors)));
       }
       arg.add(String.format("vectorPerTarget:{%s}", String.join(" ", vectorPerTargetArg)));
     }
@@ -60,24 +68,24 @@ public class NearVectorArgument implements Argument {
   }
 
   /**
-   * withValidTargetVectors makes sure the target names are repeated for each target vector,
+   * withValidTargetVectors makes sure the target names are repeated for each
+   * target vector,
    * which is required by server, but may be easily overlooked by the user.
    *
    * <p>
-   * Note, too, that in case the user fails to pass a value in targetVectors altogether, it will not be added to the query.
+   * Note, too, that in case the user fails to pass a value in targetVectors
+   * altogether, it will not be added to the query.
    *
    * @return A copy of the Targets with validated target vectors.
    */
   private Targets withValidTargetVectors(Targets targets) {
-    return Targets.builder().
-      combinationMethod(targets.getCombinationMethod()).
-      weightsMulti(targets.getWeights()).
-      targetVectors(prepareTargetVectors(targets.getTargetVectors())).
-      build();
+    return Targets.builder().combinationMethod(targets.getCombinationMethod()).weightsMulti(targets.getWeights())
+        .targetVectors(prepareTargetVectors(targets.getTargetVectors())).build();
   }
 
   /**
-   * prepareTargetVectors adds appends the target name for each target vector associated with it.
+   * prepareTargetVectors adds appends the target name for each target vector
+   * associated with it.
    */
   private String[] prepareTargetVectors(String[] targets) {
     List<String> out = new ArrayList<>();
@@ -101,13 +109,28 @@ public class NearVectorArgument implements Argument {
     public NearVectorArgumentBuilder vectorPerTarget(Map<String, Float[]> vectors) {
       this.vectorsPerTarget.clear(); // Overwrite the existing entries each time this is called.
       for (Map.Entry<String, Float[]> e : vectors.entrySet()) {
-        this.vectorsPerTarget.put(e.getKey(), new Float[][]{e.getValue()});
+        this.vectorsPerTarget.put(e.getKey(), new Float[][] { e.getValue() });
       }
       return this;
     }
 
     public NearVectorArgumentBuilder vectorsPerTarget(Map<String, Float[][]> vectors) {
       this.vectorsPerTarget = vectors;
+      return this;
+    }
+
+    public NearVectorArgumentBuilder vector(Float[] vector) {
+      this.vector = vector;
+      return this;
+    }
+
+    public NearVectorArgumentBuilder vector(Float[][] vectors) {
+      this.vectors = vectors;
+      return this;
+    }
+
+    /** Hide this method to promote the overloaded {@link #vector(Float[][])}. */
+    private NearVectorArgumentBuilder vectors(Float[][] _vectors) {
       return this;
     }
   }

--- a/src/main/java/io/weaviate/client/v1/grpc/GRPC.java
+++ b/src/main/java/io/weaviate/client/v1/grpc/GRPC.java
@@ -2,6 +2,7 @@ package io.weaviate.client.v1.grpc;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.FloatBuffer;
 import java.util.Arrays;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -41,12 +42,17 @@ public class GRPC {
     return new GRPC.Arguments();
   }
 
+  /** Encode Float[] to ByteString. */
   public static ByteString toByteString(Float[] vector) {
+    if (vector == null || vector.length == 0) {
+      return ByteString.EMPTY;
+    }
     ByteBuffer buffer = ByteBuffer.allocate(vector.length * Float.BYTES).order(BYTE_ORDER);
     Arrays.stream(vector).forEach(buffer::putFloat);
     return ByteString.copyFrom(buffer.array());
   }
 
+  /** Encode float[] to ByteString. */
   public static ByteString toByteString(float[] vector) {
     ByteBuffer buffer = ByteBuffer.allocate(vector.length * Float.BYTES).order(BYTE_ORDER);
     for (float f : vector) {
@@ -55,6 +61,31 @@ public class GRPC {
     return ByteString.copyFrom(buffer.array());
   }
 
+  /**
+   * Encode Float[][] to ByteString.
+   * <p>
+   * The first 2 bytes of the resulting ByteString encode the number of dimensions
+   * (uint16 / short) followed by concatenated vectors (4 bytes per element).
+   */
+  public static ByteString toByteString(Float[][] vectors) {
+    if (vectors == null || vectors.length == 0 || vectors[0].length == 0) {
+      return ByteString.EMPTY;
+    }
+
+    int n = vectors.length;
+    short dimensions = (short) vectors[0].length;
+    int capacity = /* vector dimensions */ Short.BYTES +
+    /* concatenated elements */ (n * dimensions * Float.BYTES);
+    ByteBuffer buffer = ByteBuffer.allocate(capacity).order(BYTE_ORDER)
+        .putShort(dimensions);
+    Arrays.stream(vectors).forEach(v -> Arrays.stream(v).forEach(buffer::putFloat));
+    return ByteString.copyFrom(buffer.array());
+  }
+
+  /**
+   * Decode ByteString into a Float[]. ByteString size must be a multiple of
+   * {@link Float#BYTES}, throws {@link IllegalArgumentException} otherwise.
+   */
   public static Float[] fromByteString(ByteString bs) {
     if (bs.size() % Float.BYTES != 0) {
       throw new IllegalArgumentException(
@@ -63,5 +94,30 @@ public class GRPC {
     float[] vector = new float[bs.size() / Float.BYTES];
     bs.asReadOnlyByteBuffer().order(BYTE_ORDER).asFloatBuffer().get(vector);
     return ArrayUtils.toObject(vector);
+  }
+
+  /** Decode ByteString into a Float[][]. */
+  public static Float[][] fromByteStringMulti(ByteString bs) {
+    if (bs == null || bs.size() == 0) {
+      return new Float[0][0];
+    }
+
+    ByteBuffer buf = bs.asReadOnlyByteBuffer().order(BYTE_ORDER);
+
+    // Dimensions are encoded in the first 2 bytes.
+    short dimensions = buf.getShort(); // advances current position
+
+    FloatBuffer fbuf = buf.asFloatBuffer();
+    int n = fbuf.remaining() / dimensions; // fbuf size is buf / Float.BYTES
+
+    // Reading from buffer advances current position,
+    // so we always read from offset=0.
+    Float[][] vectors = new Float[n][dimensions];
+    for (int i = 0; i < n; i++) {
+      float[] v = new float[dimensions];
+      fbuf.get(v, 0, dimensions);
+      vectors[i] = ArrayUtils.toObject(v);
+    }
+    return vectors;
   }
 }

--- a/src/main/java/io/weaviate/client/v1/misc/model/MultiVectorConfig.java
+++ b/src/main/java/io/weaviate/client/v1/misc/model/MultiVectorConfig.java
@@ -1,0 +1,24 @@
+package io.weaviate.client.v1.misc.model;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.FieldDefaults;
+
+@Getter
+@Builder
+@ToString
+@EqualsAndHashCode
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class MultiVectorConfig {
+  @Builder.Default
+  private boolean enabled = true;
+  @Builder.Default
+  private Aggregation aggregation = Aggregation.MAX_SIM;
+
+  public enum Aggregation {
+    MAX_SIM;
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/misc/model/VectorIndexConfig.java
+++ b/src/main/java/io/weaviate/client/v1/misc/model/VectorIndexConfig.java
@@ -1,6 +1,7 @@
 package io.weaviate.client.v1.misc.model;
 
 import com.google.gson.annotations.SerializedName;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -29,6 +30,9 @@ public class VectorIndexConfig {
   PQConfig pq;
   BQConfig bq;
   SQConfig sq;
+
+  @SerializedName("multivector")
+  MultiVectorConfig multiVector;
 
   public enum FilterStrategy {
     @SerializedName("sweeping")

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
@@ -98,7 +98,7 @@ public abstract class Permission<P extends Permission<P>> {
    *
    * <p>
    * Example: convert Data[read_data, MyCollection], Data[delete_data,
-   * MyCollection] => Data[[read_data, delete_data], MyCollection].
+   * MyCollection] to Data[[read_data, delete_data], MyCollection].
    */
   public static final List<Permission<?>> merge(List<Permission<?>> permissions) {
     @EqualsAndHashCode

--- a/src/main/java/io/weaviate/client/v1/rbac/model/RbacAction.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/RbacAction.java
@@ -7,15 +7,15 @@ package io.weaviate.client.v1.rbac.model;
  * <p>
  * Usage:
  *
- * <pre>
+ * <pre>{@code
  * enum MyAction implements RbacAction {
  *   FOO("do_foo"),
  *   BAR("do_bar");
  *
- *   @Getter
+ *   {@literal @Getter}
  *   private String value;
  * }
- * </pre>
+ * }</pre>
  *
  * <p>
  * Then {@code MyAction.FOO} can be retrieved from "do_foo" using
@@ -32,7 +32,7 @@ interface RbacAction {
    *
    * <pre>{@code
    * OLD_ACTION("old_action") {
-   *  &#64;Override
+   *  {@literal @Override}
    *  public boolean isDeprecated() { return true; }
    * };
    * }</pre>

--- a/src/test/java/io/weaviate/client/v1/data/model/ObjectTest.java
+++ b/src/test/java/io/weaviate/client/v1/data/model/ObjectTest.java
@@ -1,7 +1,5 @@
 package io.weaviate.client.v1.data.model;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -9,9 +7,14 @@ import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import junit.framework.TestCase;
+
 import org.junit.Assert;
 import org.junit.Test;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import junit.framework.TestCase;
 
 public class ObjectTest extends TestCase {
   @Test
@@ -21,13 +24,13 @@ public class ObjectTest extends TestCase {
     properties.put("name", "Pizza");
     properties.put("description", "Italian pizzas");
     WeaviateObject obj = WeaviateObject.builder()
-            .id("uuid")
-            .className("class")
-            .creationTimeUnix(1000l)
-            .lastUpdateTimeUnix(2000l)
-            .vector(new Float[]{ 1.0f, 2.0f })
-            .properties(properties)
-            .build();
+        .id("uuid")
+        .className("class")
+        .creationTimeUnix(1000l)
+        .lastUpdateTimeUnix(2000l)
+        .vector(new Float[] { 1.0f, 2.0f })
+        .properties(properties)
+        .build();
     // when
     String result = new GsonBuilder().setPrettyPrinting().create().toJson(obj);
     // then
@@ -82,26 +85,28 @@ public class ObjectTest extends TestCase {
   @Test
   public void testSerializeWithReferenceProperty() {
     // given
-    Map<String, Object> properties = new HashMap() {{
-      put("name", "RefBeaconSoup");
-      put("description", "Used only to check if reference can be added.");
-      put("otherFoods", new ObjectReference[]{
-              ObjectReference.builder()
-                      .beacon("weaviate://localhost/someClass/abefd256-8574-442b-9293-9205193737ee")
-                      .build()
-      });
-      put("rating", "9/10");
-    }};
+    Map<String, Object> properties = new HashMap<String, Object>() {
+      {
+        put("name", "RefBeaconSoup");
+        put("description", "Used only to check if reference can be added.");
+        put("otherFoods", new ObjectReference[] {
+            ObjectReference.builder()
+                .beacon("weaviate://localhost/someClass/abefd256-8574-442b-9293-9205193737ee")
+                .build()
+        });
+        put("rating", "9/10");
+      }
+    };
     WeaviateObject obj = WeaviateObject.builder()
-            .id("uuid")
-            .className("class")
-            .properties(properties)
-            .build();
+        .id("uuid")
+        .className("class")
+        .properties(properties)
+        .build();
     // when
     String result = new GsonBuilder()
-            .setPrettyPrinting()
-            .create()
-            .toJson(obj);
+        .setPrettyPrinting()
+        .create()
+        .toJson(obj);
     // then
     Assert.assertNotNull(result);
     Assert.assertTrue(result.contains("otherFoods"));

--- a/src/test/java/io/weaviate/client/v1/graphql/query/argument/HybridArgumentTest.java
+++ b/src/test/java/io/weaviate/client/v1/graphql/query/argument/HybridArgumentTest.java
@@ -13,112 +13,127 @@ import com.jparams.junit4.data.DataMethod;
 @RunWith(JParamsTestRunner.class)
 public class HybridArgumentTest {
   public static Object[][] provideTestCases() {
-    return new Object[][]{
-      {
-        "simple query",
-        HybridArgument.builder()
-          .query("I'm a simple string")
-          .build(),
-        "hybrid:{query:\"I'm a simple string\"}"
-      },
-      {
-        "vector and alpha",
-        HybridArgument.builder()
-          .query("I'm a simple string")
-          .vector(new Float[]{ .1f, .2f, .3f })
-          .alpha(.567f)
-          .build(),
-        "hybrid:{query:\"I'm a simple string\" vector:[0.1,0.2,0.3] alpha:0.567}"
-      },
-      {
-        "vector and target vectors",
-        HybridArgument.builder()
-          .query("I'm a simple string")
-          .vector(new Float[]{ .1f, .2f, .3f })
-          .targetVectors(new String[]{ "vector1" })
-          .build(),
-        "hybrid:{query:\"I'm a simple string\" vector:[0.1,0.2,0.3] targetVectors:[\"vector1\"]}"
-      },
-      {
-        "with escaped characters",
-        HybridArgument.builder()
-          .query("\"I'm a complex string\" says the {'`:string:`'}")
-          .build(),
-        "hybrid:{query:\"\\\"I'm a complex string\\\" says the {'`:string:`'}\"}"
-      },
-      {
-        "fusion type ranked",
-        HybridArgument.builder()
-          .query("I'm a simple string")
-          .fusionType(FusionType.RANKED)
-          .build(),
-        "hybrid:{query:\"I'm a simple string\" fusionType:rankedFusion}"
-      },
-      {
-        "fusion type relative score",
-        HybridArgument.builder()
-          .query("I'm a simple string")
-          .fusionType(FusionType.RELATIVE_SCORE)
-          .build(),
-        "hybrid:{query:\"I'm a simple string\" fusionType:relativeScoreFusion}"
-      },
-      {
-        "specify properties to search on",
-        HybridArgument.builder()
-          .query("I'm a simple string")
-          .properties(new String[]{ "prop1", "prop2" })
-          .build(),
-        "hybrid:{query:\"I'm a simple string\" properties:[\"prop1\",\"prop2\"]}"
-      },
-      {
-        "nearVector search",
-        HybridArgument.builder().query("I'm a simple string")
-          .searches(HybridArgument.Searches.builder()
-            .nearVector(NearVectorArgument.builder()
-              .vector(new Float[]{ .1f, .2f, .3f })
-              .certainty(0.9f)
-              .build())
-            .build())
-          .build(),
-        "hybrid:{query:\"I'm a simple string\" searches:{nearVector:{vector:[0.1,0.2,0.3] certainty:0.9}}}"
-      },
-      {
-        "nearText search",
-        HybridArgument.builder().query("I'm a simple string")
-          .searches(
-            HybridArgument.Searches.builder().nearText(
-                NearTextArgument.builder()
-                  .concepts(new String[]{ "concept" })
-                  .certainty(0.9f)
-                  .build())
-              .build())
-          .build(),
-        "hybrid:{query:\"I'm a simple string\" searches:{nearText:{concepts:[\"concept\"] certainty:0.9}}}"
-      },
-      {
-        "target vectors",
-        HybridArgument.builder().query("I'm a simple string")
-          .targets(Targets.builder()
-            .targetVectors(new String[]{ "t1", "t2" })
-            .combinationMethod(Targets.CombinationMethod.minimum)
-            .weights(new LinkedHashMap<String, Float>() {{
-              put("t1", 0.8f);
-              put("t2", 0.2f);
-            }})
-            .build())
-          .build(),
-        "hybrid:{query:\"I'm a simple string\" targets:{combinationMethod:minimum targetVectors:[\"t1\",\"t2\"] weights:{t1:0.8 t2:0.2}}}"
-      },
-      {
-        "max vector distance",
-        HybridArgument.builder().query("I'm a simple string")
-          .searches(HybridArgument.Searches.builder().nearText(
-            NearTextArgument.builder().concepts(new String[]{ "concept" }).build()).build()
-          )
-          .maxVectorDistance(.5f)
-          .build(),
-        "hybrid:{query:\"I'm a simple string\" maxVectorDistance:0.5 searches:{nearText:{concepts:[\"concept\"]}}}"
-      }
+    return new Object[][] {
+        {
+            "simple query",
+            HybridArgument.builder()
+                .query("I'm a simple string")
+                .build(),
+            "hybrid:{query:\"I'm a simple string\"}"
+        },
+        {
+            "vector and alpha",
+            HybridArgument.builder()
+                .query("I'm a simple string")
+                .vector(new Float[] { .1f, .2f, .3f })
+                .alpha(.567f)
+                .build(),
+            "hybrid:{query:\"I'm a simple string\" vector:[0.1,0.2,0.3] alpha:0.567}"
+        },
+        {
+            "vector and target vectors",
+            HybridArgument.builder()
+                .query("I'm a simple string")
+                .vector(new Float[] { .1f, .2f, .3f })
+                .targetVectors(new String[] { "vector1" })
+                .build(),
+            "hybrid:{query:\"I'm a simple string\" vector:[0.1,0.2,0.3] targetVectors:[\"vector1\"]}"
+        },
+        {
+            "with escaped characters",
+            HybridArgument.builder()
+                .query("\"I'm a complex string\" says the {'`:string:`'}")
+                .build(),
+            "hybrid:{query:\"\\\"I'm a complex string\\\" says the {'`:string:`'}\"}"
+        },
+        {
+            "fusion type ranked",
+            HybridArgument.builder()
+                .query("I'm a simple string")
+                .fusionType(FusionType.RANKED)
+                .build(),
+            "hybrid:{query:\"I'm a simple string\" fusionType:rankedFusion}"
+        },
+        {
+            "fusion type relative score",
+            HybridArgument.builder()
+                .query("I'm a simple string")
+                .fusionType(FusionType.RELATIVE_SCORE)
+                .build(),
+            "hybrid:{query:\"I'm a simple string\" fusionType:relativeScoreFusion}"
+        },
+        {
+            "specify properties to search on",
+            HybridArgument.builder()
+                .query("I'm a simple string")
+                .properties(new String[] { "prop1", "prop2" })
+                .build(),
+            "hybrid:{query:\"I'm a simple string\" properties:[\"prop1\",\"prop2\"]}"
+        },
+        {
+            "nearVector search",
+            HybridArgument.builder().query("I'm a simple string")
+                .searches(HybridArgument.Searches.builder()
+                    .nearVector(NearVectorArgument.builder()
+                        .vector(new Float[] { .1f, .2f, .3f })
+                        .certainty(0.9f)
+                        .build())
+                    .build())
+                .build(),
+            "hybrid:{query:\"I'm a simple string\" searches:{nearVector:{vector:[0.1,0.2,0.3] certainty:0.9}}}"
+        },
+        {
+            "nearText search",
+            HybridArgument.builder().query("I'm a simple string")
+                .searches(
+                    HybridArgument.Searches.builder().nearText(
+                        NearTextArgument.builder()
+                            .concepts(new String[] { "concept" })
+                            .certainty(0.9f)
+                            .build())
+                        .build())
+                .build(),
+            "hybrid:{query:\"I'm a simple string\" searches:{nearText:{concepts:[\"concept\"] certainty:0.9}}}"
+        },
+        {
+            "target vectors",
+            HybridArgument.builder().query("I'm a simple string")
+                .targets(Targets.builder()
+                    .targetVectors(new String[] { "t1", "t2" })
+                    .combinationMethod(Targets.CombinationMethod.minimum)
+                    .weights(new LinkedHashMap<String, Float>() {
+                      {
+                        put("t1", 0.8f);
+                        put("t2", 0.2f);
+                      }
+                    })
+                    .build())
+                .build(),
+            "hybrid:{query:\"I'm a simple string\" targets:{combinationMethod:minimum targetVectors:[\"t1\",\"t2\"] weights:{t1:0.8 t2:0.2}}}"
+        },
+        {
+            "max vector distance",
+            HybridArgument.builder().query("I'm a simple string")
+                .searches(HybridArgument.Searches.builder().nearText(
+                    NearTextArgument.builder().concepts(new String[] { "concept" }).build()).build())
+                .maxVectorDistance(.5f)
+                .build(),
+            "hybrid:{query:\"I'm a simple string\" maxVectorDistance:0.5 searches:{nearText:{concepts:[\"concept\"]}}}"
+        },
+        {
+            "multi-dimensional vector",
+            HybridArgument.builder().query("ColBERT me if you can!")
+                .searches(HybridArgument.Searches.builder().nearVector(
+                    NearVectorArgument.builder()
+                        .targetVectors(new String[] { "colbert" })
+                        .vector(new Float[][] {
+                            { 1f, 2f, 3f },
+                            { 4f, 5f, 6f },
+                        }).build())
+                    .build())
+                .build(),
+            "hybrid:{query:\"ColBERT me if you can!\" searches:{nearVector:{vector:[[1.0,2.0,3.0],[4.0,5.0,6.0]] targetVectors:[\"colbert\"]}}}",
+        }
     };
   }
 

--- a/src/test/java/io/weaviate/client/v1/graphql/query/argument/NearVectorArgumentTest.java
+++ b/src/test/java/io/weaviate/client/v1/graphql/query/argument/NearVectorArgumentTest.java
@@ -1,9 +1,11 @@
 package io.weaviate.client.v1.graphql.query.argument;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import org.junit.Test;
 
 public class NearVectorArgumentTest {
@@ -12,7 +14,7 @@ public class NearVectorArgumentTest {
   public void testBuildWithCertainty() {
     // given
     NearVectorArgument nearVector = NearVectorArgument.builder()
-      .vector(new Float[]{1f, 2f, 3f}).certainty(0.8f).build();
+        .vector(new Float[] { 1f, 2f, 3f }).certainty(0.8f).build();
     // when
     String arg = nearVector.build();
     // then
@@ -23,7 +25,7 @@ public class NearVectorArgumentTest {
   public void testBuildWithDistance() {
     // given
     NearVectorArgument nearVector = NearVectorArgument.builder()
-      .vector(new Float[]{1f, 2f, 3f}).distance(0.8f).build();
+        .vector(new Float[] { 1f, 2f, 3f }).distance(0.8f).build();
     // when
     String arg = nearVector.build();
     // then
@@ -33,7 +35,7 @@ public class NearVectorArgumentTest {
   @Test
   public void testBuildWithNoCertainty() {
     NearVectorArgument nearVector = NearVectorArgument.builder()
-      .vector(new Float[]{1f, 2f, 3f}).build();
+        .vector(new Float[] { 1f, 2f, 3f }).build();
     // when
     String arg = nearVector.build();
     // then
@@ -43,9 +45,9 @@ public class NearVectorArgumentTest {
   @Test
   public void shouldBuildWithTargetVectors() {
     String nearVector = NearVectorArgument.builder()
-      .vector(new Float[]{1f, 2f, 3f})
-      .targetVectors(new String[]{"vector1"})
-      .build().build();
+        .vector(new Float[] { 1f, 2f, 3f })
+        .targetVectors(new String[] { "vector1" })
+        .build().build();
 
     assertThat(nearVector).isEqualTo("nearVector:{vector:[1.0,2.0,3.0] targetVectors:[\"vector1\"]}");
   }
@@ -54,41 +56,58 @@ public class NearVectorArgumentTest {
   public void testBuildWithTargets() {
     // given
     LinkedHashMap<String, Float[]> vectorPerTarget = new LinkedHashMap<>();
-    vectorPerTarget.put("t1", new Float[]{1f, 2f, 3f});
-    vectorPerTarget.put("t2", new Float[]{.1f, .2f, .3f});
+    vectorPerTarget.put("t1", new Float[] { 1f, 2f, 3f });
+    vectorPerTarget.put("t2", new Float[] { .1f, .2f, .3f });
     LinkedHashMap<String, Float> weights = new LinkedHashMap<>();
     weights.put("t1", 0.8f);
     weights.put("t2", 0.2f);
     Targets targets = Targets.builder()
-      .targetVectors(new String[]{"t1", "t2"})
-      .combinationMethod(Targets.CombinationMethod.sum)
-      .weights(weights)
-      .build();
+        .targetVectors(new String[] { "t1", "t2" })
+        .combinationMethod(Targets.CombinationMethod.sum)
+        .weights(weights)
+        .build();
     NearVectorArgument nearVector = NearVectorArgument.builder()
-      .vectorPerTarget(vectorPerTarget)
-      .targets(targets)
-      .build();
+        .vectorPerTarget(vectorPerTarget)
+        .targets(targets)
+        .build();
     // when
     String arg = nearVector.build();
     // then
     assertEquals(
-      "nearVector:{vectorPerTarget:{t1:[1.0,2.0,3.0] t2:[0.1,0.2,0.3]} targets:{combinationMethod:sum targetVectors:[\"t1\",\"t2\"] weights:{t1:0.8 t2:0.2}}}",
-      arg);
+        "nearVector:{vectorPerTarget:{t1:[1.0,2.0,3.0] t2:[0.1,0.2,0.3]} targets:{combinationMethod:sum targetVectors:[\"t1\",\"t2\"] weights:{t1:0.8 t2:0.2}}}",
+        arg);
   }
 
   @Test
   public void testBuildWithMultipleVectorsPerTarget() {
     Map<String, Float[][]> vectorsPerTarget = new LinkedHashMap<String, Float[][]>() {
       {
-        this.put("t1", new Float[][]{new Float[]{1f, 2f, 3f}, new Float[]{4f, 5f, 6f}});
-        this.put("t2", new Float[][]{new Float[]{.1f, .2f, .3f}});
+        this.put("t1", new Float[][] { new Float[] { 1f, 2f, 3f }, new Float[] { 4f, 5f, 6f } });
+        this.put("t2", new Float[][] { new Float[] { .1f, .2f, .3f } });
       }
     };
-    NearVectorArgument nearVector =
-      NearVectorArgument.builder().targets(Targets.builder().targetVectors(new String[]{"t1", "t2"}).build()).vectorsPerTarget(vectorsPerTarget).build();
+    NearVectorArgument nearVector = NearVectorArgument.builder()
+        .targets(Targets.builder().targetVectors(new String[] { "t1", "t2" }).build())
+        .vectorsPerTarget(vectorsPerTarget).build();
 
     String got = nearVector.build();
 
-    assertEquals("nearVector:{vectorPerTarget:{t1:[[1.0,2.0,3.0],[4.0,5.0,6.0]] t2:[0.1,0.2,0.3]} targets:{targetVectors:[\"t1\",\"t1\",\"t2\"]}}", got);
+    assertEquals(
+        "nearVector:{vectorPerTarget:{t1:[[1.0,2.0,3.0],[4.0,5.0,6.0]] t2:[0.1,0.2,0.3]} targets:{targetVectors:[\"t1\",\"t1\",\"t2\"]}}",
+        got);
+  }
+
+  @Test
+  public void testBuildWithColBERTVectorsAndTarget() {
+    NearVectorArgument nearVector = NearVectorArgument.builder()
+        .targetVectors(new String[] { "colbert" })
+        .vector(new Float[][] { { 1f, 2f, 3f }, { 4f, 5f, 6f } })
+        .build();
+
+    String got = nearVector.build();
+
+    assertEquals(
+        "nearVector:{vector:[[1.0,2.0,3.0],[4.0,5.0,6.0]] targetVectors:[\"colbert\"]}",
+        got);
   }
 }

--- a/src/test/java/io/weaviate/client/v1/grpc/GRPCTest.java
+++ b/src/test/java/io/weaviate/client/v1/grpc/GRPCTest.java
@@ -8,7 +8,7 @@ import com.google.protobuf.ByteString;
 
 /**
  * Note: Java's {@code byte} is signed (int8) and is different from {@code byte}
- * in Go, which is an aliar for uint8.
+ * in Go, which is an alias for uint8.
  *
  * For this tests purposes the distinction is immaterial, as "want" arrays
  * are "golden values" meant to be a readable respresentation for the test.

--- a/src/test/java/io/weaviate/client/v1/grpc/GRPCTest.java
+++ b/src/test/java/io/weaviate/client/v1/grpc/GRPCTest.java
@@ -1,0 +1,48 @@
+package io.weaviate.client.v1.grpc;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import org.junit.Test;
+
+import com.google.protobuf.ByteString;
+
+/**
+ * Note: Java's {@code byte} is signed (int8) and is different from {@code byte}
+ * in Go, which is an aliar for uint8.
+ *
+ * For this tests purposes the distinction is immaterial, as "want" arrays
+ * are "golden values" meant to be a readable respresentation for the test.
+ */
+public class GRPCTest {
+  @Test
+  public void test_toBytesString_1d() {
+    Float[] vector = { 1f, 2f, 3f };
+    byte[] want = { 0, 0, -128, 63, 0, 0, 0, 64, 0, 0, 64, 64 };
+    byte[] got = GRPC.toByteString(vector).toByteArray();
+    assertArrayEquals(want, got);
+  }
+
+  @Test
+  public void test_fromBytesString_1d() {
+    byte[] bytes = { 0, 0, -128, 63, 0, 0, 0, 64, 0, 0, 64, 64 };
+    Float[] want = { 1f, 2f, 3f };
+    Float[] got = GRPC.fromByteString(ByteString.copyFrom(bytes));
+    assertArrayEquals(want, got);
+  }
+
+  @Test
+  public void test_toBytesString_multi() {
+    Float[][] vector = { { 1f, 2f, 3f }, { 4f, 5f, 6f } };
+    byte[] want = { 3, 0, 0, 0, -128, 63, 0, 0, 0, 64, 0, 0, 64, 64, 0, 0, -128, 64, 0, 0, -96, 64, 0, 0, -64, 64 };
+    byte[] got = GRPC.toByteString(vector).toByteArray();
+    assertArrayEquals(want, got);
+  }
+
+  @Test
+  public void test_fromBytesString_multi() {
+    byte[] bytes = { 3, 0, 0, 0, -128, 63, 0, 0, 0, 64, 0, 0, 64, 64, 0, 0, -128, 64, 0, 0, -96, 64, 0, 0, -64, 64 };
+    Float[][] want = { { 1f, 2f, 3f }, { 4f, 5f, 6f } };
+    Float[][] got = GRPC.fromByteStringMulti(ByteString.copyFrom(bytes));
+    assertArrayEquals(want, got);
+  }
+}

--- a/src/test/java/io/weaviate/integration/client/async/batch/ClientBatchGrpcCreateNamedVectorsTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/batch/ClientBatchGrpcCreateNamedVectorsTest.java
@@ -1,5 +1,13 @@
 package io.weaviate.integration.client.async.batch;
 
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
 import io.weaviate.client.Config;
 import io.weaviate.client.WeaviateClient;
 import io.weaviate.client.base.Result;
@@ -9,12 +17,6 @@ import io.weaviate.client.v1.data.model.WeaviateObject;
 import io.weaviate.client.v1.schema.model.WeaviateClass;
 import io.weaviate.integration.client.WeaviateDockerCompose;
 import io.weaviate.integration.tests.batch.ClientBatchGrpcCreateNamedVectorsTestSuite;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.function.Function;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
 
 public class ClientBatchGrpcCreateNamedVectorsTest {
   private static String httpHost;
@@ -36,8 +38,8 @@ public class ClientBatchGrpcCreateNamedVectorsTest {
     Function<WeaviateClass, Result<Boolean>> classCreate = (weaviateClass) -> {
       try (WeaviateAsyncClient asyncClient = client.async()) {
         return asyncClient.schema().classCreator()
-          .withClass(weaviateClass)
-          .run().get();
+            .withClass(weaviateClass)
+            .run().get();
       } catch (InterruptedException | ExecutionException e) {
         throw new RuntimeException(e);
       }
@@ -46,8 +48,8 @@ public class ClientBatchGrpcCreateNamedVectorsTest {
     Function<WeaviateObject, Result<ObjectGetResponse[]>> batchCreate = (weaviateObj) -> {
       try (WeaviateAsyncClient asyncClient = client.async()) {
         return asyncClient.batch().objectsBatcher()
-          .withObjects(weaviateObj)
-          .run().get();
+            .withObjects(weaviateObj)
+            .run().get();
       } catch (InterruptedException | ExecutionException e) {
         throw new RuntimeException(e);
       }
@@ -56,10 +58,10 @@ public class ClientBatchGrpcCreateNamedVectorsTest {
     Function<WeaviateObject, Result<List<WeaviateObject>>> fetch = (weaviateObject) -> {
       try (WeaviateAsyncClient asyncClient = client.async()) {
         return asyncClient.data().objectsGetter()
-          .withID(weaviateObject.getId())
-          .withClassName(weaviateObject.getClassName())
-          .withVector()
-          .run().get();
+            .withID(weaviateObject.getId())
+            .withClassName(weaviateObject.getClassName())
+            .withVector()
+            .run().get();
       } catch (InterruptedException | ExecutionException e) {
         throw new RuntimeException(e);
       }
@@ -73,7 +75,56 @@ public class ClientBatchGrpcCreateNamedVectorsTest {
       }
     };
 
-    ClientBatchGrpcCreateNamedVectorsTestSuite.shouldCreateObjectsWithNamedVectors(classCreate, batchCreate, fetch, deleteClass);
+    ClientBatchGrpcCreateNamedVectorsTestSuite.shouldCreateObjectsWithNamedVectors(classCreate, batchCreate, fetch,
+        deleteClass);
+  }
+
+  @Test
+  public void shouldCreateObjectsWithNamedMultiVectors() {
+    WeaviateClient client = createClient();
+
+    Function<WeaviateClass, Result<Boolean>> classCreate = (weaviateClass) -> {
+      try (WeaviateAsyncClient asyncClient = client.async()) {
+        return asyncClient.schema().classCreator()
+            .withClass(weaviateClass)
+            .run().get();
+      } catch (InterruptedException | ExecutionException e) {
+        throw new RuntimeException(e);
+      }
+    };
+
+    Function<WeaviateObject, Result<ObjectGetResponse[]>> batchCreate = (weaviateObj) -> {
+      try (WeaviateAsyncClient asyncClient = client.async()) {
+        return asyncClient.batch().objectsBatcher()
+            .withObjects(weaviateObj)
+            .run().get();
+      } catch (InterruptedException | ExecutionException e) {
+        throw new RuntimeException(e);
+      }
+    };
+
+    Function<WeaviateObject, Result<List<WeaviateObject>>> fetch = (weaviateObject) -> {
+      try (WeaviateAsyncClient asyncClient = client.async()) {
+        return asyncClient.data().objectsGetter()
+            .withID(weaviateObject.getId())
+            .withClassName(weaviateObject.getClassName())
+            .withVector()
+            .run().get();
+      } catch (InterruptedException | ExecutionException e) {
+        throw new RuntimeException(e);
+      }
+    };
+
+    Function<String, Result<Boolean>> deleteClass = (className) -> {
+      try (WeaviateAsyncClient asyncClient = client.async()) {
+        return asyncClient.schema().classDeleter().withClassName(className).run().get();
+      } catch (InterruptedException | ExecutionException e) {
+        throw new RuntimeException(e);
+      }
+    };
+
+    ClientBatchGrpcCreateNamedVectorsTestSuite.shouldCreateObjectsWithNamedMultiVectors(classCreate, batchCreate, fetch,
+        deleteClass);
   }
 
   private WeaviateClient createClient() {

--- a/src/test/java/io/weaviate/integration/client/async/data/ClientDataTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/data/ClientDataTest.java
@@ -1,25 +1,37 @@
 package io.weaviate.integration.client.async.data;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
 import io.weaviate.client.Config;
 import io.weaviate.client.WeaviateClient;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.v1.async.WeaviateAsyncClient;
 import io.weaviate.client.v1.data.model.WeaviateObject;
 import io.weaviate.client.v1.data.replication.model.ConsistencyLevel;
+import io.weaviate.client.v1.misc.model.MultiVectorConfig;
+import io.weaviate.client.v1.misc.model.VectorIndexConfig;
+import io.weaviate.client.v1.schema.model.DataType;
+import io.weaviate.client.v1.schema.model.Property;
 import io.weaviate.client.v1.schema.model.Schema;
 import io.weaviate.client.v1.schema.model.WeaviateClass;
 import io.weaviate.integration.client.WeaviateDockerCompose;
 import io.weaviate.integration.client.WeaviateTestGenerics;
 import io.weaviate.integration.tests.data.DataTestSuite;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
 
 public class ClientDataTest {
   private String address;
@@ -46,24 +58,116 @@ public class ClientDataTest {
       // when
       testGenerics.createWeaviateTestSchemaFoodAsync(client);
       Result<WeaviateObject> objectT = client.data().creator()
-        .withClassName("Pizza")
-        .withID(objTID)
-        .withProperties(propertiesSchemaT)
-        .withConsistencyLevel(ConsistencyLevel.QUORUM)
-        .run()
-        .get();
+          .withClassName("Pizza")
+          .withID(objTID)
+          .withProperties(propertiesSchemaT)
+          .withConsistencyLevel(ConsistencyLevel.QUORUM)
+          .run()
+          .get();
       Result<WeaviateObject> objectA = client.data().creator()
-        .withClassName("Soup")
-        .withID(objAID)
-        .withProperties(propertiesSchemaA)
-        .withConsistencyLevel(ConsistencyLevel.QUORUM)
-        .run()
-        .get();
-      Result<List<WeaviateObject>> objectsT = client.data().objectsGetter().withClassName("Pizza").withID(objTID).run().get();
-      Result<List<WeaviateObject>> objectsA = client.data().objectsGetter().withClassName("Soup").withID(objAID).run().get();
+          .withClassName("Soup")
+          .withID(objAID)
+          .withProperties(propertiesSchemaA)
+          .withConsistencyLevel(ConsistencyLevel.QUORUM)
+          .run()
+          .get();
+      Result<List<WeaviateObject>> objectsT = client.data().objectsGetter().withClassName("Pizza").withID(objTID).run()
+          .get();
+      Result<List<WeaviateObject>> objectsA = client.data().objectsGetter().withClassName("Soup").withID(objAID).run()
+          .get();
       testGenerics.cleanupWeaviateAsync(client);
       // then
       DataTestSuite.testDataCreate.assertResults(objectT, objectA, objectsT, objectsA);
+    }
+  }
+
+  @Test
+  public void testDataCreateAndRetrieveMultiVectors() throws ExecutionException, InterruptedException {
+    try (WeaviateAsyncClient client = new WeaviateClient(new Config("http", address)).async()) {
+
+      // Arrange: Configure collection and create it
+      String className = "NamedMultiVectors";
+      WeaviateClass weaviateClass = WeaviateClass.builder()
+          .className(className)
+          .properties(Arrays.asList(
+              Property.builder()
+                  .name("name")
+                  .dataType(Collections.singletonList(DataType.TEXT))
+                  .build()))
+          .vectorConfig(new HashMap<String, WeaviateClass.VectorConfig>() {
+            {
+              this.put("regular", WeaviateClass.VectorConfig.builder()
+                  .vectorizer(new HashMap<String, Object>() {
+                    {
+                      this.put("none", new Object());
+                    }
+                  })
+                  .vectorIndexType("hnsw")
+                  .build());
+              this.put("colbert", WeaviateClass.VectorConfig.builder()
+                  .vectorizer(new HashMap<String, Object>() {
+                    {
+                      this.put("none", new Object());
+                    }
+                  })
+                  .vectorIndexConfig(VectorIndexConfig.builder()
+                      .multiVector(MultiVectorConfig.builder().build())
+                      .build())
+                  .vectorIndexType("hnsw")
+                  .build());
+            }
+          })
+          .build();
+
+      Result<Boolean> createResult = client.schema().classCreator().withClass(weaviateClass).run().get();
+      assumeTrue(createResult.getResult(), "schema created successfully");
+
+      String id = UUID.randomUUID().toString();
+      Float[][] colbertVector = new Float[][] {
+          { 0.11f, 0.22f, 0.33f, 0.123f, -0.900009f, -0.0000000001f },
+          { 0.11f, 0.22f, 0.33f, 0.123f, -0.900009f, -0.0000000001f },
+      };
+
+      // Act: Insert test data
+      Result<WeaviateObject> insertResult = client.data().creator()
+          .withID(id).withClassName(className)
+          .withProperties(new HashMap<String, Object>() {
+            {
+              this.put("name", "TestObject-1");
+              this.put("title", "The Lord of the Rings");
+            }
+          })
+          .withVectors(new HashMap<String, Float[]>() {
+            {
+              this.put("regular", colbertVector[0]);
+            }
+          })
+          .withMultiVectors(new HashMap<String, Float[][]>() {
+            {
+              this.put("colbert", colbertVector);
+            }
+          })
+          .run().get();
+
+      // Assert: Retrieve object and check its dimensions
+      Result<List<WeaviateObject>> getResult = client.data().objectsGetter()
+          .withClassName(className).withID(id).withVector().run().get();
+
+      Assertions.assertThat(getResult).isNotNull()
+          .returns(null, Result::getError).as("get object error")
+          .extracting(Result::getResult).isNotNull().as("result not null")
+          .extracting(r -> r.get(0)).isNotNull().as("first object")
+          .satisfies(o -> {
+            Assertions.assertThat(o.getVectors()).as("1d-vectors")
+                .isNotEmpty().containsOnlyKeys("regular");
+
+            Assertions.assertThat(o.getMultiVectors()).as("multi-vectors")
+                .isNotEmpty().containsOnlyKeys("colbert")
+                .satisfies(multi -> {
+                  Assertions.assertThat(multi.get("colbert")).as("colbert multivector")
+                      .isEqualTo(colbertVector);
+                });
+          }).as("expected object metadata");
     }
   }
 
@@ -76,17 +180,19 @@ public class ClientDataTest {
     String objTID = DataTestSuite.testDataCreateWithSpecialCharacters.objTID;
     String name = DataTestSuite.testDataCreateWithSpecialCharacters.name;
     String description = DataTestSuite.testDataCreateWithSpecialCharacters.description;
-    Map<String, java.lang.Object> propertiesSchemaT = DataTestSuite.testDataCreateWithSpecialCharacters.propertiesSchemaT();
+    Map<String, java.lang.Object> propertiesSchemaT = DataTestSuite.testDataCreateWithSpecialCharacters
+        .propertiesSchemaT();
     try (WeaviateAsyncClient client = syncClient.async()) {
       // when
       testGenerics.createWeaviateTestSchemaFoodAsync(client);
       Result<WeaviateObject> objectT = client.data().creator()
-        .withClassName("Pizza")
-        .withID(objTID)
-        .withProperties(propertiesSchemaT)
-        .run()
-        .get();
-      Result<List<WeaviateObject>> objectsT = client.data().objectsGetter().withClassName("Pizza").withID(objTID).run().get();
+          .withClassName("Pizza")
+          .withID(objTID)
+          .withProperties(propertiesSchemaT)
+          .run()
+          .get();
+      Result<List<WeaviateObject>> objectsT = client.data().objectsGetter().withClassName("Pizza").withID(objTID).run()
+          .get();
       testGenerics.cleanupWeaviateAsync(client);
       // then
       DataTestSuite.testDataCreateWithSpecialCharacters.assertResults(objectT, objectsT);
@@ -102,35 +208,49 @@ public class ClientDataTest {
     try (WeaviateAsyncClient client = syncClient.async()) {
       // when
       testGenerics.createWeaviateTestSchemaFoodAsync(client);
-      Result<WeaviateObject> pizzaObj1 = client.data().creator().withClassName("Pizza").withProperties(new HashMap<String, Object>() {{
-        put("name", "Margherita");
-        put("description", "plain");
-      }}).run().get();
-      Result<WeaviateObject> pizzaObj2 = client.data().creator().withClassName("Pizza").withProperties(new HashMap<String, java.lang.Object>() {{
-        put("name", "Pepperoni");
-        put("description", "meat");
-      }}).run().get();
-      Result<WeaviateObject> soupObj1 = client.data().creator().withClassName("Soup").withProperties(new HashMap<String, java.lang.Object>() {{
-        put("name", "Chicken");
-        put("description", "plain");
-      }}).run().get();
-      Result<WeaviateObject> soupObj2 = client.data().creator().withClassName("Soup").withProperties(new HashMap<String, java.lang.Object>() {{
-        put("name", "Tofu");
-        put("description", "vegetarian");
-      }}).run().get();
+      Result<WeaviateObject> pizzaObj1 = client.data().creator().withClassName("Pizza")
+          .withProperties(new HashMap<String, Object>() {
+            {
+              put("name", "Margherita");
+              put("description", "plain");
+            }
+          }).run().get();
+      Result<WeaviateObject> pizzaObj2 = client.data().creator().withClassName("Pizza")
+          .withProperties(new HashMap<String, java.lang.Object>() {
+            {
+              put("name", "Pepperoni");
+              put("description", "meat");
+            }
+          }).run().get();
+      Result<WeaviateObject> soupObj1 = client.data().creator().withClassName("Soup")
+          .withProperties(new HashMap<String, java.lang.Object>() {
+            {
+              put("name", "Chicken");
+              put("description", "plain");
+            }
+          }).run().get();
+      Result<WeaviateObject> soupObj2 = client.data().creator().withClassName("Soup")
+          .withProperties(new HashMap<String, java.lang.Object>() {
+            {
+              put("name", "Tofu");
+              put("description", "vegetarian");
+            }
+          }).run().get();
       Result<List<WeaviateObject>> objects = client.data().objectsGetter().run().get();
-      Result<List<WeaviateObject>> objects1 = client.data().objectsGetter().withClassName("Pizza").withLimit(1).run().get();
+      Result<List<WeaviateObject>> objects1 = client.data().objectsGetter().withClassName("Pizza").withLimit(1).run()
+          .get();
       assertNull(objects1.getError());
       assertEquals(1l, objects1.getResult().size());
       String firstPizzaID = objects1.getResult().get(0).getId();
       Result<List<WeaviateObject>> afterFirstPizzaObjects = client.data()
-        .objectsGetter()
-        .withClassName("Pizza").withAfter(firstPizzaID).withLimit(1)
-        .run().get();
+          .objectsGetter()
+          .withClassName("Pizza").withAfter(firstPizzaID).withLimit(1)
+          .run().get();
 
       testGenerics.cleanupWeaviateAsync(client);
       // then
-      DataTestSuite.testDataGetActionsThings.assertResults(pizzaObj1, pizzaObj2, soupObj1, soupObj2, objects, afterFirstPizzaObjects);
+      DataTestSuite.testDataGetActionsThings.assertResults(pizzaObj1, pizzaObj2, soupObj1, soupObj2, objects,
+          afterFirstPizzaObjects);
     }
   }
 
@@ -148,50 +268,52 @@ public class ClientDataTest {
       // when
       testGenerics.createWeaviateTestSchemaFoodAsync(client);
       Result<WeaviateObject> objectT = client.data().creator()
-        .withClassName("Pizza")
-        .withID(objTID)
-        .withProperties(propertiesSchemaT)
-        .run().get();
+          .withClassName("Pizza")
+          .withID(objTID)
+          .withProperties(propertiesSchemaT)
+          .run().get();
       Result<WeaviateObject> objectA = client.data().creator()
-        .withClassName("Soup")
-        .withID(objAID)
-        .withProperties(propertiesSchemaA)
-        .run().get();
-      Result<List<WeaviateObject>> objectsT = client.data().objectsGetter().withClassName("Pizza").withID(objTID).run().get();
-      Result<List<WeaviateObject>> objectsA = client.data().objectsGetter().withClassName("Soup").withID(objAID).run().get();
+          .withClassName("Soup")
+          .withID(objAID)
+          .withProperties(propertiesSchemaA)
+          .run().get();
+      Result<List<WeaviateObject>> objectsT = client.data().objectsGetter().withClassName("Pizza").withID(objTID).run()
+          .get();
+      Result<List<WeaviateObject>> objectsA = client.data().objectsGetter().withClassName("Soup").withID(objAID).run()
+          .get();
       Result<List<WeaviateObject>> objsAdditionalT = client.data()
-        .objectsGetter()
-        .withID(objTID)
-        .withClassName("Pizza")
-        .withAdditional("classification")
-        .withAdditional("nearestNeighbors")
-        .withVector()
-        .run().get();
+          .objectsGetter()
+          .withID(objTID)
+          .withClassName("Pizza")
+          .withAdditional("classification")
+          .withAdditional("nearestNeighbors")
+          .withVector()
+          .run().get();
       Result<List<WeaviateObject>> objsAdditionalA = client.data()
-        .objectsGetter()
-        .withID(objAID)
-        .withClassName("Soup")
-        .withAdditional("classification")
-        .withAdditional("nearestNeighbors")
-        .withAdditional("interpretation")
-        .withVector()
-        .run().get();
+          .objectsGetter()
+          .withID(objAID)
+          .withClassName("Soup")
+          .withAdditional("classification")
+          .withAdditional("nearestNeighbors")
+          .withAdditional("interpretation")
+          .withVector()
+          .run().get();
       Result<List<WeaviateObject>> objsAdditionalA1 = client.data()
-        .objectsGetter().withID(objAID).withClassName("Soup")
-        .run().get();
+          .objectsGetter().withID(objAID).withClassName("Soup")
+          .run().get();
       Result<List<WeaviateObject>> objsAdditionalA2 = client.data()
-        .objectsGetter().withID(objAID).withClassName("Soup")
-        .withAdditional("interpretation")
-        .run().get();
+          .objectsGetter().withID(objAID).withClassName("Soup")
+          .withAdditional("interpretation")
+          .run().get();
       Result<List<WeaviateObject>> objsAdditionalAError = client.data()
-        .objectsGetter().withID(objAID).withClassName("Soup")
-        .withAdditional("featureProjection")
-        .run().get();
+          .objectsGetter().withID(objAID).withClassName("Soup")
+          .withAdditional("featureProjection")
+          .run().get();
       testGenerics.cleanupWeaviateAsync(client);
       // then
       DataTestSuite.testDataGetWithAdditional.assertResults(objectT, objectA, objectsT, objectsA,
-        objsAdditionalT, objsAdditionalA, objsAdditionalA1, objsAdditionalA2,
-        objsAdditionalAError);
+          objsAdditionalT, objsAdditionalA, objsAdditionalA1, objsAdditionalA2,
+          objsAdditionalAError);
     }
   }
 
@@ -209,27 +331,29 @@ public class ClientDataTest {
       // when
       testGenerics.createWeaviateTestSchemaFoodAsync(client);
       Result<WeaviateObject> objectT = client.data().creator()
-        .withClassName("Pizza")
-        .withID(objTID)
-        .withProperties(propertiesSchemaT)
-        .run().get();
+          .withClassName("Pizza")
+          .withID(objTID)
+          .withProperties(propertiesSchemaT)
+          .run().get();
       Result<WeaviateObject> objectA = client.data().creator()
-        .withClassName("Soup")
-        .withID(objAID)
-        .withProperties(propertiesSchemaA)
-        .run().get();
+          .withClassName("Soup")
+          .withID(objAID)
+          .withProperties(propertiesSchemaA)
+          .run().get();
       Result<Boolean> deleteObjT = client.data().deleter()
-        .withClassName("Pizza")
-        .withID(objTID)
-        .withConsistencyLevel(ConsistencyLevel.QUORUM)
-        .run().get();
-      Result<List<WeaviateObject>> objTlist = client.data().objectsGetter().withClassName("Pizza").withID(objTID).run().get();
+          .withClassName("Pizza")
+          .withID(objTID)
+          .withConsistencyLevel(ConsistencyLevel.QUORUM)
+          .run().get();
+      Result<List<WeaviateObject>> objTlist = client.data().objectsGetter().withClassName("Pizza").withID(objTID).run()
+          .get();
       Result<Boolean> deleteObjA = client.data().deleter()
-        .withClassName("Soup")
-        .withID(objAID)
-        .withConsistencyLevel(ConsistencyLevel.QUORUM)
-        .run().get();
-      Result<List<WeaviateObject>> objAlist = client.data().objectsGetter().withClassName("Soup").withID(objAID).run().get();
+          .withClassName("Soup")
+          .withID(objAID)
+          .withConsistencyLevel(ConsistencyLevel.QUORUM)
+          .run().get();
+      Result<List<WeaviateObject>> objAlist = client.data().objectsGetter().withClassName("Soup").withID(objAID).run()
+          .get();
       testGenerics.cleanupWeaviateAsync(client);
       // then
       DataTestSuite.testDataDelete.assertResults(objectT, objectA, deleteObjT, objTlist, deleteObjA, objAlist);
@@ -250,38 +374,45 @@ public class ClientDataTest {
       // when
       testGenerics.createWeaviateTestSchemaFoodAsync(client);
       Result<WeaviateObject> objectT = client.data().creator()
-        .withClassName("Pizza")
-        .withID(objTID)
-        .withProperties(propertiesSchemaT)
-        .run().get();
+          .withClassName("Pizza")
+          .withID(objTID)
+          .withProperties(propertiesSchemaT)
+          .run().get();
       Result<WeaviateObject> objectA = client.data().creator()
-        .withClassName("Soup")
-        .withID(objAID)
-        .withProperties(propertiesSchemaA)
-        .run().get();
+          .withClassName("Soup")
+          .withID(objAID)
+          .withProperties(propertiesSchemaA)
+          .run().get();
       Result<Boolean> updateObjectT = client.data().updater()
-        .withClassName("Pizza")
-        .withID(objTID)
-        .withProperties(new HashMap<String, java.lang.Object>() {{
-          put("name", "Hawaii");
-          put("description", "Universally accepted to be the best pizza ever created.");
-        }})
-        .withConsistencyLevel(ConsistencyLevel.QUORUM)
-        .run().get();
+          .withClassName("Pizza")
+          .withID(objTID)
+          .withProperties(new HashMap<String, java.lang.Object>() {
+            {
+              put("name", "Hawaii");
+              put("description", "Universally accepted to be the best pizza ever created.");
+            }
+          })
+          .withConsistencyLevel(ConsistencyLevel.QUORUM)
+          .run().get();
       Result<Boolean> updateObjectA = client.data().updater()
-        .withClassName("Soup")
-        .withID(objAID)
-        .withProperties(new HashMap<String, java.lang.Object>() {{
-          put("name", "ChickenSoup");
-          put("description", "Used by humans when their inferior genetics are attacked by microscopic organisms.");
-        }})
-        .withConsistencyLevel(ConsistencyLevel.QUORUM)
-        .run().get();
-      Result<List<WeaviateObject>> updatedObjsT = client.data().objectsGetter().withClassName("Pizza").withID(objTID).run().get();
-      Result<List<WeaviateObject>> updatedObjsA = client.data().objectsGetter().withClassName("Soup").withID(objAID).run().get();
+          .withClassName("Soup")
+          .withID(objAID)
+          .withProperties(new HashMap<String, java.lang.Object>() {
+            {
+              put("name", "ChickenSoup");
+              put("description", "Used by humans when their inferior genetics are attacked by microscopic organisms.");
+            }
+          })
+          .withConsistencyLevel(ConsistencyLevel.QUORUM)
+          .run().get();
+      Result<List<WeaviateObject>> updatedObjsT = client.data().objectsGetter().withClassName("Pizza").withID(objTID)
+          .run().get();
+      Result<List<WeaviateObject>> updatedObjsA = client.data().objectsGetter().withClassName("Soup").withID(objAID)
+          .run().get();
       testGenerics.cleanupWeaviateAsync(client);
       // then
-      DataTestSuite.testDataUpdate.assertResults(objectT, objectA, updateObjectT, updateObjectA, updatedObjsT, updatedObjsA);
+      DataTestSuite.testDataUpdate.assertResults(objectT, objectA, updateObjectT, updateObjectA, updatedObjsT,
+          updatedObjsA);
     }
   }
 
@@ -299,36 +430,43 @@ public class ClientDataTest {
       // when
       testGenerics.createWeaviateTestSchemaFoodAsync(client);
       Result<WeaviateObject> objectT = client.data().creator()
-        .withClassName("Pizza")
-        .withID(objTID)
-        .withProperties(propertiesSchemaT)
-        .run().get();
+          .withClassName("Pizza")
+          .withID(objTID)
+          .withProperties(propertiesSchemaT)
+          .run().get();
       Result<WeaviateObject> objectA = client.data().creator()
-        .withClassName("Soup")
-        .withID(objAID)
-        .withProperties(propertiesSchemaA)
-        .run().get();
+          .withClassName("Soup")
+          .withID(objAID)
+          .withProperties(propertiesSchemaA)
+          .run().get();
       Result<Boolean> mergeObjectT = client.data().updater()
-        .withClassName("Pizza")
-        .withID(objTID)
-        .withProperties(new HashMap<String, java.lang.Object>() {{
-          put("description", "Universally accepted to be the best pizza ever created.");
-        }})
-        .withMerge()
-        .run().get();
+          .withClassName("Pizza")
+          .withID(objTID)
+          .withProperties(new HashMap<String, java.lang.Object>() {
+            {
+              put("description", "Universally accepted to be the best pizza ever created.");
+            }
+          })
+          .withMerge()
+          .run().get();
       Result<Boolean> mergeObjectA = client.data().updater()
-        .withClassName("Soup")
-        .withID(objAID)
-        .withProperties(new HashMap<String, java.lang.Object>() {{
-          put("description", "Used by humans when their inferior genetics are attacked by microscopic organisms.");
-        }})
-        .withMerge()
-        .run().get();
-      Result<List<WeaviateObject>> mergedObjsT = client.data().objectsGetter().withClassName("Pizza").withID(objTID).run().get();
-      Result<List<WeaviateObject>> mergeddObjsA = client.data().objectsGetter().withClassName("Soup").withID(objAID).run().get();
+          .withClassName("Soup")
+          .withID(objAID)
+          .withProperties(new HashMap<String, java.lang.Object>() {
+            {
+              put("description", "Used by humans when their inferior genetics are attacked by microscopic organisms.");
+            }
+          })
+          .withMerge()
+          .run().get();
+      Result<List<WeaviateObject>> mergedObjsT = client.data().objectsGetter().withClassName("Pizza").withID(objTID)
+          .run().get();
+      Result<List<WeaviateObject>> mergeddObjsA = client.data().objectsGetter().withClassName("Soup").withID(objAID)
+          .run().get();
       testGenerics.cleanupWeaviateAsync(client);
       // then
-      DataTestSuite.testDataMerge.assertResults(objectT, objectA, mergeObjectT, mergeObjectA, mergedObjsT, mergeddObjsA);
+      DataTestSuite.testDataMerge.assertResults(objectT, objectA, mergeObjectT, mergeObjectA, mergedObjsT,
+          mergeddObjsA);
     }
   }
 
@@ -346,27 +484,27 @@ public class ClientDataTest {
       // when
       testGenerics.createWeaviateTestSchemaFoodAsync(client);
       Result<Boolean> validateObjT = client.data().validator()
-        .withClassName("Pizza")
-        .withID(objTID)
-        .withProperties(propertiesSchemaT)
-        .run().get();
+          .withClassName("Pizza")
+          .withID(objTID)
+          .withProperties(propertiesSchemaT)
+          .run().get();
       Result<Boolean> validateObjA = client.data().validator()
-        .withClassName("Soup")
-        .withID(objAID)
-        .withProperties(propertiesSchemaA)
-        .run().get();
+          .withClassName("Soup")
+          .withID(objAID)
+          .withProperties(propertiesSchemaA)
+          .run().get();
       propertiesSchemaT.put("test", "not existing property");
       Result<Boolean> validateObjT1 = client.data().validator()
-        .withClassName("Pizza")
-        .withID(objTID)
-        .withProperties(propertiesSchemaT)
-        .run().get();
+          .withClassName("Pizza")
+          .withID(objTID)
+          .withProperties(propertiesSchemaT)
+          .run().get();
       propertiesSchemaA.put("test", "not existing property");
       Result<Boolean> validateObjA1 = client.data().validator()
-        .withClassName("Pizza")
-        .withID(objTID)
-        .withProperties(propertiesSchemaT)
-        .run().get();
+          .withClassName("Pizza")
+          .withID(objTID)
+          .withProperties(propertiesSchemaT)
+          .run().get();
       testGenerics.cleanupWeaviateAsync(client);
       // then
       DataTestSuite.testDataValidate.assertResults(validateObjT, validateObjA, validateObjT1, validateObjA1);
@@ -387,22 +525,22 @@ public class ClientDataTest {
       // when
       testGenerics.createWeaviateTestSchemaFoodAsync(client);
       Result<WeaviateObject> objectT = client.data().creator()
-        .withClassName("Pizza")
-        .withID(objTID)
-        .withProperties(propertiesSchemaT)
-        .run().get();
+          .withClassName("Pizza")
+          .withID(objTID)
+          .withProperties(propertiesSchemaT)
+          .run().get();
       Result<WeaviateObject> objectA = client.data().creator()
-        .withClassName("Soup")
-        .withID(objAID)
-        .withProperties(propertiesSchemaA)
-        .run().get();
+          .withClassName("Soup")
+          .withID(objAID)
+          .withProperties(propertiesSchemaA)
+          .run().get();
       Result<List<WeaviateObject>> objsAdditionalT = client.data()
-        .objectsGetter()
-        .withID(objTID)
-        .withClassName("Pizza")
-        .withAdditional("featureProjection")
-        .withVector()
-        .run().get();
+          .objectsGetter()
+          .withID(objTID)
+          .withClassName("Pizza")
+          .withAdditional("featureProjection")
+          .withVector()
+          .run().get();
       testGenerics.cleanupWeaviateAsync(client);
       // then
       DataTestSuite.testDataGetWithAdditionalError.assertResults(objectT, objectA, objsAdditionalT);
@@ -422,15 +560,17 @@ public class ClientDataTest {
       Result<Boolean> createStatus = client.schema().classCreator().withClass(clazz).run().get();
       Result<Schema> schemaAfterCreate = client.schema().getter().run().get();
       Result<WeaviateObject> objectT = client.data().creator()
-        .withClassName("ClassArrays")
-        .withID(objTID)
-        .withProperties(propertiesSchemaT)
-        .run().get();
-      Result<List<WeaviateObject>> objectsT = client.data().objectsGetter().withClassName("ClassArrays").withID(objTID).run().get();
+          .withClassName("ClassArrays")
+          .withID(objTID)
+          .withProperties(propertiesSchemaT)
+          .run().get();
+      Result<List<WeaviateObject>> objectsT = client.data().objectsGetter().withClassName("ClassArrays").withID(objTID)
+          .run().get();
       Result<Boolean> deleteStatus = client.schema().allDeleter().run().get();
       Result<Schema> schemaAfterDelete = client.schema().getter().run().get();
       // then
-      DataTestSuite.testDataCreateWithArrayType.assertResults(createStatus, schemaAfterCreate, objectT, objectsT, deleteStatus, schemaAfterDelete);
+      DataTestSuite.testDataCreateWithArrayType.assertResults(createStatus, schemaAfterCreate, objectT, objectsT,
+          deleteStatus, schemaAfterDelete);
     }
   }
 
@@ -448,20 +588,21 @@ public class ClientDataTest {
       Result<Boolean> createStatus = client.schema().classCreator().withClass(clazz).run().get();
       Result<Schema> schemaAfterCreate = client.schema().getter().run().get();
       Result<WeaviateObject> objectT = client.data().creator()
-        .withClassName("ClassCustomVector")
-        .withID(objTID)
-        .withVector(vectorObjT)
-        .withProperties(propertiesSchemaT)
-        .run().get();
+          .withClassName("ClassCustomVector")
+          .withID(objTID)
+          .withVector(vectorObjT)
+          .withProperties(propertiesSchemaT)
+          .run().get();
       Result<List<WeaviateObject>> objT = client.data()
-        .objectsGetter()
-        .withClassName("ClassCustomVector").withID(objTID)
-        .withVector()
-        .run().get();
+          .objectsGetter()
+          .withClassName("ClassCustomVector").withID(objTID)
+          .withVector()
+          .run().get();
       Result<Boolean> deleteStatus = client.schema().allDeleter().run().get();
       Result<Schema> schemaAfterDelete = client.schema().getter().run().get();
       // then
-      DataTestSuite.testDataGetWithVector.assertResults(createStatus, schemaAfterCreate, objectT, objT, deleteStatus, schemaAfterDelete);
+      DataTestSuite.testDataGetWithVector.assertResults(createStatus, schemaAfterCreate, objectT, objT, deleteStatus,
+          schemaAfterDelete);
     }
   }
 
@@ -480,31 +621,32 @@ public class ClientDataTest {
       // when
       testGenerics.createWeaviateTestSchemaFoodAsync(client);
       Result<WeaviateObject> objectT = client.data().creator()
-        .withClassName("Pizza")
-        .withID(objTID)
-        .withProperties(propertiesSchemaT)
-        .run().get();
+          .withClassName("Pizza")
+          .withID(objTID)
+          .withProperties(propertiesSchemaT)
+          .run().get();
       Result<WeaviateObject> objectA = client.data().creator()
-        .withClassName("Soup")
-        .withID(objAID)
-        .withProperties(propertiesSchemaA)
-        .run().get();
+          .withClassName("Soup")
+          .withID(objAID)
+          .withProperties(propertiesSchemaA)
+          .run().get();
       // check object existence
       Result<Boolean> checkObjT = client.data().checker().withClassName("Pizza").withID(objTID).run().get();
       Result<Boolean> checkObjA = client.data().checker().withClassName("Soup").withID(objAID).run().get();
       Result<List<WeaviateObject>> objA = client.data()
-        .objectsGetter()
-        .withID(objAID)
-        .withClassName("Soup")
-        .withVector()
-        .run().get();
+          .objectsGetter()
+          .withID(objAID)
+          .withClassName("Soup")
+          .withVector()
+          .run().get();
       Result<List<WeaviateObject>> objT = client.data()
-        .objectsGetter()
-        .withID(objTID)
-        .withClassName("Pizza")
-        .withVector()
-        .run().get();
-      Result<Boolean> checkNonexistentObject = client.data().checker().withClassName("Pizza").withID(nonExistentObjectID).run().get();
+          .objectsGetter()
+          .withID(objTID)
+          .withClassName("Pizza")
+          .withVector()
+          .run().get();
+      Result<Boolean> checkNonexistentObject = client.data().checker().withClassName("Pizza")
+          .withID(nonExistentObjectID).run().get();
       // delete all objects from Weaviate
       Result<Boolean> deleteStatus = client.schema().allDeleter().run().get();
       // check object's existence status after clean up
@@ -513,7 +655,8 @@ public class ClientDataTest {
       testGenerics.cleanupWeaviateAsync(client);
       // then
       DataTestSuite.testObjectCheck
-        .assertResults(objectT, objectA, checkObjT, checkObjA, objA, objT, checkNonexistentObject, deleteStatus, checkObjTAfterDelete, checkObjAAfterDelete);
+          .assertResults(objectT, objectA, checkObjT, checkObjA, objA, objT, checkNonexistentObject, deleteStatus,
+              checkObjTAfterDelete, checkObjAAfterDelete);
     }
   }
 
@@ -523,19 +666,22 @@ public class ClientDataTest {
     Config config = new Config("http", address);
     WeaviateClient syncClient = new WeaviateClient(config);
     String objID = DataTestSuite.testDataCreateWithIDInNotUUIDFormat.objID;
-    Map<String, java.lang.Object> propertiesSchemaT = DataTestSuite.testDataCreateWithIDInNotUUIDFormat.propertiesSchemaT();
+    Map<String, java.lang.Object> propertiesSchemaT = DataTestSuite.testDataCreateWithIDInNotUUIDFormat
+        .propertiesSchemaT();
     try (WeaviateAsyncClient client = syncClient.async()) {
       // when
       Result<WeaviateObject> objectT = client.data().creator()
-        .withID(objID)
-        .withClassName("Pizza")
-        .withProperties(propertiesSchemaT)
-        .run().get();
-      Result<List<WeaviateObject>> objectsT = client.data().objectsGetter().withClassName("Pizza").withID(objID).run().get();
+          .withID(objID)
+          .withClassName("Pizza")
+          .withProperties(propertiesSchemaT)
+          .run().get();
+      Result<List<WeaviateObject>> objectsT = client.data().objectsGetter().withClassName("Pizza").withID(objID).run()
+          .get();
       Result<Boolean> deleteStatus = client.schema().allDeleter().run().get();
       Result<Schema> schemaAfterDelete = client.schema().getter().run().get();
       // then
-      DataTestSuite.testDataCreateWithIDInNotUUIDFormat.assertResults(objectT, objectsT, deleteStatus, schemaAfterDelete);
+      DataTestSuite.testDataCreateWithIDInNotUUIDFormat.assertResults(objectT, objectsT, deleteStatus,
+          schemaAfterDelete);
     }
   }
 
@@ -548,28 +694,41 @@ public class ClientDataTest {
     try (WeaviateAsyncClient client = syncClient.async()) {
       // when
       testGenerics.createWeaviateTestSchemaFoodAsync(client);
-      Result<WeaviateObject> pizzaObj1 = client.data().creator().withClassName("Pizza").withProperties(new HashMap<String, java.lang.Object>() {{
-        put("name", "Margherita");
-        put("description", "plain");
-      }}).run().get();
-      Result<WeaviateObject> pizzaObj2 = client.data().creator().withClassName("Pizza").withProperties(new HashMap<String, java.lang.Object>() {{
-        put("name", "Pepperoni");
-        put("description", "meat");
-      }}).run().get();
-      Result<WeaviateObject> soupObj1 = client.data().creator().withClassName("Soup").withProperties(new HashMap<String, java.lang.Object>() {{
-        put("name", "Chicken");
-        put("description", "plain");
-      }}).run().get();
-      Result<WeaviateObject> soupObj2 = client.data().creator().withClassName("Soup").withProperties(new HashMap<String, java.lang.Object>() {{
-        put("name", "Tofu");
-        put("description", "vegetarian");
-      }}).run().get();
+      Result<WeaviateObject> pizzaObj1 = client.data().creator().withClassName("Pizza")
+          .withProperties(new HashMap<String, java.lang.Object>() {
+            {
+              put("name", "Margherita");
+              put("description", "plain");
+            }
+          }).run().get();
+      Result<WeaviateObject> pizzaObj2 = client.data().creator().withClassName("Pizza")
+          .withProperties(new HashMap<String, java.lang.Object>() {
+            {
+              put("name", "Pepperoni");
+              put("description", "meat");
+            }
+          }).run().get();
+      Result<WeaviateObject> soupObj1 = client.data().creator().withClassName("Soup")
+          .withProperties(new HashMap<String, java.lang.Object>() {
+            {
+              put("name", "Chicken");
+              put("description", "plain");
+            }
+          }).run().get();
+      Result<WeaviateObject> soupObj2 = client.data().creator().withClassName("Soup")
+          .withProperties(new HashMap<String, java.lang.Object>() {
+            {
+              put("name", "Tofu");
+              put("description", "vegetarian");
+            }
+          }).run().get();
       Result<List<WeaviateObject>> objects = client.data().objectsGetter().run().get();
       Result<List<WeaviateObject>> pizzaObjects = client.data().objectsGetter().withClassName("Pizza").run().get();
       Result<List<WeaviateObject>> soupObjects = client.data().objectsGetter().withClassName("Soup").run().get();
       testGenerics.cleanupWeaviateAsync(client);
       // then
-      DataTestSuite.testDataGetUsingClassParameter.assertResults(pizzaObj1, pizzaObj2, soupObj1, soupObj2, objects, pizzaObjects, soupObjects);
+      DataTestSuite.testDataGetUsingClassParameter.assertResults(pizzaObj1, pizzaObj2, soupObj1, soupObj2, objects,
+          pizzaObjects, soupObjects);
     }
   }
 }

--- a/src/test/java/io/weaviate/integration/client/async/data/ClientDataTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/data/ClientDataTest.java
@@ -2,6 +2,7 @@ package io.weaviate.integration.client.async.data;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.util.Arrays;
@@ -414,6 +415,92 @@ public class ClientDataTest {
       DataTestSuite.testDataUpdate.assertResults(objectT, objectA, updateObjectT, updateObjectA, updatedObjsT,
           updatedObjsA);
     }
+  }
+
+  @Test
+  public void testDataUpdateMultiVectors() {
+    WeaviateClient client = new WeaviateClient(new Config("http", address));
+
+    // Arrange: Configure collection and create it
+    String className = "NamedMultiVectors";
+    WeaviateClass weaviateClass = WeaviateClass.builder()
+        .className(className)
+        .properties(Arrays.asList(
+            Property.builder()
+                .name("name")
+                .dataType(Collections.singletonList(DataType.TEXT))
+                .build()))
+        .vectorConfig(new HashMap<String, WeaviateClass.VectorConfig>() {
+          {
+            this.put("colbert", WeaviateClass.VectorConfig.builder()
+                .vectorizer(new HashMap<String, Object>() {
+                  {
+                    this.put("none", new Object());
+                  }
+                })
+                .vectorIndexConfig(VectorIndexConfig.builder()
+                    .multiVector(MultiVectorConfig.builder().build())
+                    .build())
+                .vectorIndexType("hnsw")
+                .build());
+          }
+        })
+        .build();
+
+    Result<Boolean> createResult = client.schema().classCreator().withClass(weaviateClass).run();
+    assumeTrue(createResult.getResult(), "schema created successfully");
+
+    String id = UUID.randomUUID().toString();
+    Float[][] colbertVector = new Float[][] {
+        { 0.11f, 0.22f, 0.33f, 0.123f, -0.900009f, -0.0000000001f },
+        { 0.11f, 0.22f, 0.33f, 0.123f, -0.900009f, -0.0000000001f },
+    };
+
+    Result<WeaviateObject> insertResult = client.data().creator()
+        .withID(id).withClassName(className)
+        .withProperties(new HashMap<String, Object>() {
+          {
+            this.put("name", "TestObject-1");
+          }
+        })
+        .withMultiVectors(new HashMap<String, Float[][]>() {
+          {
+            this.put("colbert", colbertVector);
+          }
+        })
+        .run();
+    assumeFalse(insertResult.hasErrors(), "test data inserted successfully");
+
+    // Act: Update data
+    Float[][] newVector = Arrays.stream(colbertVector)
+        .map(inner -> Arrays.stream(inner).map(v -> 5 * v).toArray(Float[]::new))
+        .toArray(Float[][]::new);
+    Result<Boolean> updateResult = client.data().updater()
+        .withID(id).withClassName(className)
+        .withMultiVectors(new HashMap<String, Float[][]>() {
+          {
+            this.put("colbert", newVector);
+          }
+        })
+        .run();
+    assertNull("successfully updated metadata", updateResult.getError());
+
+    // Assert: Retrieve object and check metadata
+    Result<List<WeaviateObject>> getResult = client.data().objectsGetter()
+        .withClassName(className).withID(id).withVector().run();
+
+    Assertions.assertThat(getResult).isNotNull()
+        .returns(null, Result::getError).as("get object error")
+        .extracting(Result::getResult).isNotNull().as("result not null")
+        .extracting(r -> r.get(0)).isNotNull().as("first object")
+        .satisfies(o -> {
+          Assertions.assertThat(o.getMultiVectors()).as("multi-vectors")
+              .isNotEmpty().containsOnlyKeys("colbert")
+              .satisfies(multi -> {
+                Assertions.assertThat(multi.get("colbert")).as("colbert multivector")
+                    .isEqualTo(newVector);
+              });
+        }).as("expected updated object metadata");
   }
 
   @Test

--- a/src/test/java/io/weaviate/integration/client/batch/ClientBatchGrpcCreateNamedVectorsTest.java
+++ b/src/test/java/io/weaviate/integration/client/batch/ClientBatchGrpcCreateNamedVectorsTest.java
@@ -1,29 +1,20 @@
 package io.weaviate.integration.client.batch;
 
+import java.util.List;
+import java.util.function.Function;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
 import io.weaviate.client.Config;
 import io.weaviate.client.WeaviateClient;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.v1.batch.model.ObjectGetResponse;
 import io.weaviate.client.v1.data.model.WeaviateObject;
-import io.weaviate.client.v1.misc.model.BQConfig;
-import io.weaviate.client.v1.misc.model.VectorIndexConfig;
-import io.weaviate.client.v1.schema.model.DataType;
-import io.weaviate.client.v1.schema.model.Property;
 import io.weaviate.client.v1.schema.model.WeaviateClass;
 import io.weaviate.integration.client.WeaviateDockerCompose;
 import io.weaviate.integration.tests.batch.ClientBatchGrpcCreateNamedVectorsTestSuite;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.InstanceOfAssertFactories.ARRAY;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
 
 public class ClientBatchGrpcCreateNamedVectorsTest {
   private static String httpHost;
@@ -43,23 +34,49 @@ public class ClientBatchGrpcCreateNamedVectorsTest {
     WeaviateClient client = createClient();
 
     Function<WeaviateClass, Result<Boolean>> classCreate = (weaviateClass) -> client.schema().classCreator()
-      .withClass(weaviateClass)
-      .run();
+        .withClass(weaviateClass)
+        .run();
 
     Function<WeaviateObject, Result<ObjectGetResponse[]>> batchCreate = (weaviateObj) -> client.batch().objectsBatcher()
-      .withObjects(weaviateObj)
-      .run();
+        .withObjects(weaviateObj)
+        .run();
 
     Function<WeaviateObject, Result<List<WeaviateObject>>> fetch = (weaviateObject) -> client.data().objectsGetter()
-      .withID(weaviateObject.getId())
-      .withClassName(weaviateObject.getClassName())
-      .withVector()
-      .run();
+        .withID(weaviateObject.getId())
+        .withClassName(weaviateObject.getClassName())
+        .withVector()
+        .run();
 
-    Function<String, Result<Boolean>> deleteClass = (className) ->
-      client.schema().classDeleter().withClassName(className).run();
+    Function<String, Result<Boolean>> deleteClass = (className) -> client.schema().classDeleter()
+        .withClassName(className).run();
 
-    ClientBatchGrpcCreateNamedVectorsTestSuite.shouldCreateObjectsWithNamedVectors(classCreate, batchCreate, fetch, deleteClass);
+    ClientBatchGrpcCreateNamedVectorsTestSuite.shouldCreateObjectsWithNamedVectors(classCreate, batchCreate, fetch,
+        deleteClass);
+  }
+
+  @Test
+  public void shouldCreateObjectsWithNamedMultiVectors() {
+    WeaviateClient client = createClient();
+
+    Function<WeaviateClass, Result<Boolean>> classCreate = (weaviateClass) -> client.schema().classCreator()
+        .withClass(weaviateClass)
+        .run();
+
+    Function<WeaviateObject, Result<ObjectGetResponse[]>> batchCreate = (weaviateObj) -> client.batch().objectsBatcher()
+        .withObjects(weaviateObj)
+        .run();
+
+    Function<WeaviateObject, Result<List<WeaviateObject>>> fetch = (weaviateObject) -> client.data().objectsGetter()
+        .withID(weaviateObject.getId())
+        .withClassName(weaviateObject.getClassName())
+        .withVector()
+        .run();
+
+    Function<String, Result<Boolean>> deleteClass = (className) -> client.schema().classDeleter()
+        .withClassName(className).run();
+
+    ClientBatchGrpcCreateNamedVectorsTestSuite.shouldCreateObjectsWithNamedMultiVectors(classCreate, batchCreate, fetch,
+        deleteClass);
   }
 
   private WeaviateClient createClient() {

--- a/src/test/java/io/weaviate/integration/client/data/ClientDataTest.java
+++ b/src/test/java/io/weaviate/integration/client/data/ClientDataTest.java
@@ -80,90 +80,94 @@ public class ClientDataTest {
   @Test
   public void testDataCreateAndRetrieveMultiVectors() {
     WeaviateClient client = new WeaviateClient(new Config("http", address));
+    try {
 
-    // Arrange: Configure collection and create it
-    String className = "NamedMultiVectors";
-    WeaviateClass weaviateClass = WeaviateClass.builder()
-        .className(className)
-        .properties(Arrays.asList(
-            Property.builder()
-                .name("name")
-                .dataType(Collections.singletonList(DataType.TEXT))
-                .build()))
-        .vectorConfig(new HashMap<String, WeaviateClass.VectorConfig>() {
-          {
-            this.put("regular", WeaviateClass.VectorConfig.builder()
-                .vectorizer(new HashMap<String, Object>() {
-                  {
-                    this.put("none", new Object());
-                  }
-                })
-                .vectorIndexType("hnsw")
-                .build());
-            this.put("colbert", WeaviateClass.VectorConfig.builder()
-                .vectorizer(new HashMap<String, Object>() {
-                  {
-                    this.put("none", new Object());
-                  }
-                })
-                .vectorIndexConfig(VectorIndexConfig.builder()
-                    .multiVector(MultiVectorConfig.builder().build())
-                    .build())
-                .vectorIndexType("hnsw")
-                .build());
-          }
-        })
-        .build();
+      // Arrange: Configure collection and create it
+      String className = "NamedMultiVectors";
+      WeaviateClass weaviateClass = WeaviateClass.builder()
+          .className(className)
+          .properties(Arrays.asList(
+              Property.builder()
+                  .name("name")
+                  .dataType(Collections.singletonList(DataType.TEXT))
+                  .build()))
+          .vectorConfig(new HashMap<String, WeaviateClass.VectorConfig>() {
+            {
+              this.put("regular", WeaviateClass.VectorConfig.builder()
+                  .vectorizer(new HashMap<String, Object>() {
+                    {
+                      this.put("none", new Object());
+                    }
+                  })
+                  .vectorIndexType("hnsw")
+                  .build());
+              this.put("colbert", WeaviateClass.VectorConfig.builder()
+                  .vectorizer(new HashMap<String, Object>() {
+                    {
+                      this.put("none", new Object());
+                    }
+                  })
+                  .vectorIndexConfig(VectorIndexConfig.builder()
+                      .multiVector(MultiVectorConfig.builder().build())
+                      .build())
+                  .vectorIndexType("hnsw")
+                  .build());
+            }
+          })
+          .build();
 
-    Result<Boolean> createResult = client.schema().classCreator().withClass(weaviateClass).run();
-    assumeTrue(createResult.getResult(), "schema created successfully");
+      Result<Boolean> createResult = client.schema().classCreator().withClass(weaviateClass).run();
+      assumeTrue(createResult.getResult(), "schema created successfully");
 
-    String id = UUID.randomUUID().toString();
-    Float[][] colbertVector = new Float[][] {
-        { 0.11f, 0.22f, 0.33f, 0.123f, -0.900009f, -0.0000000001f },
-        { 0.11f, 0.22f, 0.33f, 0.123f, -0.900009f, -0.0000000001f },
-    };
+      String id = UUID.randomUUID().toString();
+      Float[][] colbertVector = new Float[][] {
+          { 0.11f, 0.22f, 0.33f, 0.123f, -0.900009f, -0.0000000001f },
+          { 0.11f, 0.22f, 0.33f, 0.123f, -0.900009f, -0.0000000001f },
+      };
 
-    // Act: Insert test data
-    Result<WeaviateObject> insertResult = client.data().creator()
-        .withID(id).withClassName(className)
-        .withProperties(new HashMap<String, Object>() {
-          {
-            this.put("name", "TestObject-1");
-            this.put("title", "The Lord of the Rings");
-          }
-        })
-        .withVectors(new HashMap<String, Float[]>() {
-          {
-            this.put("regular", colbertVector[0]);
-          }
-        })
-        .withMultiVectors(new HashMap<String, Float[][]>() {
-          {
-            this.put("colbert", colbertVector);
-          }
-        })
-        .run();
+      // Act: Insert test data
+      Result<WeaviateObject> insertResult = client.data().creator()
+          .withID(id).withClassName(className)
+          .withProperties(new HashMap<String, Object>() {
+            {
+              this.put("name", "TestObject-1");
+              this.put("title", "The Lord of the Rings");
+            }
+          })
+          .withVectors(new HashMap<String, Float[]>() {
+            {
+              this.put("regular", colbertVector[0]);
+            }
+          })
+          .withMultiVectors(new HashMap<String, Float[][]>() {
+            {
+              this.put("colbert", colbertVector);
+            }
+          })
+          .run();
 
-    // Assert: Retrieve object and check its dimensions
-    Result<List<WeaviateObject>> getResult = client.data().objectsGetter()
-        .withClassName(className).withID(id).withVector().run();
+      // Assert: Retrieve object and check its dimensions
+      Result<List<WeaviateObject>> getResult = client.data().objectsGetter()
+          .withClassName(className).withID(id).withVector().run();
 
-    assertThat(getResult).isNotNull()
-        .returns(null, Result::getError).as("get object error")
-        .extracting(Result::getResult).isNotNull().as("result not null")
-        .extracting(r -> r.get(0)).isNotNull().as("first object")
-        .satisfies(o -> {
-          assertThat(o.getVectors()).as("1d-vectors")
-              .isNotEmpty().containsOnlyKeys("regular");
+      assertThat(getResult).isNotNull()
+          .returns(null, Result::getError).as("get object error")
+          .extracting(Result::getResult).isNotNull().as("result not null")
+          .extracting(r -> r.get(0)).isNotNull().as("first object")
+          .satisfies(o -> {
+            assertThat(o.getVectors()).as("1d-vectors")
+                .isNotEmpty().containsOnlyKeys("regular");
 
-          assertThat(o.getMultiVectors()).as("multi-vectors")
-              .isNotEmpty().containsOnlyKeys("colbert")
-              .satisfies(multi -> {
-                assertThat(multi.get("colbert")).as("colbert multivector")
-                    .isEqualTo(colbertVector);
-              });
-        }).as("expected object metadata");
+            assertThat(o.getMultiVectors()).as("multi-vectors")
+                .isNotEmpty().containsOnlyKeys("colbert")
+                .satisfies(multi -> {
+                  assertThat(multi.get("colbert")).as("colbert multivector")
+                      .isEqualTo(colbertVector);
+                });
+          }).as("expected object metadata");
+    } finally {
+      new WeaviateTestGenerics().cleanupWeaviate(client);
+    }
   }
 
   @Test
@@ -397,87 +401,90 @@ public class ClientDataTest {
   @Test
   public void testDataUpdateMultiVectors() {
     WeaviateClient client = new WeaviateClient(new Config("http", address));
+    try {
+      // Arrange: Configure collection and create it
+      String className = "NamedMultiVectors";
+      WeaviateClass weaviateClass = WeaviateClass.builder()
+          .className(className)
+          .properties(Arrays.asList(
+              Property.builder()
+                  .name("name")
+                  .dataType(Collections.singletonList(DataType.TEXT))
+                  .build()))
+          .vectorConfig(new HashMap<String, WeaviateClass.VectorConfig>() {
+            {
+              this.put("colbert", WeaviateClass.VectorConfig.builder()
+                  .vectorizer(new HashMap<String, Object>() {
+                    {
+                      this.put("none", new Object());
+                    }
+                  })
+                  .vectorIndexConfig(VectorIndexConfig.builder()
+                      .multiVector(MultiVectorConfig.builder().build())
+                      .build())
+                  .vectorIndexType("hnsw")
+                  .build());
+            }
+          })
+          .build();
 
-    // Arrange: Configure collection and create it
-    String className = "NamedMultiVectors";
-    WeaviateClass weaviateClass = WeaviateClass.builder()
-        .className(className)
-        .properties(Arrays.asList(
-            Property.builder()
-                .name("name")
-                .dataType(Collections.singletonList(DataType.TEXT))
-                .build()))
-        .vectorConfig(new HashMap<String, WeaviateClass.VectorConfig>() {
-          {
-            this.put("colbert", WeaviateClass.VectorConfig.builder()
-                .vectorizer(new HashMap<String, Object>() {
-                  {
-                    this.put("none", new Object());
-                  }
-                })
-                .vectorIndexConfig(VectorIndexConfig.builder()
-                    .multiVector(MultiVectorConfig.builder().build())
-                    .build())
-                .vectorIndexType("hnsw")
-                .build());
-          }
-        })
-        .build();
+      Result<Boolean> createResult = client.schema().classCreator().withClass(weaviateClass).run();
+      assumeTrue(createResult.getResult(), "schema created successfully");
 
-    Result<Boolean> createResult = client.schema().classCreator().withClass(weaviateClass).run();
-    assumeTrue(createResult.getResult(), "schema created successfully");
+      String id = UUID.randomUUID().toString();
+      Float[][] colbertVector = new Float[][] {
+          { 0.11f, 0.22f, 0.33f, 0.123f, -0.900009f, -0.0000000001f },
+          { 0.11f, 0.22f, 0.33f, 0.123f, -0.900009f, -0.0000000001f },
+      };
 
-    String id = UUID.randomUUID().toString();
-    Float[][] colbertVector = new Float[][] {
-        { 0.11f, 0.22f, 0.33f, 0.123f, -0.900009f, -0.0000000001f },
-        { 0.11f, 0.22f, 0.33f, 0.123f, -0.900009f, -0.0000000001f },
-    };
+      Result<WeaviateObject> insertResult = client.data().creator()
+          .withID(id).withClassName(className)
+          .withProperties(new HashMap<String, Object>() {
+            {
+              this.put("name", "TestObject-1");
+            }
+          })
+          .withMultiVectors(new HashMap<String, Float[][]>() {
+            {
+              this.put("colbert", colbertVector);
+            }
+          })
+          .run();
+      assumeFalse(insertResult.hasErrors(), "test data inserted successfully");
 
-    Result<WeaviateObject> insertResult = client.data().creator()
-        .withID(id).withClassName(className)
-        .withProperties(new HashMap<String, Object>() {
-          {
-            this.put("name", "TestObject-1");
-          }
-        })
-        .withMultiVectors(new HashMap<String, Float[][]>() {
-          {
-            this.put("colbert", colbertVector);
-          }
-        })
-        .run();
-    assumeFalse(insertResult.hasErrors(), "test data inserted successfully");
+      // Act: Update data
+      Float[][] newVector = Arrays.stream(colbertVector)
+          .map(inner -> Arrays.stream(inner).map(v -> 5 * v).toArray(Float[]::new))
+          .toArray(Float[][]::new);
+      Result<Boolean> updateResult = client.data().updater()
+          .withID(id).withClassName(className)
+          .withMultiVectors(new HashMap<String, Float[][]>() {
+            {
+              this.put("colbert", newVector);
+            }
+          })
+          .run();
+      assertNull("successfully updated metadata", updateResult.getError());
 
-    // Act: Update data
-    Float[][] newVector = Arrays.stream(colbertVector)
-        .map(inner -> Arrays.stream(inner).map(v -> 5 * v).toArray(Float[]::new))
-        .toArray(Float[][]::new);
-    Result<Boolean> updateResult = client.data().updater()
-        .withID(id).withClassName(className)
-        .withMultiVectors(new HashMap<String, Float[][]>() {
-          {
-            this.put("colbert", newVector);
-          }
-        })
-        .run();
-    assertNull("successfully updated metadata", updateResult.getError());
+      // Assert: Retrieve object and check metadata
+      Result<List<WeaviateObject>> getResult = client.data().objectsGetter()
+          .withClassName(className).withID(id).withVector().run();
 
-    // Assert: Retrieve object and check metadata
-    Result<List<WeaviateObject>> getResult = client.data().objectsGetter()
-        .withClassName(className).withID(id).withVector().run();
-
-    assertThat(getResult).isNotNull()
-        .returns(null, Result::getError).as("get object error")
-        .extracting(Result::getResult).isNotNull().as("result not null")
-        .extracting(r -> r.get(0)).isNotNull().as("first object")
-        .satisfies(o -> {
-          assertThat(o.getMultiVectors()).as("multi-vectors")
-              .isNotEmpty().containsOnlyKeys("colbert")
-              .satisfies(multi -> {
-                assertThat(multi.get("colbert")).as("colbert multivector")
-                    .isEqualTo(newVector);
-              });
-        }).as("expected updated object metadata");
+      assertThat(getResult).isNotNull()
+          .returns(null, Result::getError).as("get object error")
+          .extracting(Result::getResult).isNotNull().as("result not null")
+          .extracting(r -> r.get(0)).isNotNull().as("first object")
+          .satisfies(o -> {
+            assertThat(o.getMultiVectors()).as("multi-vectors")
+                .isNotEmpty().containsOnlyKeys("colbert")
+                .satisfies(multi -> {
+                  assertThat(multi.get("colbert")).as("colbert multivector")
+                      .isEqualTo(newVector);
+                });
+          }).as("expected updated object metadata");
+    } finally {
+      new WeaviateTestGenerics().cleanupWeaviate(client);
+    }
   }
 
   @Test

--- a/src/test/java/io/weaviate/integration/client/data/ClientDataTest.java
+++ b/src/test/java/io/weaviate/integration/client/data/ClientDataTest.java
@@ -1,10 +1,31 @@
 package io.weaviate.integration.client.data;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
 import io.weaviate.client.Config;
 import io.weaviate.client.WeaviateClient;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.v1.data.model.WeaviateObject;
 import io.weaviate.client.v1.data.replication.model.ConsistencyLevel;
+import io.weaviate.client.v1.misc.model.MultiVectorConfig;
+import io.weaviate.client.v1.misc.model.VectorIndexConfig;
 import io.weaviate.client.v1.schema.model.DataType;
 import io.weaviate.client.v1.schema.model.Property;
 import io.weaviate.client.v1.schema.model.Schema;
@@ -12,22 +33,6 @@ import io.weaviate.client.v1.schema.model.WeaviateClass;
 import io.weaviate.integration.client.WeaviateDockerCompose;
 import io.weaviate.integration.client.WeaviateTestGenerics;
 import io.weaviate.integration.tests.data.DataTestSuite;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 public class ClientDataTest {
   private String address;
@@ -53,22 +58,111 @@ public class ClientDataTest {
     // when
     testGenerics.createWeaviateTestSchemaFood(client);
     Result<WeaviateObject> objectT = client.data().creator()
-      .withClassName("Pizza")
-      .withID(objTID)
-      .withProperties(propertiesSchemaT)
-      .withConsistencyLevel(ConsistencyLevel.QUORUM)
-      .run();
+        .withClassName("Pizza")
+        .withID(objTID)
+        .withProperties(propertiesSchemaT)
+        .withConsistencyLevel(ConsistencyLevel.QUORUM)
+        .run();
     Result<WeaviateObject> objectA = client.data().creator()
-      .withClassName("Soup")
-      .withID(objAID)
-      .withProperties(propertiesSchemaA)
-      .withConsistencyLevel(ConsistencyLevel.QUORUM)
-      .run();
+        .withClassName("Soup")
+        .withID(objAID)
+        .withProperties(propertiesSchemaA)
+        .withConsistencyLevel(ConsistencyLevel.QUORUM)
+        .run();
     Result<List<WeaviateObject>> objectsT = client.data().objectsGetter().withClassName("Pizza").withID(objTID).run();
     Result<List<WeaviateObject>> objectsA = client.data().objectsGetter().withClassName("Soup").withID(objAID).run();
     testGenerics.cleanupWeaviate(client);
     // then
     DataTestSuite.testDataCreate.assertResults(objectT, objectA, objectsT, objectsA);
+  }
+
+  @Test
+  public void testDataCreateAndRetrieveMultiVectors() {
+    WeaviateClient client = new WeaviateClient(new Config("http", address));
+
+    // Arrange: Configure collection and create it
+    String className = "NamedMultiVectors";
+    WeaviateClass weaviateClass = WeaviateClass.builder()
+        .className(className)
+        .properties(Arrays.asList(
+            Property.builder()
+                .name("name")
+                .dataType(Collections.singletonList(DataType.TEXT))
+                .build()))
+        .vectorConfig(new HashMap<String, WeaviateClass.VectorConfig>() {
+          {
+            this.put("regular", WeaviateClass.VectorConfig.builder()
+                .vectorizer(new HashMap<String, Object>() {
+                  {
+                    this.put("none", new Object());
+                  }
+                })
+                .vectorIndexType("hnsw")
+                .build());
+            this.put("colbert", WeaviateClass.VectorConfig.builder()
+                .vectorizer(new HashMap<String, Object>() {
+                  {
+                    this.put("none", new Object());
+                  }
+                })
+                .vectorIndexConfig(VectorIndexConfig.builder()
+                    .multiVector(MultiVectorConfig.builder().build())
+                    .build())
+                .vectorIndexType("hnsw")
+                .build());
+          }
+        })
+        .build();
+
+    Result<Boolean> createResult = client.schema().classCreator().withClass(weaviateClass).run();
+    assumeTrue(createResult.getResult(), "schema created successfully");
+
+    String id = UUID.randomUUID().toString();
+    Float[][] colbertVector = new Float[][] {
+        { 0.11f, 0.22f, 0.33f, 0.123f, -0.900009f, -0.0000000001f },
+        { 0.11f, 0.22f, 0.33f, 0.123f, -0.900009f, -0.0000000001f },
+    };
+
+    // Act: Insert test data
+    Result<WeaviateObject> insertResult = client.data().creator()
+        .withID(id).withClassName(className)
+        .withProperties(new HashMap<String, Object>() {
+          {
+            this.put("name", "TestObject-1");
+            this.put("title", "The Lord of the Rings");
+          }
+        })
+        .withVectors(new HashMap<String, Float[]>() {
+          {
+            this.put("regular", colbertVector[0]);
+          }
+        })
+        .withMultiVectors(new HashMap<String, Float[][]>() {
+          {
+            this.put("colbert", colbertVector);
+          }
+        })
+        .run();
+
+    // Assert: Retrieve object and check its dimensions
+    Result<List<WeaviateObject>> getResult = client.data().objectsGetter()
+        .withClassName(className).withID(id).withVector().run();
+
+    assertThat(getResult).isNotNull()
+        .returns(null, Result::getError).as("get object error")
+        .extracting(Result::getResult).isNotNull().as("result not null")
+        .extracting(r -> r.get(0)).isNotNull().as("first object")
+        .satisfies(o -> {
+          assertThat(o.getVectors()).as("1d-vectors")
+              .isNotEmpty().containsOnlyKeys("regular");
+
+          assertThat(o.getMultiVectors()).as("multi-vectors")
+              .isNotEmpty().containsOnlyKeys("colbert")
+              .satisfies(multi -> {
+                assertThat(multi.get("colbert")).as("colbert multivector")
+                    .isEqualTo(colbertVector);
+              });
+        }).as("expected object metadata");
   }
 
   @Test
@@ -80,14 +174,15 @@ public class ClientDataTest {
     String objTID = DataTestSuite.testDataCreateWithSpecialCharacters.objTID;
     String name = DataTestSuite.testDataCreateWithSpecialCharacters.name;
     String description = DataTestSuite.testDataCreateWithSpecialCharacters.description;
-    Map<String, java.lang.Object> propertiesSchemaT = DataTestSuite.testDataCreateWithSpecialCharacters.propertiesSchemaT();
+    Map<String, java.lang.Object> propertiesSchemaT = DataTestSuite.testDataCreateWithSpecialCharacters
+        .propertiesSchemaT();
     // when
     testGenerics.createWeaviateTestSchemaFood(client);
     Result<WeaviateObject> objectT = client.data().creator()
-      .withClassName("Pizza")
-      .withID(objTID)
-      .withProperties(propertiesSchemaT)
-      .run();
+        .withClassName("Pizza")
+        .withID(objTID)
+        .withProperties(propertiesSchemaT)
+        .run();
     Result<List<WeaviateObject>> objectsT = client.data().objectsGetter().withClassName("Pizza").withID(objTID).run();
     testGenerics.cleanupWeaviate(client);
     // then
@@ -102,35 +197,48 @@ public class ClientDataTest {
     WeaviateTestGenerics testGenerics = new WeaviateTestGenerics();
     // when
     testGenerics.createWeaviateTestSchemaFood(client);
-    Result<WeaviateObject> pizzaObj1 = client.data().creator().withClassName("Pizza").withProperties(new HashMap<String, java.lang.Object>() {{
-      put("name", "Margherita");
-      put("description", "plain");
-    }}).run();
-    Result<WeaviateObject> pizzaObj2 = client.data().creator().withClassName("Pizza").withProperties(new HashMap<String, java.lang.Object>() {{
-      put("name", "Pepperoni");
-      put("description", "meat");
-    }}).run();
-    Result<WeaviateObject> soupObj1 = client.data().creator().withClassName("Soup").withProperties(new HashMap<String, java.lang.Object>() {{
-      put("name", "Chicken");
-      put("description", "plain");
-    }}).run();
-    Result<WeaviateObject> soupObj2 = client.data().creator().withClassName("Soup").withProperties(new HashMap<String, java.lang.Object>() {{
-      put("name", "Tofu");
-      put("description", "vegetarian");
-    }}).run();
+    Result<WeaviateObject> pizzaObj1 = client.data().creator().withClassName("Pizza")
+        .withProperties(new HashMap<String, java.lang.Object>() {
+          {
+            put("name", "Margherita");
+            put("description", "plain");
+          }
+        }).run();
+    Result<WeaviateObject> pizzaObj2 = client.data().creator().withClassName("Pizza")
+        .withProperties(new HashMap<String, java.lang.Object>() {
+          {
+            put("name", "Pepperoni");
+            put("description", "meat");
+          }
+        }).run();
+    Result<WeaviateObject> soupObj1 = client.data().creator().withClassName("Soup")
+        .withProperties(new HashMap<String, java.lang.Object>() {
+          {
+            put("name", "Chicken");
+            put("description", "plain");
+          }
+        }).run();
+    Result<WeaviateObject> soupObj2 = client.data().creator().withClassName("Soup")
+        .withProperties(new HashMap<String, java.lang.Object>() {
+          {
+            put("name", "Tofu");
+            put("description", "vegetarian");
+          }
+        }).run();
     Result<List<WeaviateObject>> objects = client.data().objectsGetter().run();
     Result<List<WeaviateObject>> objects1 = client.data().objectsGetter().withClassName("Pizza").withLimit(1).run();
     assertNull(objects1.getError());
     assertEquals(1l, objects1.getResult().size());
     String firstPizzaID = objects1.getResult().get(0).getId();
     Result<List<WeaviateObject>> afterFirstPizzaObjects = client.data()
-      .objectsGetter()
-      .withClassName("Pizza").withAfter(firstPizzaID).withLimit(1)
-      .run();
+        .objectsGetter()
+        .withClassName("Pizza").withAfter(firstPizzaID).withLimit(1)
+        .run();
 
     testGenerics.cleanupWeaviate(client);
     // then
-    DataTestSuite.testDataGetActionsThings.assertResults(pizzaObj1, pizzaObj2, soupObj1, soupObj2, objects, afterFirstPizzaObjects);
+    DataTestSuite.testDataGetActionsThings.assertResults(pizzaObj1, pizzaObj2, soupObj1, soupObj2, objects,
+        afterFirstPizzaObjects);
   }
 
   @Test
@@ -146,50 +254,50 @@ public class ClientDataTest {
     // when
     testGenerics.createWeaviateTestSchemaFood(client);
     Result<WeaviateObject> objectT = client.data().creator()
-      .withClassName("Pizza")
-      .withID(objTID)
-      .withProperties(propertiesSchemaT)
-      .run();
+        .withClassName("Pizza")
+        .withID(objTID)
+        .withProperties(propertiesSchemaT)
+        .run();
     Result<WeaviateObject> objectA = client.data().creator()
-      .withClassName("Soup")
-      .withID(objAID)
-      .withProperties(propertiesSchemaA)
-      .run();
+        .withClassName("Soup")
+        .withID(objAID)
+        .withProperties(propertiesSchemaA)
+        .run();
     Result<List<WeaviateObject>> objectsT = client.data().objectsGetter().withClassName("Pizza").withID(objTID).run();
     Result<List<WeaviateObject>> objectsA = client.data().objectsGetter().withClassName("Soup").withID(objAID).run();
     Result<List<WeaviateObject>> objsAdditionalT = client.data()
-      .objectsGetter()
-      .withID(objTID)
-      .withClassName("Pizza")
-      .withAdditional("classification")
-      .withAdditional("nearestNeighbors")
-      .withVector()
-      .run();
+        .objectsGetter()
+        .withID(objTID)
+        .withClassName("Pizza")
+        .withAdditional("classification")
+        .withAdditional("nearestNeighbors")
+        .withVector()
+        .run();
     Result<List<WeaviateObject>> objsAdditionalA = client.data()
-      .objectsGetter()
-      .withID(objAID)
-      .withClassName("Soup")
-      .withAdditional("classification")
-      .withAdditional("nearestNeighbors")
-      .withAdditional("interpretation")
-      .withVector()
-      .run();
+        .objectsGetter()
+        .withID(objAID)
+        .withClassName("Soup")
+        .withAdditional("classification")
+        .withAdditional("nearestNeighbors")
+        .withAdditional("interpretation")
+        .withVector()
+        .run();
     Result<List<WeaviateObject>> objsAdditionalA1 = client.data()
-      .objectsGetter().withID(objAID).withClassName("Soup")
-      .run();
+        .objectsGetter().withID(objAID).withClassName("Soup")
+        .run();
     Result<List<WeaviateObject>> objsAdditionalA2 = client.data()
-      .objectsGetter().withID(objAID).withClassName("Soup")
-      .withAdditional("interpretation")
-      .run();
+        .objectsGetter().withID(objAID).withClassName("Soup")
+        .withAdditional("interpretation")
+        .run();
     Result<List<WeaviateObject>> objsAdditionalAError = client.data()
-      .objectsGetter().withID(objAID).withClassName("Soup")
-      .withAdditional("featureProjection")
-      .run();
+        .objectsGetter().withID(objAID).withClassName("Soup")
+        .withAdditional("featureProjection")
+        .run();
     testGenerics.cleanupWeaviate(client);
     // then
     DataTestSuite.testDataGetWithAdditional.assertResults(objectT, objectA, objectsT, objectsA,
-      objsAdditionalT, objsAdditionalA, objsAdditionalA1, objsAdditionalA2,
-      objsAdditionalAError);
+        objsAdditionalT, objsAdditionalA, objsAdditionalA1, objsAdditionalA2,
+        objsAdditionalAError);
   }
 
   @Test
@@ -205,26 +313,26 @@ public class ClientDataTest {
     // when
     testGenerics.createWeaviateTestSchemaFood(client);
     Result<WeaviateObject> objectT = client.data().creator()
-      .withClassName("Pizza")
-      .withID(objTID)
-      .withProperties(propertiesSchemaT)
-      .run();
+        .withClassName("Pizza")
+        .withID(objTID)
+        .withProperties(propertiesSchemaT)
+        .run();
     Result<WeaviateObject> objectA = client.data().creator()
-      .withClassName("Soup")
-      .withID(objAID)
-      .withProperties(propertiesSchemaA)
-      .run();
+        .withClassName("Soup")
+        .withID(objAID)
+        .withProperties(propertiesSchemaA)
+        .run();
     Result<Boolean> deleteObjT = client.data().deleter()
-      .withClassName("Pizza")
-      .withID(objTID)
-      .withConsistencyLevel(ConsistencyLevel.QUORUM)
-      .run();
+        .withClassName("Pizza")
+        .withID(objTID)
+        .withConsistencyLevel(ConsistencyLevel.QUORUM)
+        .run();
     Result<List<WeaviateObject>> objTlist = client.data().objectsGetter().withClassName("Pizza").withID(objTID).run();
     Result<Boolean> deleteObjA = client.data().deleter()
-      .withClassName("Soup")
-      .withID(objAID)
-      .withConsistencyLevel(ConsistencyLevel.QUORUM)
-      .run();
+        .withClassName("Soup")
+        .withID(objAID)
+        .withConsistencyLevel(ConsistencyLevel.QUORUM)
+        .run();
     Result<List<WeaviateObject>> objAlist = client.data().objectsGetter().withClassName("Soup").withID(objAID).run();
     testGenerics.cleanupWeaviate(client);
     // then
@@ -244,38 +352,45 @@ public class ClientDataTest {
     // when
     testGenerics.createWeaviateTestSchemaFood(client);
     Result<WeaviateObject> objectT = client.data().creator()
-      .withClassName("Pizza")
-      .withID(objTID)
-      .withProperties(propertiesSchemaT)
-      .run();
+        .withClassName("Pizza")
+        .withID(objTID)
+        .withProperties(propertiesSchemaT)
+        .run();
     Result<WeaviateObject> objectA = client.data().creator()
-      .withClassName("Soup")
-      .withID(objAID)
-      .withProperties(propertiesSchemaA)
-      .run();
+        .withClassName("Soup")
+        .withID(objAID)
+        .withProperties(propertiesSchemaA)
+        .run();
     Result<Boolean> updateObjectT = client.data().updater()
-      .withClassName("Pizza")
-      .withID(objTID)
-      .withProperties(new HashMap<String, java.lang.Object>() {{
-        put("name", "Hawaii");
-        put("description", "Universally accepted to be the best pizza ever created.");
-      }})
-      .withConsistencyLevel(ConsistencyLevel.QUORUM)
-      .run();
+        .withClassName("Pizza")
+        .withID(objTID)
+        .withProperties(new HashMap<String, java.lang.Object>() {
+          {
+            put("name", "Hawaii");
+            put("description", "Universally accepted to be the best pizza ever created.");
+          }
+        })
+        .withConsistencyLevel(ConsistencyLevel.QUORUM)
+        .run();
     Result<Boolean> updateObjectA = client.data().updater()
-      .withClassName("Soup")
-      .withID(objAID)
-      .withProperties(new HashMap<String, java.lang.Object>() {{
-        put("name", "ChickenSoup");
-        put("description", "Used by humans when their inferior genetics are attacked by microscopic organisms.");
-      }})
-      .withConsistencyLevel(ConsistencyLevel.QUORUM)
-      .run();
-    Result<List<WeaviateObject>> updatedObjsT = client.data().objectsGetter().withClassName("Pizza").withID(objTID).run();
-    Result<List<WeaviateObject>> updatedObjsA = client.data().objectsGetter().withClassName("Soup").withID(objAID).run();
+        .withClassName("Soup")
+        .withID(objAID)
+        .withProperties(new HashMap<String, java.lang.Object>() {
+          {
+            put("name", "ChickenSoup");
+            put("description", "Used by humans when their inferior genetics are attacked by microscopic organisms.");
+          }
+        })
+        .withConsistencyLevel(ConsistencyLevel.QUORUM)
+        .run();
+    Result<List<WeaviateObject>> updatedObjsT = client.data().objectsGetter().withClassName("Pizza").withID(objTID)
+        .run();
+    Result<List<WeaviateObject>> updatedObjsA = client.data().objectsGetter().withClassName("Soup").withID(objAID)
+        .run();
     testGenerics.cleanupWeaviate(client);
     // then
-    DataTestSuite.testDataUpdate.assertResults(objectT, objectA, updateObjectT, updateObjectA, updatedObjsT, updatedObjsA);
+    DataTestSuite.testDataUpdate.assertResults(objectT, objectA, updateObjectT, updateObjectA, updatedObjsT,
+        updatedObjsA);
   }
 
   @Test
@@ -291,33 +406,39 @@ public class ClientDataTest {
     // when
     testGenerics.createWeaviateTestSchemaFood(client);
     Result<WeaviateObject> objectT = client.data().creator()
-      .withClassName("Pizza")
-      .withID(objTID)
-      .withProperties(propertiesSchemaT)
-      .run();
+        .withClassName("Pizza")
+        .withID(objTID)
+        .withProperties(propertiesSchemaT)
+        .run();
     Result<WeaviateObject> objectA = client.data().creator()
-      .withClassName("Soup")
-      .withID(objAID)
-      .withProperties(propertiesSchemaA)
-      .run();
+        .withClassName("Soup")
+        .withID(objAID)
+        .withProperties(propertiesSchemaA)
+        .run();
     Result<Boolean> mergeObjectT = client.data().updater()
-      .withClassName("Pizza")
-      .withID(objTID)
-      .withProperties(new HashMap<String, java.lang.Object>() {{
-        put("description", "Universally accepted to be the best pizza ever created.");
-      }})
-      .withMerge()
-      .run();
+        .withClassName("Pizza")
+        .withID(objTID)
+        .withProperties(new HashMap<String, java.lang.Object>() {
+          {
+            put("description", "Universally accepted to be the best pizza ever created.");
+          }
+        })
+        .withMerge()
+        .run();
     Result<Boolean> mergeObjectA = client.data().updater()
-      .withClassName("Soup")
-      .withID(objAID)
-      .withProperties(new HashMap<String, java.lang.Object>() {{
-        put("description", "Used by humans when their inferior genetics are attacked by microscopic organisms.");
-      }})
-      .withMerge()
-      .run();
-    Result<List<WeaviateObject>> mergedObjsT = client.data().objectsGetter().withClassName("Pizza").withID(objTID).run();
-    Result<List<WeaviateObject>> mergeddObjsA = client.data().objectsGetter().withClassName("Soup").withID(objAID).run();
+        .withClassName("Soup")
+        .withID(objAID)
+        .withProperties(new HashMap<String, java.lang.Object>() {
+          {
+            put("description", "Used by humans when their inferior genetics are attacked by microscopic organisms.");
+          }
+        })
+        .withMerge()
+        .run();
+    Result<List<WeaviateObject>> mergedObjsT = client.data().objectsGetter().withClassName("Pizza").withID(objTID)
+        .run();
+    Result<List<WeaviateObject>> mergeddObjsA = client.data().objectsGetter().withClassName("Soup").withID(objAID)
+        .run();
     testGenerics.cleanupWeaviate(client);
     // then
     DataTestSuite.testDataMerge.assertResults(objectT, objectA, mergeObjectT, mergeObjectA, mergedObjsT, mergeddObjsA);
@@ -336,27 +457,27 @@ public class ClientDataTest {
     // when
     testGenerics.createWeaviateTestSchemaFood(client);
     Result<Boolean> validateObjT = client.data().validator()
-      .withClassName("Pizza")
-      .withID(objTID)
-      .withProperties(propertiesSchemaT)
-      .run();
+        .withClassName("Pizza")
+        .withID(objTID)
+        .withProperties(propertiesSchemaT)
+        .run();
     Result<Boolean> validateObjA = client.data().validator()
-      .withClassName("Soup")
-      .withID(objAID)
-      .withProperties(propertiesSchemaA)
-      .run();
+        .withClassName("Soup")
+        .withID(objAID)
+        .withProperties(propertiesSchemaA)
+        .run();
     propertiesSchemaT.put("test", "not existing property");
     Result<Boolean> validateObjT1 = client.data().validator()
-      .withClassName("Pizza")
-      .withID(objTID)
-      .withProperties(propertiesSchemaT)
-      .run();
+        .withClassName("Pizza")
+        .withID(objTID)
+        .withProperties(propertiesSchemaT)
+        .run();
     propertiesSchemaA.put("test", "not existing property");
     Result<Boolean> validateObjA1 = client.data().validator()
-      .withClassName("Pizza")
-      .withID(objTID)
-      .withProperties(propertiesSchemaT)
-      .run();
+        .withClassName("Pizza")
+        .withID(objTID)
+        .withProperties(propertiesSchemaT)
+        .run();
     testGenerics.cleanupWeaviate(client);
     // then
     DataTestSuite.testDataValidate.assertResults(validateObjT, validateObjA, validateObjT1, validateObjA1);
@@ -375,22 +496,22 @@ public class ClientDataTest {
     // when
     testGenerics.createWeaviateTestSchemaFood(client);
     Result<WeaviateObject> objectT = client.data().creator()
-      .withClassName("Pizza")
-      .withID(objTID)
-      .withProperties(propertiesSchemaT)
-      .run();
+        .withClassName("Pizza")
+        .withID(objTID)
+        .withProperties(propertiesSchemaT)
+        .run();
     Result<WeaviateObject> objectA = client.data().creator()
-      .withClassName("Soup")
-      .withID(objAID)
-      .withProperties(propertiesSchemaA)
-      .run();
+        .withClassName("Soup")
+        .withID(objAID)
+        .withProperties(propertiesSchemaA)
+        .run();
     Result<List<WeaviateObject>> objsAdditionalT = client.data()
-      .objectsGetter()
-      .withID(objTID)
-      .withClassName("Pizza")
-      .withAdditional("featureProjection")
-      .withVector()
-      .run();
+        .objectsGetter()
+        .withID(objTID)
+        .withClassName("Pizza")
+        .withAdditional("featureProjection")
+        .withVector()
+        .run();
     testGenerics.cleanupWeaviate(client);
     // then
     DataTestSuite.testDataGetWithAdditionalError.assertResults(objectT, objectA, objsAdditionalT);
@@ -408,15 +529,17 @@ public class ClientDataTest {
     Result<Boolean> createStatus = client.schema().classCreator().withClass(clazz).run();
     Result<Schema> schemaAfterCreate = client.schema().getter().run();
     Result<WeaviateObject> objectT = client.data().creator()
-      .withClassName("ClassArrays")
-      .withID(objTID)
-      .withProperties(propertiesSchemaT)
-      .run();
-    Result<List<WeaviateObject>> objectsT = client.data().objectsGetter().withClassName("ClassArrays").withID(objTID).run();
+        .withClassName("ClassArrays")
+        .withID(objTID)
+        .withProperties(propertiesSchemaT)
+        .run();
+    Result<List<WeaviateObject>> objectsT = client.data().objectsGetter().withClassName("ClassArrays").withID(objTID)
+        .run();
     Result<Boolean> deleteStatus = client.schema().allDeleter().run();
     Result<Schema> schemaAfterDelete = client.schema().getter().run();
     // then
-    DataTestSuite.testDataCreateWithArrayType.assertResults(createStatus, schemaAfterCreate, objectT, objectsT, deleteStatus, schemaAfterDelete);
+    DataTestSuite.testDataCreateWithArrayType.assertResults(createStatus, schemaAfterCreate, objectT, objectsT,
+        deleteStatus, schemaAfterDelete);
   }
 
   @Test
@@ -432,20 +555,21 @@ public class ClientDataTest {
     Result<Boolean> createStatus = client.schema().classCreator().withClass(clazz).run();
     Result<Schema> schemaAfterCreate = client.schema().getter().run();
     Result<WeaviateObject> objectT = client.data().creator()
-      .withClassName("ClassCustomVector")
-      .withID(objTID)
-      .withVector(vectorObjT)
-      .withProperties(propertiesSchemaT)
-      .run();
+        .withClassName("ClassCustomVector")
+        .withID(objTID)
+        .withVector(vectorObjT)
+        .withProperties(propertiesSchemaT)
+        .run();
     Result<List<WeaviateObject>> objT = client.data()
-      .objectsGetter()
-      .withClassName("ClassCustomVector").withID(objTID)
-      .withVector()
-      .run();
+        .objectsGetter()
+        .withClassName("ClassCustomVector").withID(objTID)
+        .withVector()
+        .run();
     Result<Boolean> deleteStatus = client.schema().allDeleter().run();
     Result<Schema> schemaAfterDelete = client.schema().getter().run();
     // then
-    DataTestSuite.testDataGetWithVector.assertResults(createStatus, schemaAfterCreate, objectT, objT, deleteStatus, schemaAfterDelete);
+    DataTestSuite.testDataGetWithVector.assertResults(createStatus, schemaAfterCreate, objectT, objT, deleteStatus,
+        schemaAfterDelete);
   }
 
   @Test
@@ -462,31 +586,32 @@ public class ClientDataTest {
     // when
     testGenerics.createWeaviateTestSchemaFood(client);
     Result<WeaviateObject> objectT = client.data().creator()
-      .withClassName("Pizza")
-      .withID(objTID)
-      .withProperties(propertiesSchemaT)
-      .run();
+        .withClassName("Pizza")
+        .withID(objTID)
+        .withProperties(propertiesSchemaT)
+        .run();
     Result<WeaviateObject> objectA = client.data().creator()
-      .withClassName("Soup")
-      .withID(objAID)
-      .withProperties(propertiesSchemaA)
-      .run();
+        .withClassName("Soup")
+        .withID(objAID)
+        .withProperties(propertiesSchemaA)
+        .run();
     // check object existence
     Result<Boolean> checkObjT = client.data().checker().withClassName("Pizza").withID(objTID).run();
     Result<Boolean> checkObjA = client.data().checker().withClassName("Soup").withID(objAID).run();
     Result<List<WeaviateObject>> objA = client.data()
-      .objectsGetter()
-      .withID(objAID)
-      .withClassName("Soup")
-      .withVector()
-      .run();
+        .objectsGetter()
+        .withID(objAID)
+        .withClassName("Soup")
+        .withVector()
+        .run();
     Result<List<WeaviateObject>> objT = client.data()
-      .objectsGetter()
-      .withID(objTID)
-      .withClassName("Pizza")
-      .withVector()
-      .run();
-    Result<Boolean> checkNonexistentObject = client.data().checker().withClassName("Pizza").withID(nonExistentObjectID).run();
+        .objectsGetter()
+        .withID(objTID)
+        .withClassName("Pizza")
+        .withVector()
+        .run();
+    Result<Boolean> checkNonexistentObject = client.data().checker().withClassName("Pizza").withID(nonExistentObjectID)
+        .run();
     // delete all objects from Weaviate
     Result<Boolean> deleteStatus = client.schema().allDeleter().run();
     // check object's existence status after clean up
@@ -495,7 +620,8 @@ public class ClientDataTest {
     testGenerics.cleanupWeaviate(client);
     // then
     DataTestSuite.testObjectCheck
-      .assertResults(objectT, objectA, checkObjT, checkObjA, objA, objT, checkNonexistentObject, deleteStatus, checkObjTAfterDelete, checkObjAAfterDelete);
+        .assertResults(objectT, objectA, checkObjT, checkObjA, objA, objT, checkNonexistentObject, deleteStatus,
+            checkObjTAfterDelete, checkObjAAfterDelete);
   }
 
   @Test
@@ -504,13 +630,14 @@ public class ClientDataTest {
     Config config = new Config("http", address);
     WeaviateClient client = new WeaviateClient(config);
     String objID = DataTestSuite.testDataCreateWithIDInNotUUIDFormat.objID;
-    Map<String, java.lang.Object> propertiesSchemaT = DataTestSuite.testDataCreateWithIDInNotUUIDFormat.propertiesSchemaT();
+    Map<String, java.lang.Object> propertiesSchemaT = DataTestSuite.testDataCreateWithIDInNotUUIDFormat
+        .propertiesSchemaT();
     // when
     Result<WeaviateObject> objectT = client.data().creator()
-      .withID(objID)
-      .withClassName("Pizza")
-      .withProperties(propertiesSchemaT)
-      .run();
+        .withID(objID)
+        .withClassName("Pizza")
+        .withProperties(propertiesSchemaT)
+        .run();
     Result<List<WeaviateObject>> objectsT = client.data().objectsGetter().withClassName("Pizza").withID(objID).run();
     Result<Boolean> deleteStatus = client.schema().allDeleter().run();
     Result<Schema> schemaAfterDelete = client.schema().getter().run();
@@ -526,28 +653,41 @@ public class ClientDataTest {
     WeaviateTestGenerics testGenerics = new WeaviateTestGenerics();
     // when
     testGenerics.createWeaviateTestSchemaFood(client);
-    Result<WeaviateObject> pizzaObj1 = client.data().creator().withClassName("Pizza").withProperties(new HashMap<String, java.lang.Object>() {{
-      put("name", "Margherita");
-      put("description", "plain");
-    }}).run();
-    Result<WeaviateObject> pizzaObj2 = client.data().creator().withClassName("Pizza").withProperties(new HashMap<String, java.lang.Object>() {{
-      put("name", "Pepperoni");
-      put("description", "meat");
-    }}).run();
-    Result<WeaviateObject> soupObj1 = client.data().creator().withClassName("Soup").withProperties(new HashMap<String, java.lang.Object>() {{
-      put("name", "Chicken");
-      put("description", "plain");
-    }}).run();
-    Result<WeaviateObject> soupObj2 = client.data().creator().withClassName("Soup").withProperties(new HashMap<String, java.lang.Object>() {{
-      put("name", "Tofu");
-      put("description", "vegetarian");
-    }}).run();
+    Result<WeaviateObject> pizzaObj1 = client.data().creator().withClassName("Pizza")
+        .withProperties(new HashMap<String, java.lang.Object>() {
+          {
+            put("name", "Margherita");
+            put("description", "plain");
+          }
+        }).run();
+    Result<WeaviateObject> pizzaObj2 = client.data().creator().withClassName("Pizza")
+        .withProperties(new HashMap<String, java.lang.Object>() {
+          {
+            put("name", "Pepperoni");
+            put("description", "meat");
+          }
+        }).run();
+    Result<WeaviateObject> soupObj1 = client.data().creator().withClassName("Soup")
+        .withProperties(new HashMap<String, java.lang.Object>() {
+          {
+            put("name", "Chicken");
+            put("description", "plain");
+          }
+        }).run();
+    Result<WeaviateObject> soupObj2 = client.data().creator().withClassName("Soup")
+        .withProperties(new HashMap<String, java.lang.Object>() {
+          {
+            put("name", "Tofu");
+            put("description", "vegetarian");
+          }
+        }).run();
     Result<List<WeaviateObject>> objects = client.data().objectsGetter().run();
     Result<List<WeaviateObject>> pizzaObjects = client.data().objectsGetter().withClassName("Pizza").run();
     Result<List<WeaviateObject>> soupObjects = client.data().objectsGetter().withClassName("Soup").run();
     testGenerics.cleanupWeaviate(client);
     // then
-    DataTestSuite.testDataGetUsingClassParameter.assertResults(pizzaObj1, pizzaObj2, soupObj1, soupObj2, objects, pizzaObjects, soupObjects);
+    DataTestSuite.testDataGetUsingClassParameter.assertResults(pizzaObj1, pizzaObj2, soupObj1, soupObj2, objects,
+        pizzaObjects, soupObjects);
   }
 
   private void assertCreated(Result<WeaviateObject> obj) {
@@ -572,67 +712,64 @@ public class ClientDataTest {
 
     String className = "ClassUUID";
     WeaviateClass clazz = WeaviateClass.builder()
-      .className(className)
-      .description("class with uuid properties")
-      .properties(Arrays.asList(
-        Property.builder()
-          .dataType(Collections.singletonList(DataType.UUID))
-          .name("uuidProp")
-          .build(),
-        Property.builder()
-          .dataType(Collections.singletonList(DataType.UUID_ARRAY))
-          .name("uuidArrayProp")
-          .build()
-      ))
-      .build();
+        .className(className)
+        .description("class with uuid properties")
+        .properties(Arrays.asList(
+            Property.builder()
+                .dataType(Collections.singletonList(DataType.UUID))
+                .name("uuidProp")
+                .build(),
+            Property.builder()
+                .dataType(Collections.singletonList(DataType.UUID_ARRAY))
+                .name("uuidArrayProp")
+                .build()))
+        .build();
 
     String id = "abefd256-8574-442b-9293-9205193737ee";
     Map<String, Object> properties = new HashMap<>();
     properties.put("uuidProp", "7aaa79d3-a564-45db-8fa8-c49e20b8a39a");
-    properties.put("uuidArrayProp", new String[]{
-      "f70512a3-26cb-4ae4-9369-204555917f15",
-      "9e516f40-fd54-4083-a476-f4675b2b5f92"
+    properties.put("uuidArrayProp", new String[] {
+        "f70512a3-26cb-4ae4-9369-204555917f15",
+        "9e516f40-fd54-4083-a476-f4675b2b5f92"
     });
 
     Result<Boolean> createStatus = client.schema().classCreator()
-      .withClass(clazz)
-      .run();
+        .withClass(clazz)
+        .run();
 
     assertThat(createStatus).isNotNull()
-      .returns(false, Result::hasErrors)
-      .returns(true, Result::getResult);
+        .returns(false, Result::hasErrors)
+        .returns(true, Result::getResult);
 
     Result<WeaviateObject> objectStatus = client.data().creator()
-      .withClassName(className)
-      .withID(id)
-      .withProperties(properties)
-      .run();
+        .withClassName(className)
+        .withID(id)
+        .withProperties(properties)
+        .run();
 
     assertThat(objectStatus).isNotNull()
-      .returns(false, Result::hasErrors)
-      .extracting(Result::getResult).isNotNull();
+        .returns(false, Result::hasErrors)
+        .extracting(Result::getResult).isNotNull();
 
     Result<List<WeaviateObject>> objectsStatus = client.data().objectsGetter()
-      .withClassName(className)
-      .withID(id)
-      .run();
+        .withClassName(className)
+        .withID(id)
+        .run();
 
     assertThat(objectsStatus).isNotNull()
-      .returns(false, Result::hasErrors)
-      .extracting(Result::getResult).asList()
-      .hasSize(1)
-      .first().extracting(obj -> ((WeaviateObject) obj).getProperties())
-      .returns("7aaa79d3-a564-45db-8fa8-c49e20b8a39a", props -> props.get("uuidProp"))
-      .returns(Arrays.asList(
-        "f70512a3-26cb-4ae4-9369-204555917f15",
-        "9e516f40-fd54-4083-a476-f4675b2b5f92"
-      ), props -> props.get("uuidArrayProp"));
+        .returns(false, Result::hasErrors)
+        .extracting(Result::getResult).asList()
+        .hasSize(1)
+        .first().extracting(obj -> ((WeaviateObject) obj).getProperties())
+        .returns("7aaa79d3-a564-45db-8fa8-c49e20b8a39a", props -> props.get("uuidProp"))
+        .returns(Arrays.asList(
+            "f70512a3-26cb-4ae4-9369-204555917f15",
+            "9e516f40-fd54-4083-a476-f4675b2b5f92"), props -> props.get("uuidArrayProp"));
 
     Result<Boolean> deleteStatus = client.schema().allDeleter().run();
 
     assertThat(deleteStatus).isNotNull()
-      .returns(false, Result::hasErrors)
-      .returns(true, Result::getResult);
+        .returns(false, Result::hasErrors)
+        .returns(true, Result::getResult);
   }
 }
-

--- a/src/test/java/io/weaviate/integration/client/data/ClientDataTest.java
+++ b/src/test/java/io/weaviate/integration/client/data/ClientDataTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.util.ArrayList;
@@ -391,6 +392,92 @@ public class ClientDataTest {
     // then
     DataTestSuite.testDataUpdate.assertResults(objectT, objectA, updateObjectT, updateObjectA, updatedObjsT,
         updatedObjsA);
+  }
+
+  @Test
+  public void testDataUpdateMultiVectors() {
+    WeaviateClient client = new WeaviateClient(new Config("http", address));
+
+    // Arrange: Configure collection and create it
+    String className = "NamedMultiVectors";
+    WeaviateClass weaviateClass = WeaviateClass.builder()
+        .className(className)
+        .properties(Arrays.asList(
+            Property.builder()
+                .name("name")
+                .dataType(Collections.singletonList(DataType.TEXT))
+                .build()))
+        .vectorConfig(new HashMap<String, WeaviateClass.VectorConfig>() {
+          {
+            this.put("colbert", WeaviateClass.VectorConfig.builder()
+                .vectorizer(new HashMap<String, Object>() {
+                  {
+                    this.put("none", new Object());
+                  }
+                })
+                .vectorIndexConfig(VectorIndexConfig.builder()
+                    .multiVector(MultiVectorConfig.builder().build())
+                    .build())
+                .vectorIndexType("hnsw")
+                .build());
+          }
+        })
+        .build();
+
+    Result<Boolean> createResult = client.schema().classCreator().withClass(weaviateClass).run();
+    assumeTrue(createResult.getResult(), "schema created successfully");
+
+    String id = UUID.randomUUID().toString();
+    Float[][] colbertVector = new Float[][] {
+        { 0.11f, 0.22f, 0.33f, 0.123f, -0.900009f, -0.0000000001f },
+        { 0.11f, 0.22f, 0.33f, 0.123f, -0.900009f, -0.0000000001f },
+    };
+
+    Result<WeaviateObject> insertResult = client.data().creator()
+        .withID(id).withClassName(className)
+        .withProperties(new HashMap<String, Object>() {
+          {
+            this.put("name", "TestObject-1");
+          }
+        })
+        .withMultiVectors(new HashMap<String, Float[][]>() {
+          {
+            this.put("colbert", colbertVector);
+          }
+        })
+        .run();
+    assumeFalse(insertResult.hasErrors(), "test data inserted successfully");
+
+    // Act: Update data
+    Float[][] newVector = Arrays.stream(colbertVector)
+        .map(inner -> Arrays.stream(inner).map(v -> 5 * v).toArray(Float[]::new))
+        .toArray(Float[][]::new);
+    Result<Boolean> updateResult = client.data().updater()
+        .withID(id).withClassName(className)
+        .withMultiVectors(new HashMap<String, Float[][]>() {
+          {
+            this.put("colbert", newVector);
+          }
+        })
+        .run();
+    assertNull("successfully updated metadata", updateResult.getError());
+
+    // Assert: Retrieve object and check metadata
+    Result<List<WeaviateObject>> getResult = client.data().objectsGetter()
+        .withClassName(className).withID(id).withVector().run();
+
+    assertThat(getResult).isNotNull()
+        .returns(null, Result::getError).as("get object error")
+        .extracting(Result::getResult).isNotNull().as("result not null")
+        .extracting(r -> r.get(0)).isNotNull().as("first object")
+        .satisfies(o -> {
+          assertThat(o.getMultiVectors()).as("multi-vectors")
+              .isNotEmpty().containsOnlyKeys("colbert")
+              .satisfies(multi -> {
+                assertThat(multi.get("colbert")).as("colbert multivector")
+                    .isEqualTo(newVector);
+              });
+        }).as("expected updated object metadata");
   }
 
   @Test

--- a/src/test/java/io/weaviate/integration/tests/batch/ClientBatchGrpcCreateNamedVectorsTestSuite.java
+++ b/src/test/java/io/weaviate/integration/tests/batch/ClientBatchGrpcCreateNamedVectorsTestSuite.java
@@ -1,113 +1,249 @@
 package io.weaviate.integration.tests.batch;
 
-import io.weaviate.client.base.Result;
-import io.weaviate.client.v1.batch.model.ObjectGetResponse;
-import io.weaviate.client.v1.data.model.WeaviateObject;
-import io.weaviate.client.v1.misc.model.BQConfig;
-import io.weaviate.client.v1.misc.model.VectorIndexConfig;
-import io.weaviate.client.v1.schema.model.DataType;
-import io.weaviate.client.v1.schema.model.Property;
-import io.weaviate.client.v1.schema.model.WeaviateClass;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.ARRAY;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.Function;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.InstanceOfAssertFactories.ARRAY;
+
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.batch.model.ObjectGetResponse;
+import io.weaviate.client.v1.batch.model.ObjectsGetResponseAO2Result;
+import io.weaviate.client.v1.data.model.WeaviateObject;
+import io.weaviate.client.v1.misc.model.BQConfig;
+import io.weaviate.client.v1.misc.model.MultiVectorConfig;
+import io.weaviate.client.v1.misc.model.VectorIndexConfig;
+import io.weaviate.client.v1.schema.model.DataType;
+import io.weaviate.client.v1.schema.model.Property;
+import io.weaviate.client.v1.schema.model.WeaviateClass;
 
 public class ClientBatchGrpcCreateNamedVectorsTestSuite {
 
   public static void shouldCreateObjectsWithNamedVectors(Function<WeaviateClass, Result<Boolean>> classCreate,
-    Function<WeaviateObject, Result<ObjectGetResponse[]>> batchCreate,
-    Function<WeaviateObject, Result<List<WeaviateObject>>> fetch,
-    Function<String, Result<Boolean>> deleteClass) {
+      Function<WeaviateObject, Result<ObjectGetResponse[]>> batchCreate,
+      Function<WeaviateObject, Result<List<WeaviateObject>>> fetch,
+      Function<String, Result<Boolean>> deleteClass) {
     String className = "NamedVectors";
     List<Property> properties = Arrays.asList(
-      Property.builder()
-        .name("name")
-        .dataType(Collections.singletonList(DataType.TEXT))
-        .build(),
-      Property.builder()
-        .name("title")
-        .dataType(Collections.singletonList(DataType.TEXT))
-        .build());
+        Property.builder()
+            .name("name")
+            .dataType(Collections.singletonList(DataType.TEXT))
+            .build(),
+        Property.builder()
+            .name("title")
+            .dataType(Collections.singletonList(DataType.TEXT))
+            .build());
     Map<String, Object> none = new HashMap<>();
     none.put("none", new Object());
     Map<String, Object> text2vecContextionary = new HashMap<>();
-    Map<String, Object> text2vecContextionarySettings =  new HashMap<>();
+    Map<String, Object> text2vecContextionarySettings = new HashMap<>();
     text2vecContextionarySettings.put("vectorizeClassName", false);
-    text2vecContextionarySettings.put("properties", new String[]{"title"});
+    text2vecContextionarySettings.put("properties", new String[] { "title" });
     text2vecContextionary.put("text2vec-contextionary", text2vecContextionarySettings);
     Map<String, WeaviateClass.VectorConfig> vectorConfig = new HashMap<>();
     vectorConfig.put("hnswVector", WeaviateClass.VectorConfig.builder()
-      .vectorIndexType("hnsw")
-      .vectorizer(none)
-      .build());
+        .vectorIndexType("hnsw")
+        .vectorizer(none)
+        .build());
     vectorConfig.put("c11y", WeaviateClass.VectorConfig.builder()
-      .vectorIndexType("flat")
-      .vectorizer(text2vecContextionary)
-      .vectorIndexConfig(VectorIndexConfig.builder()
-        .bq(BQConfig.builder().enabled(true).build())
-        .build())
-      .build());
+        .vectorIndexType("flat")
+        .vectorizer(text2vecContextionary)
+        .vectorIndexConfig(VectorIndexConfig.builder()
+            .bq(BQConfig.builder().enabled(true).build())
+            .build())
+        .build());
     WeaviateClass weaviateClass = WeaviateClass.builder()
-      .className(className)
-      .properties(properties)
-      .vectorConfig(vectorConfig)
-      .build();
+        .className(className)
+        .properties(properties)
+        .vectorConfig(vectorConfig)
+        .build();
     // Supply
     Result<Boolean> createResult = classCreate.apply(weaviateClass);
     assertThat(createResult).isNotNull()
-      .returns(false, Result::hasErrors)
-      .returns(true, Result::getResult);
+        .returns(false, Result::hasErrors)
+        .returns(true, Result::getResult);
 
     // create object
     String id = "00000000-0000-0000-0000-000000000001";
     Map<String, Object> props = new HashMap<>();
     props.put("name", "some name");
     props.put("title", "The Lord of the Rings");
-    Float[] vector = new Float[]{0.11f, 0.22f, 0.33f, 0.123f, -0.900009f, -0.0000000001f};
+    Float[] vector = new Float[] { 0.11f, 0.22f, 0.33f, 0.123f, -0.900009f, -0.0000000001f };
     Map<String, Float[]> vectors = new HashMap<>();
     vectors.put("hnswVector", vector);
     WeaviateObject obj = WeaviateObject.builder()
-      .id(id)
-      .className(className)
-      .properties(props)
-      .vectors(vectors)
-      .build();
+        .id(id)
+        .className(className)
+        .properties(props)
+        .vectors(vectors)
+        .build();
     Result<ObjectGetResponse[]> result = batchCreate.apply(obj);
     assertThat(result).isNotNull()
-      .returns(false, Result::hasErrors)
-      .extracting(Result::getResult).asInstanceOf(ARRAY)
-      .hasSize(1);
+        .returns(false, Result::hasErrors)
+        .extracting(Result::getResult).asInstanceOf(ARRAY)
+        .hasSize(1);
 
     // fetch that object
     Result<List<WeaviateObject>> resultObj = fetch.apply(obj);
     assertThat(resultObj).isNotNull()
-      .returns(false, Result::hasErrors)
-      .extracting(Result::getResult).isNotNull()
-      .extracting(r -> r.get(0)).isNotNull()
-      .satisfies(o -> {
-        assertThat(o.getId()).isEqualTo(obj.getId());
-        assertThat(o.getVectors()).isNotEmpty()
-          .containsOnlyKeys("hnswVector", "c11y")
-          .satisfies(vecs -> {
-            assertThat(vecs.get("hnswVector")).isNotNull().isEqualTo(vector);
-            assertThat(vecs.get("c11y")).isNotEmpty();
+        .returns(false, Result::hasErrors)
+        .extracting(Result::getResult).isNotNull()
+        .extracting(r -> r.get(0)).isNotNull()
+        .satisfies(o -> {
+          assertThat(o.getId()).isEqualTo(obj.getId());
+          assertThat(o.getVectors()).isNotEmpty()
+              .containsOnlyKeys("hnswVector", "c11y")
+              .satisfies(vecs -> {
+                assertThat(vecs.get("hnswVector")).isNotNull().isEqualTo(vector);
+                assertThat(vecs.get("c11y")).isNotEmpty();
+              });
+          assertThat(o.getProperties()).isNotNull()
+              .extracting(Map::size).isEqualTo(obj.getProperties().size());
+          obj.getProperties().keySet().forEach(propName -> {
+            assertThat(o.getProperties().get(propName)).isNotNull();
           });
-        assertThat(o.getProperties()).isNotNull()
-          .extracting(Map::size).isEqualTo(obj.getProperties().size());
-        obj.getProperties().keySet().forEach(propName -> {
-          assertThat(o.getProperties().get(propName)).isNotNull();
         });
-      });
 
     // clean up
     Result<Boolean> delete = deleteClass.apply(className);
     assertThat(delete).isNotNull()
-      .returns(false, Result::hasErrors)
-      .returns(true, Result::getResult);
+        .returns(false, Result::hasErrors)
+        .returns(true, Result::getResult);
+  }
+
+  public static void shouldCreateObjectsWithNamedMultiVectors(Function<WeaviateClass, Result<Boolean>> classCreate,
+      Function<WeaviateObject, Result<ObjectGetResponse[]>> batchCreate,
+      Function<WeaviateObject, Result<List<WeaviateObject>>> fetch,
+      Function<String, Result<Boolean>> deleteClass) {
+
+    // Arrange: Configure collection and create it
+    String className = "NamedMultiVectors";
+    WeaviateClass weaviateClass = WeaviateClass.builder()
+        .className(className)
+        .properties(Arrays.asList(
+            Property.builder()
+                .name("name")
+                .dataType(Collections.singletonList(DataType.TEXT))
+                .build(),
+            Property.builder()
+                .name("title")
+                .dataType(Collections.singletonList(DataType.TEXT))
+                .build()))
+        .vectorConfig(new HashMap<String, WeaviateClass.VectorConfig>() {
+          {
+            this.put("regular", WeaviateClass.VectorConfig.builder()
+                .vectorizer(new HashMap<String, Object>() {
+                  {
+                    this.put("none", new Object());
+                  }
+                })
+                .vectorIndexType("hnsw")
+                .build());
+            this.put("colbert", WeaviateClass.VectorConfig.builder()
+                .vectorizer(new HashMap<String, Object>() {
+                  {
+                    this.put("none", new Object());
+                  }
+                })
+                .vectorIndexConfig(VectorIndexConfig.builder()
+                    .multiVector(MultiVectorConfig.builder().build())
+                    .build())
+                .vectorIndexType("hnsw")
+                .build());
+          }
+        })
+        .build();
+
+    Result<Boolean> createResult = classCreate.apply(weaviateClass);
+    assertThat(createResult).isNotNull()
+        .returns(null, Result::getError).as("create class error")
+        .returns(true, Result::getResult).as("create class successful");
+
+    // Arrange: Prepare test object
+    String id = UUID.randomUUID().toString();
+    Float[][] colbertVector = new Float[][] {
+        { 0.11f, 0.22f, 0.33f, 0.123f, -0.900009f, -0.0000000001f },
+        { 0.11f, 0.22f, 0.33f, 0.123f, -0.900009f, -0.0000000001f },
+    };
+    WeaviateObject testObject = WeaviateObject.builder()
+        .id(id).className(className)
+        .properties(new HashMap<String, Object>() {
+          {
+            this.put("name", "TestObject-1");
+            this.put("title", "The Lord of the Rings");
+          }
+        })
+        .vectors(new HashMap<String, Float[]>() {
+          {
+            this.put("regular", colbertVector[0]);
+          }
+        })
+        .multiVectors(new HashMap<String, Float[][]>() {
+          {
+            this.put("colbert", colbertVector);
+          }
+        })
+        .build();
+
+    // Act: Run batch insert
+    Result<ObjectGetResponse[]> result = batchCreate.apply(testObject);
+    assertThat(result).isNotNull()
+        .returns(null, Result::getError).as("batch insert error")
+        .extracting(Result::getResult).asInstanceOf(ARRAY)
+        .hasSize(1)
+        .satisfies(obj -> {
+          ObjectGetResponse response = ((ObjectGetResponse) obj[0]);
+
+          assertThat(response).extracting(ObjectGetResponse::getResult)
+              .satisfies(r -> {
+                assertThat(r).extracting(ObjectsGetResponseAO2Result::getStatus)
+                    .isEqualTo("SUCCESS").as("gRPC response status");
+                assertThat(r).extracting(ObjectsGetResponseAO2Result::getErrors)
+                    .as("gRPC errors").isNull();
+              });
+          assertThat(response.getMultiVectors()).containsKey("colbert");
+        });
+
+    // Assert: Retrieve object and check its dimensions
+    Result<List<WeaviateObject>> resultObj = fetch.apply(testObject);
+    assertThat(resultObj).isNotNull()
+        .returns(null, Result::getError).as("fetch object error")
+        .extracting(Result::getResult).isNotNull().as("result not null")
+        .extracting(r -> r.get(0)).isNotNull().as("first object")
+        .satisfies(o -> {
+          assertThat(o.getId()).isEqualTo(id).as("ids match");
+
+          // 1d vectors under "vectors"
+          assertThat(o.getVectors()).isNotEmpty()
+              .containsOnlyKeys("regular");
+
+          // ColBERT vectors under "multiVectors"
+          assertThat(o.getMultiVectors()).isNotEmpty()
+              .containsOnlyKeys("colbert")
+              .satisfies(vecs -> {
+                assertThat(vecs.get("colbert")).isEqualTo(colbertVector)
+                    .as("colbert vector");
+              }).as("has expected vectors");
+
+          assertThat(o.getProperties()).isNotNull()
+              .extracting(Map::size).isEqualTo(testObject.getProperties().size())
+              .as("has expected properties");
+
+          testObject.getProperties().keySet().forEach(propName -> {
+            assertThat(o.getProperties().get(propName))
+                .isNotNull().as(propName);
+          });
+        }).as("wrong object data");
+
+    // clean up
+    Result<Boolean> delete = deleteClass.apply(className);
+    assertThat(delete).isNotNull()
+        .returns(false, Result::hasErrors)
+        .returns(true, Result::getResult);
   }
 }

--- a/src/test/java/io/weaviate/integration/tests/batch/ClientBatchGrpcCreateNamedVectorsTestSuite.java
+++ b/src/test/java/io/weaviate/integration/tests/batch/ClientBatchGrpcCreateNamedVectorsTestSuite.java
@@ -238,7 +238,7 @@ public class ClientBatchGrpcCreateNamedVectorsTestSuite {
             assertThat(o.getProperties().get(propName))
                 .isNotNull().as(propName);
           });
-        }).as("wrong object data");
+        }).as("expected object metadata");
 
     // clean up
     Result<Boolean> delete = deleteClass.apply(className);


### PR DESCRIPTION
## What's changed

This PR adds supports for ColBERT embeddings / multi-vectors.
Notable changes:

- Collection has a new parameter `MultiVectorConfig`
- GRPC util methods extended to handle `Float[][]` vectors (`byteops` package as a reference implementation) 
- Custom JsonSerializer + JsonDeserializer for `WeaviateObject` which merges named vectors and named "multi-vectors" to `"vectors"` field

Note, that WeaviateObject does not have a `Float[][] vector` field, as [Weaviate only expects 1d-vectors under `"vector"`](https://github.com/weaviate/weaviate/blob/7bcbd61a893de80a0724da31ecee4b26485c5538/entities/models/object.go#L31-L63).

## How is this tested:
- Unit tests for float arrays (de-)serialization
- Integration tests for:
  - collection configuration
  - creating/updating multi-vectors on a collection
  - batch insertion