### PR TITLE
fix(experimental): handle null property values

### DIFF
--- a/src/main/java/io/weaviate/client/v1/experimental/SearchClient.java
+++ b/src/main/java/io/weaviate/client/v1/experimental/SearchClient.java
@@ -2,6 +2,7 @@ package io.weaviate.client.v1.experimental;
 
 import java.time.OffsetDateTime;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -138,8 +139,14 @@ public class SearchClient<T> {
    * (de-)serialized by {@link Gson}.
    */
   private static Map<String, Object> convertProtoMap(Map<String, Value> map) {
-    return map.entrySet().stream().collect(Collectors.toMap(
-        Map.Entry::getKey, e -> convertProtoValue(e.getValue())));
+    return map.entrySet().stream()
+        // We cannot use Collectors.toMap() here, because convertProtoValue may
+        // return null (a collection property can be null), which breaks toMap().
+        // See: https://bugs.openjdk.org/browse/JDK-8148463
+        .collect(
+            HashMap::new,
+            (m, e) -> m.put(e.getKey(), convertProtoValue(e.getValue())),
+            HashMap::putAll);
   }
 
   /**

--- a/src/main/java/io/weaviate/client/v1/experimental/SearchClient.java
+++ b/src/main/java/io/weaviate/client/v1/experimental/SearchClient.java
@@ -166,6 +166,8 @@ public class SearchClient<T> {
     } else if (value.hasDateValue()) {
       OffsetDateTime offsetDateTime = OffsetDateTime.parse(value.getDateValue());
       return Date.from(offsetDateTime.toInstant());
+    } else if (value.hasNullValue()) {
+      return null;
     } else {
       assert false : "branch not covered";
     }

--- a/src/test/java/io/weaviate/integration/client/grpc/GRPCBenchTest.java
+++ b/src/test/java/io/weaviate/integration/client/grpc/GRPCBenchTest.java
@@ -55,7 +55,7 @@ public class GRPCBenchTest {
 
   private WeaviateClient client;
 
-  private static final String[] returnProperties = { "title", "price", "bestBefore" };
+  private static final String[] returnProperties = { "title", "price", "bestBefore", "possiblyNull" };
   private static final String className = "Things";
   private static final Date NOW = Date.from(Instant.now());
 
@@ -174,6 +174,9 @@ public class GRPCBenchTest {
     // WARN: this is to test filtering with List<?> values. Creating List<?>
     // properties is not supported in this version.
     public String[] ingredientsList = {};
+
+    // Property containing null values.
+    public String possiblyNull;
   }
 
   @Test
@@ -400,7 +403,8 @@ public class GRPCBenchTest {
               // and convert it to the correct format behind the scenes.
               /* bestBefore */ DateUtils.addDays(NOW, i),
               /* ingredientsArray */ ingr,
-              /* ingredientsList */ ingr);
+              /* ingredientsList */ ingr,
+              i == 2 ? "not null" : null);
           b.add(thing, e);
           i++;
         }


### PR DESCRIPTION
There is a [known JDK bug](https://bugs.openjdk.org/browse/JDK-8148463) which breaks unpacking the database response in case one of the collection properties is null.

Our mapping code also wasn't covering the case where the proto value is actual `null`. This PR fixes both issues. 

