### PR TITLE
fix: return batch errors alongside successfully inserted objects

### DIFF
--- a/src/main/java/io/weaviate/client/v1/batch/model/ObjectsGetResponseAO2Result.java
+++ b/src/main/java/io/weaviate/client/v1/batch/model/ObjectsGetResponseAO2Result.java
@@ -1,13 +1,16 @@
 package io.weaviate.client.v1.batch.model;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.FieldDefaults;
-
-import java.util.List;
 
 @Getter
 @Setter
@@ -18,19 +21,23 @@ public class ObjectsGetResponseAO2Result {
   ErrorResponse errors;
   String status;
 
-
   @Getter
   @ToString
   @EqualsAndHashCode
   @FieldDefaults(level = AccessLevel.PRIVATE)
   public static class ErrorResponse {
     List<ErrorItem> error;
+
+    public ErrorResponse(String... errors) {
+      this.error = Arrays.stream(errors).map(ErrorItem::new).collect(Collectors.toList());
+    }
   }
 
   @Getter
   @ToString
   @EqualsAndHashCode
   @FieldDefaults(level = AccessLevel.PRIVATE)
+  @AllArgsConstructor
   public static class ErrorItem {
     String message;
   }

--- a/src/test/java/io/weaviate/integration/client/async/batch/ClientBatchGrpcCreateTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/batch/ClientBatchGrpcCreateTest.java
@@ -1,5 +1,16 @@
 package io.weaviate.integration.client.async.batch;
 
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
 import io.weaviate.client.Config;
 import io.weaviate.client.WeaviateClient;
 import io.weaviate.client.base.Result;
@@ -8,18 +19,16 @@ import io.weaviate.client.v1.batch.model.ObjectGetResponse;
 import io.weaviate.client.v1.data.model.WeaviateObject;
 import io.weaviate.client.v1.schema.model.WeaviateClass;
 import io.weaviate.integration.client.WeaviateDockerCompose;
+import io.weaviate.integration.client.WeaviateTestGenerics;
+import io.weaviate.integration.tests.batch.BatchObjectsTestSuite;
 import io.weaviate.integration.tests.batch.ClientBatchGrpcCreateTestSuite;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.function.Function;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
 
 public class ClientBatchGrpcCreateTest {
 
   private static String httpHost;
   private static String grpcHost;
+
+  private final WeaviateTestGenerics testGenerics = new WeaviateTestGenerics();
 
   @ClassRule
   public static WeaviateDockerCompose compose = new WeaviateDockerCompose();
@@ -28,6 +37,11 @@ public class ClientBatchGrpcCreateTest {
   public void before() {
     httpHost = compose.getHttpHostAddress();
     grpcHost = compose.getGrpcHostAddress();
+
+    WeaviateClient client = createClient(false);
+
+    testGenerics.cleanupWeaviate(client);
+    testGenerics.createWeaviateTestSchemaFood(client);
   }
 
   @Test
@@ -46,8 +60,8 @@ public class ClientBatchGrpcCreateTest {
     Function<WeaviateClass, Result<Boolean>> createClass = (weaviateClass) -> {
       try (WeaviateAsyncClient asyncClient = client.async()) {
         return asyncClient.schema().classCreator()
-          .withClass(weaviateClass)
-          .run().get();
+            .withClass(weaviateClass)
+            .run().get();
       } catch (InterruptedException | ExecutionException e) {
         throw new RuntimeException(e);
       }
@@ -56,8 +70,8 @@ public class ClientBatchGrpcCreateTest {
     Function<WeaviateObject[], Result<ObjectGetResponse[]>> batchCreate = (objects) -> {
       try (WeaviateAsyncClient asyncClient = client.async()) {
         return asyncClient.batch().objectsBatcher()
-          .withObjects(objects)
-          .run().get();
+            .withObjects(objects)
+            .run().get();
       } catch (InterruptedException | ExecutionException e) {
         throw new RuntimeException(e);
       }
@@ -66,8 +80,8 @@ public class ClientBatchGrpcCreateTest {
     Function<WeaviateObject, Result<List<WeaviateObject>>> fetchObject = (obj) -> {
       try (WeaviateAsyncClient asyncClient = client.async()) {
         return asyncClient.data().objectsGetter()
-          .withID(obj.getId()).withClassName(obj.getClassName()).withVector()
-          .run().get();
+            .withID(obj.getId()).withClassName(obj.getClassName()).withVector()
+            .run().get();
       } catch (InterruptedException | ExecutionException e) {
         throw new RuntimeException(e);
       }
@@ -82,6 +96,39 @@ public class ClientBatchGrpcCreateTest {
     };
 
     ClientBatchGrpcCreateTestSuite.shouldCreateBatch(client, createClass, batchCreate, fetchObject, deleteClass);
+  }
+
+  @Test
+  public void testPartialErrorResponse() throws ExecutionException, InterruptedException {
+    WeaviateClient syncClient = createClient(true);
+
+    try (WeaviateAsyncClient client = syncClient.async()) {
+
+      WeaviateObject[] batchObjects = {
+          WeaviateObject.builder()
+              .className("Pizza")
+              .id(UUID.randomUUID().toString())
+              .properties(BatchObjectsTestSuite.createFoodProperties(1, "This pizza should throw a invalid name error"))
+              .build(),
+          WeaviateObject.builder()
+              .className("Pizza")
+              .id(UUID.randomUUID().toString())
+              .properties(BatchObjectsTestSuite.PIZZA_2_PROPS)
+              .build(),
+      };
+
+      Result<ObjectGetResponse[]> result = client.batch().objectsBatcher()
+          .withObjects(batchObjects)
+          .run().get();
+
+      Assertions.assertThat(result).as("batch insert result")
+          .returns(true, Result::hasErrors)
+          .extracting(Result::getResult).asInstanceOf(InstanceOfAssertFactories.array(ObjectGetResponse[].class))
+          .hasSameSizeAs(batchObjects).as("all batch objects included in the response");
+
+      Assertions.assertThat(result.getResult()[0].getResult().getErrors().getError().get(0).getMessage())
+          .contains("invalid text property 'name' on class 'Pizza': not a string, but float64");
+    }
   }
 
   private WeaviateClient createClient(Boolean useGRPC) {

--- a/src/test/java/io/weaviate/integration/client/batch/ClientBatchCreateTest.java
+++ b/src/test/java/io/weaviate/integration/client/batch/ClientBatchCreateTest.java
@@ -44,135 +44,139 @@ public class ClientBatchCreateTest {
 
   @Test
   public void shouldCreateBatch() {
-    Function<WeaviateObject, Result<ObjectGetResponse[]>> supplierObjectsBatcherPizzas = pizza -> client.batch().objectsBatcher()
-      .withObjects(pizza, WeaviateObject.builder()
-        .className("Pizza")
-        .id(BatchObjectsTestSuite.PIZZA_2_ID)
-        .properties(BatchObjectsTestSuite.PIZZA_2_PROPS)
-        .build())
-      .withConsistencyLevel(ConsistencyLevel.QUORUM)
-      .run();
-    Function<WeaviateObject, Result<ObjectGetResponse[]>> supplierObjectsBatcherSoups = soup -> client.batch().objectsBatcher()
-      .withObjects(soup, WeaviateObject.builder()
-        .className("Soup")
-        .id(BatchObjectsTestSuite.SOUP_2_ID)
-        .properties(BatchObjectsTestSuite.SOUP_2_PROPS)
-        .build())
-      .withConsistencyLevel(ConsistencyLevel.QUORUM)
-      .run();
+    Function<WeaviateObject, Result<ObjectGetResponse[]>> supplierObjectsBatcherPizzas = pizza -> client.batch()
+        .objectsBatcher()
+        .withObjects(pizza, WeaviateObject.builder()
+            .className("Pizza")
+            .id(BatchObjectsTestSuite.PIZZA_2_ID)
+            .properties(BatchObjectsTestSuite.PIZZA_2_PROPS)
+            .build())
+        .withConsistencyLevel(ConsistencyLevel.QUORUM)
+        .run();
+    Function<WeaviateObject, Result<ObjectGetResponse[]>> supplierObjectsBatcherSoups = soup -> client.batch()
+        .objectsBatcher()
+        .withObjects(soup, WeaviateObject.builder()
+            .className("Soup")
+            .id(BatchObjectsTestSuite.SOUP_2_ID)
+            .properties(BatchObjectsTestSuite.SOUP_2_PROPS)
+            .build())
+        .withConsistencyLevel(ConsistencyLevel.QUORUM)
+        .run();
 
     BatchObjectsTestSuite.testCreateBatch(supplierObjectsBatcherPizzas, supplierObjectsBatcherSoups,
-      createSupplierDataPizza1(), createSupplierDataSoup1(),
-      createSupplierGetterPizza1(), createSupplierGetterPizza2(),
-      createSupplierGetterSoup1(), createSupplierGetterSoup2());
+        createSupplierDataPizza1(), createSupplierDataSoup1(),
+        createSupplierGetterPizza1(), createSupplierGetterPizza2(),
+        createSupplierGetterSoup1(), createSupplierGetterSoup2());
   }
 
   @Test
   public void shouldCreateAutoBatch() {
-    BiConsumer<WeaviateObject, Consumer<Result<ObjectGetResponse[]>>> supplierObjectsBatcherPizzas = (pizza, callback) -> {
+    BiConsumer<WeaviateObject, Consumer<Result<ObjectGetResponse[]>>> supplierObjectsBatcherPizzas = (pizza,
+        callback) -> {
       ObjectsBatcher.AutoBatchConfig autoBatchConfig = ObjectsBatcher.AutoBatchConfig.defaultConfig()
-        .batchSize(2)
-        .callback(callback)
-        .build();
+          .batchSize(2)
+          .callback(callback)
+          .build();
 
       client.batch().objectsAutoBatcher(autoBatchConfig)
-        .withObjects(pizza, WeaviateObject.builder().className("Pizza")
-          .id(BatchObjectsTestSuite.PIZZA_2_ID)
-          .properties(BatchObjectsTestSuite.PIZZA_2_PROPS)
-          .build())
-        .flush();
+          .withObjects(pizza, WeaviateObject.builder().className("Pizza")
+              .id(BatchObjectsTestSuite.PIZZA_2_ID)
+              .properties(BatchObjectsTestSuite.PIZZA_2_PROPS)
+              .build())
+          .flush();
     };
-    BiConsumer<WeaviateObject, Consumer<Result<ObjectGetResponse[]>>> supplierObjectsBatcherSoups = (soup, callback) -> {
+    BiConsumer<WeaviateObject, Consumer<Result<ObjectGetResponse[]>>> supplierObjectsBatcherSoups = (soup,
+        callback) -> {
       ObjectsBatcher.AutoBatchConfig autoBatchConfig = ObjectsBatcher.AutoBatchConfig.defaultConfig()
-        .batchSize(2)
-        .callback(callback)
-        .build();
+          .batchSize(2)
+          .callback(callback)
+          .build();
 
       client.batch().objectsAutoBatcher(autoBatchConfig)
-        .withObjects(soup, WeaviateObject.builder()
-          .className("Soup")
-          .id(BatchObjectsTestSuite.SOUP_2_ID)
-          .properties(BatchObjectsTestSuite.SOUP_2_PROPS)
-          .build())
-        .flush();
+          .withObjects(soup, WeaviateObject.builder()
+              .className("Soup")
+              .id(BatchObjectsTestSuite.SOUP_2_ID)
+              .properties(BatchObjectsTestSuite.SOUP_2_PROPS)
+              .build())
+          .flush();
     };
 
     BatchObjectsTestSuite.testCreateAutoBatch(supplierObjectsBatcherPizzas, supplierObjectsBatcherSoups,
-      createSupplierDataPizza1(), createSupplierDataSoup1(),
-      createSupplierGetterPizza1(), createSupplierGetterPizza2(),
-      createSupplierGetterSoup1(), createSupplierGetterSoup2());
+        createSupplierDataPizza1(), createSupplierDataSoup1(),
+        createSupplierGetterPizza1(), createSupplierGetterPizza2(),
+        createSupplierGetterSoup1(), createSupplierGetterSoup2());
   }
 
   @Test
   public void shouldCreateBatchWithPartialError() {
     Supplier<Result<ObjectGetResponse[]>> supplierObjectsBatcherPizzas = () -> {
       WeaviateObject pizzaWithError = WeaviateObject.builder()
-        .className("Pizza")
-        .id(BatchObjectsTestSuite.PIZZA_1_ID)
-        .properties(BatchObjectsTestSuite.createFoodProperties(1, "This pizza should throw a invalid name error"))
-        .build();
+          .className("Pizza")
+          .id(BatchObjectsTestSuite.PIZZA_1_ID)
+          .properties(BatchObjectsTestSuite.createFoodProperties(1, "This pizza should throw a invalid name error"))
+          .build();
       WeaviateObject pizza = WeaviateObject.builder()
-        .className("Pizza")
-        .id(BatchObjectsTestSuite.PIZZA_2_ID)
-        .properties(BatchObjectsTestSuite.PIZZA_2_PROPS)
-        .build();
+          .className("Pizza")
+          .id(BatchObjectsTestSuite.PIZZA_2_ID)
+          .properties(BatchObjectsTestSuite.PIZZA_2_PROPS)
+          .build();
 
       return client.batch().objectsBatcher()
-        .withObjects(pizzaWithError, pizza)
-        .run();
+          .withObjects(pizzaWithError, pizza)
+          .run();
     };
 
     BatchObjectsTestSuite.testCreateBatchWithPartialError(supplierObjectsBatcherPizzas,
-      createSupplierGetterPizza1(), createSupplierGetterPizza2());
+        createSupplierGetterPizza1(), createSupplierGetterPizza2());
   }
 
   @NotNull
   private Supplier<Result<WeaviateObject>> createSupplierDataSoup1() {
     return () -> client.data().creator()
-      .withClassName("Soup")
-      .withID(BatchObjectsTestSuite.SOUP_1_ID)
-      .withProperties(BatchObjectsTestSuite.SOUP_1_PROPS)
-      .run();
+        .withClassName("Soup")
+        .withID(BatchObjectsTestSuite.SOUP_1_ID)
+        .withProperties(BatchObjectsTestSuite.SOUP_1_PROPS)
+        .run();
   }
 
   @NotNull
   private Supplier<Result<WeaviateObject>> createSupplierDataPizza1() {
     return () -> client.data().creator()
-      .withClassName("Pizza")
-      .withID(BatchObjectsTestSuite.PIZZA_1_ID)
-      .withProperties(BatchObjectsTestSuite.PIZZA_1_PROPS)
-      .run();
+        .withClassName("Pizza")
+        .withID(BatchObjectsTestSuite.PIZZA_1_ID)
+        .withProperties(BatchObjectsTestSuite.PIZZA_1_PROPS)
+        .run();
   }
 
   @NotNull
   private Supplier<Result<List<WeaviateObject>>> createSupplierGetterPizza1() {
     return () -> client.data().objectsGetter()
-      .withID(BatchObjectsTestSuite.PIZZA_1_ID)
-      .withClassName("Pizza")
-      .run();
+        .withID(BatchObjectsTestSuite.PIZZA_1_ID)
+        .withClassName("Pizza")
+        .run();
   }
 
   @NotNull
   private Supplier<Result<List<WeaviateObject>>> createSupplierGetterPizza2() {
     return () -> client.data().objectsGetter()
-      .withID(BatchObjectsTestSuite.PIZZA_2_ID)
-      .withClassName("Pizza")
-      .run();
+        .withID(BatchObjectsTestSuite.PIZZA_2_ID)
+        .withClassName("Pizza")
+        .run();
   }
 
   @NotNull
   private Supplier<Result<List<WeaviateObject>>> createSupplierGetterSoup1() {
     return () -> client.data().objectsGetter()
-      .withID(BatchObjectsTestSuite.SOUP_1_ID)
-      .withClassName("Soup")
-      .run();
+        .withID(BatchObjectsTestSuite.SOUP_1_ID)
+        .withClassName("Soup")
+        .run();
   }
 
   @NotNull
   private Supplier<Result<List<WeaviateObject>>> createSupplierGetterSoup2() {
     return () -> client.data().objectsGetter()
-      .withID(BatchObjectsTestSuite.SOUP_2_ID)
-      .withClassName("Soup")
-      .run();
+        .withID(BatchObjectsTestSuite.SOUP_2_ID)
+        .withClassName("Soup")
+        .run();
   }
 }

--- a/src/test/java/io/weaviate/integration/client/batch/ClientBatchGrpcCreateTest.java
+++ b/src/test/java/io/weaviate/integration/client/batch/ClientBatchGrpcCreateTest.java
@@ -1,5 +1,15 @@
 package io.weaviate.integration.client.batch;
 
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
 import io.weaviate.client.Config;
 import io.weaviate.client.WeaviateClient;
 import io.weaviate.client.base.Result;
@@ -7,17 +17,16 @@ import io.weaviate.client.v1.batch.model.ObjectGetResponse;
 import io.weaviate.client.v1.data.model.WeaviateObject;
 import io.weaviate.client.v1.schema.model.WeaviateClass;
 import io.weaviate.integration.client.WeaviateDockerCompose;
+import io.weaviate.integration.client.WeaviateTestGenerics;
+import io.weaviate.integration.tests.batch.BatchObjectsTestSuite;
 import io.weaviate.integration.tests.batch.ClientBatchGrpcCreateTestSuite;
-import java.util.List;
-import java.util.function.Function;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
 
 public class ClientBatchGrpcCreateTest {
 
   private static String httpHost;
   private static String grpcHost;
+
+  private final WeaviateTestGenerics testGenerics = new WeaviateTestGenerics();
 
   @ClassRule
   public static WeaviateDockerCompose compose = new WeaviateDockerCompose();
@@ -26,6 +35,11 @@ public class ClientBatchGrpcCreateTest {
   public void before() {
     httpHost = compose.getHttpHostAddress();
     grpcHost = compose.getGrpcHostAddress();
+
+    WeaviateClient client = createClient(false);
+
+    testGenerics.cleanupWeaviate(client);
+    testGenerics.createWeaviateTestSchemaFood(client);
   }
 
   @Test
@@ -42,20 +56,51 @@ public class ClientBatchGrpcCreateTest {
     WeaviateClient client = createClient(useGRPC);
 
     Function<WeaviateClass, Result<Boolean>> createClass = (weaviateClass) -> client.schema().classCreator()
-      .withClass(weaviateClass)
-      .run();
+        .withClass(weaviateClass)
+        .run();
 
     Function<WeaviateObject[], Result<ObjectGetResponse[]>> batchCreate = (objects) -> client.batch().objectsBatcher()
-      .withObjects(objects)
-      .run();
+        .withObjects(objects)
+        .run();
 
     Function<WeaviateObject, Result<List<WeaviateObject>>> fetchObject = (obj) -> client.data().objectsGetter()
-      .withID(obj.getId()).withClassName(obj.getClassName()).withVector()
-      .run();
+        .withID(obj.getId()).withClassName(obj.getClassName()).withVector()
+        .run();
 
-    Function<String, Result<Boolean>> deleteClass = (className) -> client.schema().classDeleter().withClassName(className).run();
+    Function<String, Result<Boolean>> deleteClass = (className) -> client.schema().classDeleter()
+        .withClassName(className).run();
 
     ClientBatchGrpcCreateTestSuite.shouldCreateBatch(client, createClass, batchCreate, fetchObject, deleteClass);
+  }
+
+  @Test
+  public void testPartialErrorResponse() {
+    WeaviateClient client = createClient(true);
+
+    WeaviateObject[] batchObjects = {
+        WeaviateObject.builder()
+            .className("Pizza")
+            .id(UUID.randomUUID().toString())
+            .properties(BatchObjectsTestSuite.createFoodProperties(1, "This pizza should throw a invalid name error"))
+            .build(),
+        WeaviateObject.builder()
+            .className("Pizza")
+            .id(UUID.randomUUID().toString())
+            .properties(BatchObjectsTestSuite.PIZZA_2_PROPS)
+            .build(),
+    };
+
+    Result<ObjectGetResponse[]> result = client.batch().objectsBatcher()
+        .withObjects(batchObjects)
+        .run();
+
+    Assertions.assertThat(result)
+        .returns(true, Result::hasErrors)
+        .extracting(Result::getResult).asInstanceOf(InstanceOfAssertFactories.array(ObjectGetResponse[].class))
+        .hasSameSizeAs(batchObjects).as("all batch objects included in the response");
+
+    Assertions.assertThat(result.getResult()[0].getResult().getErrors().getError().get(0).getMessage())
+        .contains("invalid text property 'name' on class 'Pizza': not a string, but float64");
   }
 
   private WeaviateClient createClient(Boolean useGRPC) {

--- a/src/test/java/io/weaviate/integration/tests/batch/BatchObjectsTestSuite.java
+++ b/src/test/java/io/weaviate/integration/tests/batch/BatchObjectsTestSuite.java
@@ -21,45 +21,44 @@ public class BatchObjectsTestSuite {
 
   public static final String PIZZA_1_ID = "abefd256-8574-442b-9293-9205193737ee";
   public static final Map<String, Object> PIZZA_1_PROPS = createFoodProperties(
-    "Hawaii", "Universally accepted to be the best pizza ever created.");
+      "Hawaii", "Universally accepted to be the best pizza ever created.");
   public static final String PIZZA_2_ID = "97fa5147-bdad-4d74-9a81-f8babc811b09";
   public static final Map<String, Object> PIZZA_2_PROPS = createFoodProperties(
-    "Doener", "A innovation, some say revolution, in the pizza industry.");
+      "Doener", "A innovation, some say revolution, in the pizza industry.");
   public static final String SOUP_1_ID = "565da3b6-60b3-40e5-ba21-e6bfe5dbba91";
   public static final Map<String, Object> SOUP_1_PROPS = createFoodProperties(
-    "ChickenSoup", "Used by humans when their inferior genetics are attacked by microscopic organisms.");
+      "ChickenSoup", "Used by humans when their inferior genetics are attacked by microscopic organisms.");
   public static final String SOUP_2_ID = "07473b34-0ab2-4120-882d-303d9e13f7af";
   public static final Map<String, Object> SOUP_2_PROPS = createFoodProperties(
-    "Beautiful", "Putting the game of letter soups to a whole new level.");
-
+      "Beautiful", "Putting the game of letter soups to a whole new level.");
 
   public static void testCreateBatch(Function<WeaviateObject, Result<ObjectGetResponse[]>> supplierObjectsBatcherPizzas,
-                                     Function<WeaviateObject, Result<ObjectGetResponse[]>> supplierObjectBatcherSoups,
-                                     Supplier<Result<WeaviateObject>> supplierDataPizza1,
-                                     Supplier<Result<WeaviateObject>> supplierDataSoup1,
-                                     Supplier<Result<List<WeaviateObject>>> supplierGetterPizza1,
-                                     Supplier<Result<List<WeaviateObject>>> supplierGetterPizza2,
-                                     Supplier<Result<List<WeaviateObject>>> supplierGetterSoup1,
-                                     Supplier<Result<List<WeaviateObject>>> supplierGetterSoup2) {
+      Function<WeaviateObject, Result<ObjectGetResponse[]>> supplierObjectBatcherSoups,
+      Supplier<Result<WeaviateObject>> supplierDataPizza1,
+      Supplier<Result<WeaviateObject>> supplierDataSoup1,
+      Supplier<Result<List<WeaviateObject>>> supplierGetterPizza1,
+      Supplier<Result<List<WeaviateObject>>> supplierGetterPizza2,
+      Supplier<Result<List<WeaviateObject>>> supplierGetterSoup1,
+      Supplier<Result<List<WeaviateObject>>> supplierGetterSoup2) {
     // when
     Result<WeaviateObject> resPizza1 = supplierDataPizza1.get();
     Result<WeaviateObject> resSoup1 = supplierDataSoup1.get();
 
     assertThat(resPizza1).isNotNull()
-      .returns(false, Result::hasErrors)
-      .extracting(Result::getResult).isNotNull();
+        .returns(false, Result::hasErrors)
+        .extracting(Result::getResult).isNotNull();
     assertThat(resSoup1).isNotNull()
-      .returns(false, Result::hasErrors)
-      .extracting(Result::getResult).isNotNull();
+        .returns(false, Result::hasErrors)
+        .extracting(Result::getResult).isNotNull();
 
     Result<ObjectGetResponse[]> resBatchPizzas = supplierObjectsBatcherPizzas.apply(resPizza1.getResult());
     Result<ObjectGetResponse[]> resBatchSoups = supplierObjectBatcherSoups.apply(resSoup1.getResult());
 
     assertThat(resBatchPizzas).isNotNull()
-      .returns(false, Result::hasErrors);
+        .returns(false, Result::hasErrors);
     assertThat(resBatchPizzas.getResult()).hasSize(2);
     assertThat(resBatchSoups).isNotNull()
-      .returns(false, Result::hasErrors);
+        .returns(false, Result::hasErrors);
     assertThat(resBatchSoups.getResult()).hasSize(2);
 
     // check if created objects exist
@@ -69,51 +68,52 @@ public class BatchObjectsTestSuite {
     Result<List<WeaviateObject>> resGetSoup2 = supplierGetterSoup2.get();
 
     assertThat(resGetPizza1).isNotNull()
-      .returns(false, Result::hasErrors)
-      .extracting(Result::getResult).asList().hasSize(1)
-      .extracting(o -> ((WeaviateObject) o).getId()).first().isEqualTo(PIZZA_1_ID);
+        .returns(false, Result::hasErrors)
+        .extracting(Result::getResult).asList().hasSize(1)
+        .extracting(o -> ((WeaviateObject) o).getId()).first().isEqualTo(PIZZA_1_ID);
     assertThat(resGetPizza2).isNotNull()
-      .returns(false, Result::hasErrors)
-      .extracting(Result::getResult).asList().hasSize(1)
-      .extracting(o -> ((WeaviateObject) o).getId()).first().isEqualTo(PIZZA_2_ID);
+        .returns(false, Result::hasErrors)
+        .extracting(Result::getResult).asList().hasSize(1)
+        .extracting(o -> ((WeaviateObject) o).getId()).first().isEqualTo(PIZZA_2_ID);
     assertThat(resGetSoup1).isNotNull()
-      .returns(false, Result::hasErrors)
-      .extracting(Result::getResult).asList().hasSize(1)
-      .extracting(o -> ((WeaviateObject) o).getId()).first().isEqualTo(SOUP_1_ID);
+        .returns(false, Result::hasErrors)
+        .extracting(Result::getResult).asList().hasSize(1)
+        .extracting(o -> ((WeaviateObject) o).getId()).first().isEqualTo(SOUP_1_ID);
     assertThat(resGetSoup2).isNotNull()
-      .returns(false, Result::hasErrors)
-      .extracting(Result::getResult).asList().hasSize(1)
-      .extracting(o -> ((WeaviateObject) o).getId()).first().isEqualTo(SOUP_2_ID);
+        .returns(false, Result::hasErrors)
+        .extracting(Result::getResult).asList().hasSize(1)
+        .extracting(o -> ((WeaviateObject) o).getId()).first().isEqualTo(SOUP_2_ID);
   }
 
-  public static void testCreateAutoBatch(BiConsumer<WeaviateObject, Consumer<Result<ObjectGetResponse[]>>> supplierObjectsBatcherPizzas,
-                                         BiConsumer<WeaviateObject, Consumer<Result<ObjectGetResponse[]>>> supplierObjectsBatcherSoups,
-                                         Supplier<Result<WeaviateObject>> supplierDataPizza1,
-                                         Supplier<Result<WeaviateObject>> supplierDataSoup1,
-                                         Supplier<Result<List<WeaviateObject>>> supplierGetterPizza1,
-                                         Supplier<Result<List<WeaviateObject>>> supplierGetterPizza2,
-                                         Supplier<Result<List<WeaviateObject>>> supplierGetterSoup1,
-                                         Supplier<Result<List<WeaviateObject>>> supplierGetterSoup2) {
+  public static void testCreateAutoBatch(
+      BiConsumer<WeaviateObject, Consumer<Result<ObjectGetResponse[]>>> supplierObjectsBatcherPizzas,
+      BiConsumer<WeaviateObject, Consumer<Result<ObjectGetResponse[]>>> supplierObjectsBatcherSoups,
+      Supplier<Result<WeaviateObject>> supplierDataPizza1,
+      Supplier<Result<WeaviateObject>> supplierDataSoup1,
+      Supplier<Result<List<WeaviateObject>>> supplierGetterPizza1,
+      Supplier<Result<List<WeaviateObject>>> supplierGetterPizza2,
+      Supplier<Result<List<WeaviateObject>>> supplierGetterSoup1,
+      Supplier<Result<List<WeaviateObject>>> supplierGetterSoup2) {
     // when
     Result<WeaviateObject> resPizza1 = supplierDataPizza1.get();
     Result<WeaviateObject> resSoup1 = supplierDataSoup1.get();
 
     assertThat(resPizza1).isNotNull()
-      .returns(false, Result::hasErrors)
-      .extracting(Result::getResult).isNotNull();
+        .returns(false, Result::hasErrors)
+        .extracting(Result::getResult).isNotNull();
     assertThat(resSoup1).isNotNull()
-      .returns(false, Result::hasErrors)
-      .extracting(Result::getResult).isNotNull();
+        .returns(false, Result::hasErrors)
+        .extracting(Result::getResult).isNotNull();
 
     List<Result<ObjectGetResponse[]>> resBatches = Collections.synchronizedList(new ArrayList<>(2));
     supplierObjectsBatcherPizzas.accept(resPizza1.getResult(), resBatches::add);
     supplierObjectsBatcherSoups.accept(resSoup1.getResult(), resBatches::add);
 
     assertThat(resBatches.get(0)).isNotNull()
-      .returns(false, Result::hasErrors);
+        .returns(false, Result::hasErrors);
     assertThat(resBatches.get(0).getResult()).hasSize(2);
     assertThat(resBatches.get(1)).isNotNull()
-      .returns(false, Result::hasErrors);
+        .returns(false, Result::hasErrors);
     assertThat(resBatches.get(1).getResult()).hasSize(2);
 
     // check if created objects exist
@@ -123,38 +123,38 @@ public class BatchObjectsTestSuite {
     Result<List<WeaviateObject>> resGetSoup2 = supplierGetterSoup2.get();
 
     assertThat(resGetPizza1).isNotNull()
-      .returns(false, Result::hasErrors)
-      .extracting(Result::getResult).asList().hasSize(1)
-      .extracting(o -> ((WeaviateObject) o).getId()).first().isEqualTo(PIZZA_1_ID);
+        .returns(false, Result::hasErrors)
+        .extracting(Result::getResult).asList().hasSize(1)
+        .extracting(o -> ((WeaviateObject) o).getId()).first().isEqualTo(PIZZA_1_ID);
     assertThat(resGetPizza2).isNotNull()
-      .returns(false, Result::hasErrors)
-      .extracting(Result::getResult).asList().hasSize(1)
-      .extracting(o -> ((WeaviateObject) o).getId()).first().isEqualTo(PIZZA_2_ID);
+        .returns(false, Result::hasErrors)
+        .extracting(Result::getResult).asList().hasSize(1)
+        .extracting(o -> ((WeaviateObject) o).getId()).first().isEqualTo(PIZZA_2_ID);
     assertThat(resGetSoup1).isNotNull()
-      .returns(false, Result::hasErrors)
-      .extracting(Result::getResult).asList().hasSize(1)
-      .extracting(o -> ((WeaviateObject) o).getId()).first().isEqualTo(SOUP_1_ID);
+        .returns(false, Result::hasErrors)
+        .extracting(Result::getResult).asList().hasSize(1)
+        .extracting(o -> ((WeaviateObject) o).getId()).first().isEqualTo(SOUP_1_ID);
     assertThat(resGetSoup2).isNotNull()
-      .returns(false, Result::hasErrors)
-      .extracting(Result::getResult).asList().hasSize(1)
-      .extracting(o -> ((WeaviateObject) o).getId()).first().isEqualTo(SOUP_2_ID);
+        .returns(false, Result::hasErrors)
+        .extracting(Result::getResult).asList().hasSize(1)
+        .extracting(o -> ((WeaviateObject) o).getId()).first().isEqualTo(SOUP_2_ID);
   }
 
   public static void testCreateBatchWithPartialError(Supplier<Result<ObjectGetResponse[]>> supplierObjectsBatcherPizzas,
-                                                     Supplier<Result<List<WeaviateObject>>> supplierGetterPizza1,
-                                                     Supplier<Result<List<WeaviateObject>>> supplierGetterPizza2) {
+      Supplier<Result<List<WeaviateObject>>> supplierGetterPizza1,
+      Supplier<Result<List<WeaviateObject>>> supplierGetterPizza2) {
     Result<ObjectGetResponse[]> resBatch = supplierObjectsBatcherPizzas.get();
     assertThat(resBatch).isNotNull()
-      .returns(false, Result::hasErrors);
+        .returns(false, Result::hasErrors);
     assertThat(resBatch.getResult()).hasSize(2);
 
     ObjectGetResponse resPizzaWithError = resBatch.getResult()[0];
     assertThat(resPizzaWithError.getId()).isEqualTo(PIZZA_1_ID);
     assertThat(resPizzaWithError.getResult().getErrors())
-      .extracting(ObjectsGetResponseAO2Result.ErrorResponse::getError).asList()
-      .first()
-      .extracting(i -> ((ObjectsGetResponseAO2Result.ErrorItem) i).getMessage()).asString()
-      .contains("invalid text property 'name' on class 'Pizza': not a string, but json.Number");
+        .extracting(ObjectsGetResponseAO2Result.ErrorResponse::getError).asList()
+        .first()
+        .extracting(i -> ((ObjectsGetResponseAO2Result.ErrorItem) i).getMessage()).asString()
+        .contains("invalid text property 'name' on class 'Pizza': not a string, but json.Number");
     ObjectGetResponse resPizza = resBatch.getResult()[1];
     assertThat(resPizza.getId()).isEqualTo(PIZZA_2_ID);
     assertThat(resPizza.getResult().getErrors()).isNull();
@@ -163,13 +163,12 @@ public class BatchObjectsTestSuite {
     Result<List<WeaviateObject>> resGetPizza = supplierGetterPizza2.get();
 
     assertThat(resGetPizzaWithError).isNotNull()
-      .returns(false, Result::hasErrors);
+        .returns(false, Result::hasErrors);
     assertThat(resGetPizzaWithError.getResult()).isNull();
     assertThat(resGetPizza).isNotNull()
-      .returns(false, Result::hasErrors);
+        .returns(false, Result::hasErrors);
     assertThat(resGetPizza.getResult()).hasSize(1);
   }
-
 
   public static Map<String, Object> createFoodProperties(Object name, Object description) {
     Map<String, Object> props = new HashMap<>();


### PR DESCRIPTION
This PR aligns Java client with how Go client [treats partial errors in batch](https://github.com/weaviate/weaviate-go-client/blob/93535fb0af578a4d710dcddcdb63252fc8285fc2/weaviate/grpc/batch/batch.go#L324). 

I had to make a tradeoff between gRPC batching returning the same response as REST-batching and returning a response that's similar to the one `internalGrpc` returns now; I opted for the latter. Check [this comment](https://github.com/weaviate/java-client/pull/358/files?diff=unified&w=0#diff-d7c761d76ef9c877430249d277c9611f38b72819f95791c31808f6ee2238ed84R365-R372) for more details. 