### PR TITLE
feat: support dynamic user management in Weaviate v1.30

### DIFF
--- a/src/main/java/io/weaviate/client/base/AsyncBaseClient.java
+++ b/src/main/java/io/weaviate/client/base/AsyncBaseClient.java
@@ -1,17 +1,19 @@
 package io.weaviate.client.base;
 
-import io.weaviate.client.Config;
-import io.weaviate.client.base.http.async.ResponseParser;
-import io.weaviate.client.base.http.async.WeaviateResponseConsumer;
-import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 import java.util.Map;
 import java.util.concurrent.Future;
+
 import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
 import org.apache.hc.client5.http.async.methods.SimpleRequestProducer;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpHeaders;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.http.async.ResponseParser;
+import io.weaviate.client.base.http.async.WeaviateResponseConsumer;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 
 public abstract class AsyncBaseClient<T> {
   protected final CloseableHttpAsyncClient client;
@@ -30,39 +32,48 @@ public abstract class AsyncBaseClient<T> {
     return sendRequest(endpoint, null, "GET", classOfT, callback, null);
   }
 
-  protected Future<Result<T>> sendGetRequest(String endpoint, FutureCallback<Result<T>> callback, ResponseParser<T> parser) {
+  protected Future<Result<T>> sendGetRequest(String endpoint, FutureCallback<Result<T>> callback,
+      ResponseParser<T> parser) {
     return sendRequest(endpoint, null, "GET", null, callback, parser);
   }
 
-  protected Future<Result<T>> sendPostRequest(String endpoint, Object payload, Class<T> classOfT, FutureCallback<Result<T>> callback) {
+  protected Future<Result<T>> sendPostRequest(String endpoint, Object payload, Class<T> classOfT,
+      FutureCallback<Result<T>> callback) {
     return sendRequest(endpoint, payload, "POST", classOfT, callback, null);
   }
 
-  protected Future<Result<T>> sendPostRequest(String endpoint, Object payload, FutureCallback<Result<T>> callback, ResponseParser<T> parser) {
+  protected Future<Result<T>> sendPostRequest(String endpoint, Object payload, FutureCallback<Result<T>> callback,
+      ResponseParser<T> parser) {
     return sendRequest(endpoint, payload, "POST", null, callback, parser);
   }
 
-  protected Future<Result<T>> sendPutRequest(String endpoint, Object payload, Class<T> classOfT, FutureCallback<Result<T>> callback) {
+  protected Future<Result<T>> sendPutRequest(String endpoint, Object payload, Class<T> classOfT,
+      FutureCallback<Result<T>> callback) {
     return sendRequest(endpoint, payload, "PUT", classOfT, callback, null);
   }
 
-  protected Future<Result<T>> sendPutRequest(String endpoint, Object payload, FutureCallback<Result<T>> callback, ResponseParser<T> parser) {
+  protected Future<Result<T>> sendPutRequest(String endpoint, Object payload, FutureCallback<Result<T>> callback,
+      ResponseParser<T> parser) {
     return sendRequest(endpoint, payload, "PUT", null, callback, parser);
   }
 
-  protected Future<Result<T>> sendPatchRequest(String endpoint, Object payload, Class<T> classOfT, FutureCallback<Result<T>> callback) {
+  protected Future<Result<T>> sendPatchRequest(String endpoint, Object payload, Class<T> classOfT,
+      FutureCallback<Result<T>> callback) {
     return sendRequest(endpoint, payload, "PATCH", classOfT, callback, null);
   }
 
-  protected Future<Result<T>> sendPatchRequest(String endpoint, Object payload, FutureCallback<Result<T>> callback, ResponseParser<T> parser) {
+  protected Future<Result<T>> sendPatchRequest(String endpoint, Object payload, FutureCallback<Result<T>> callback,
+      ResponseParser<T> parser) {
     return sendRequest(endpoint, payload, "PATCH", null, callback, parser);
   }
 
-  protected Future<Result<T>> sendDeleteRequest(String endpoint, Object payload, Class<T> classOfT, FutureCallback<Result<T>> callback) {
+  protected Future<Result<T>> sendDeleteRequest(String endpoint, Object payload, Class<T> classOfT,
+      FutureCallback<Result<T>> callback) {
     return sendRequest(endpoint, payload, "DELETE", classOfT, callback, null);
   }
 
-  protected Future<Result<T>> sendDeleteRequest(String endpoint, Object payload, FutureCallback<Result<T>> callback, ResponseParser<T> parser) {
+  protected Future<Result<T>> sendDeleteRequest(String endpoint, Object payload, FutureCallback<Result<T>> callback,
+      ResponseParser<T> parser) {
     return sendRequest(endpoint, payload, "DELETE", null, callback, parser);
   }
 
@@ -70,12 +81,15 @@ public abstract class AsyncBaseClient<T> {
     return sendRequest(endpoint, null, "HEAD", classOfT, callback, null);
   }
 
-  protected Future<Result<T>> sendHeadRequest(String endpoint, FutureCallback<Result<T>> callback, ResponseParser<T> parser) {
+  protected Future<Result<T>> sendHeadRequest(String endpoint, FutureCallback<Result<T>> callback,
+      ResponseParser<T> parser) {
     return sendRequest(endpoint, null, "HEAD", null, callback, parser);
   }
 
-  private Future<Result<T>> sendRequest(String endpoint, Object payload, String method, Class<T> classOfT, FutureCallback<Result<T>> callback, ResponseParser<T> parser) {
-    return client.execute(SimpleRequestProducer.create(getRequest(endpoint, payload, method)), new WeaviateResponseConsumer<>(classOfT, parser), callback);
+  private Future<Result<T>> sendRequest(String endpoint, Object payload, String method, Class<T> classOfT,
+      FutureCallback<Result<T>> callback, ResponseParser<T> parser) {
+    return client.execute(SimpleRequestProducer.create(getRequest(endpoint, payload, method)),
+        new WeaviateResponseConsumer<>(classOfT, parser), callback);
   }
 
   protected SimpleHttpRequest getRequest(String endpoint, Object payload, String method) {

--- a/src/main/java/io/weaviate/client/base/AsyncBaseClient.java
+++ b/src/main/java/io/weaviate/client/base/AsyncBaseClient.java
@@ -1,19 +1,17 @@
 package io.weaviate.client.base;
 
+import io.weaviate.client.Config;
+import io.weaviate.client.base.http.async.ResponseParser;
+import io.weaviate.client.base.http.async.WeaviateResponseConsumer;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 import java.util.Map;
 import java.util.concurrent.Future;
-
 import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
 import org.apache.hc.client5.http.async.methods.SimpleRequestProducer;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpHeaders;
-
-import io.weaviate.client.Config;
-import io.weaviate.client.base.http.async.ResponseParser;
-import io.weaviate.client.base.http.async.WeaviateResponseConsumer;
-import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 
 public abstract class AsyncBaseClient<T> {
   protected final CloseableHttpAsyncClient client;
@@ -32,48 +30,39 @@ public abstract class AsyncBaseClient<T> {
     return sendRequest(endpoint, null, "GET", classOfT, callback, null);
   }
 
-  protected Future<Result<T>> sendGetRequest(String endpoint, FutureCallback<Result<T>> callback,
-      ResponseParser<T> parser) {
+  protected Future<Result<T>> sendGetRequest(String endpoint, FutureCallback<Result<T>> callback, ResponseParser<T> parser) {
     return sendRequest(endpoint, null, "GET", null, callback, parser);
   }
 
-  protected Future<Result<T>> sendPostRequest(String endpoint, Object payload, Class<T> classOfT,
-      FutureCallback<Result<T>> callback) {
+  protected Future<Result<T>> sendPostRequest(String endpoint, Object payload, Class<T> classOfT, FutureCallback<Result<T>> callback) {
     return sendRequest(endpoint, payload, "POST", classOfT, callback, null);
   }
 
-  protected Future<Result<T>> sendPostRequest(String endpoint, Object payload, FutureCallback<Result<T>> callback,
-      ResponseParser<T> parser) {
+  protected Future<Result<T>> sendPostRequest(String endpoint, Object payload, FutureCallback<Result<T>> callback, ResponseParser<T> parser) {
     return sendRequest(endpoint, payload, "POST", null, callback, parser);
   }
 
-  protected Future<Result<T>> sendPutRequest(String endpoint, Object payload, Class<T> classOfT,
-      FutureCallback<Result<T>> callback) {
+  protected Future<Result<T>> sendPutRequest(String endpoint, Object payload, Class<T> classOfT, FutureCallback<Result<T>> callback) {
     return sendRequest(endpoint, payload, "PUT", classOfT, callback, null);
   }
 
-  protected Future<Result<T>> sendPutRequest(String endpoint, Object payload, FutureCallback<Result<T>> callback,
-      ResponseParser<T> parser) {
+  protected Future<Result<T>> sendPutRequest(String endpoint, Object payload, FutureCallback<Result<T>> callback, ResponseParser<T> parser) {
     return sendRequest(endpoint, payload, "PUT", null, callback, parser);
   }
 
-  protected Future<Result<T>> sendPatchRequest(String endpoint, Object payload, Class<T> classOfT,
-      FutureCallback<Result<T>> callback) {
+  protected Future<Result<T>> sendPatchRequest(String endpoint, Object payload, Class<T> classOfT, FutureCallback<Result<T>> callback) {
     return sendRequest(endpoint, payload, "PATCH", classOfT, callback, null);
   }
 
-  protected Future<Result<T>> sendPatchRequest(String endpoint, Object payload, FutureCallback<Result<T>> callback,
-      ResponseParser<T> parser) {
+  protected Future<Result<T>> sendPatchRequest(String endpoint, Object payload, FutureCallback<Result<T>> callback, ResponseParser<T> parser) {
     return sendRequest(endpoint, payload, "PATCH", null, callback, parser);
   }
 
-  protected Future<Result<T>> sendDeleteRequest(String endpoint, Object payload, Class<T> classOfT,
-      FutureCallback<Result<T>> callback) {
+  protected Future<Result<T>> sendDeleteRequest(String endpoint, Object payload, Class<T> classOfT, FutureCallback<Result<T>> callback) {
     return sendRequest(endpoint, payload, "DELETE", classOfT, callback, null);
   }
 
-  protected Future<Result<T>> sendDeleteRequest(String endpoint, Object payload, FutureCallback<Result<T>> callback,
-      ResponseParser<T> parser) {
+  protected Future<Result<T>> sendDeleteRequest(String endpoint, Object payload, FutureCallback<Result<T>> callback, ResponseParser<T> parser) {
     return sendRequest(endpoint, payload, "DELETE", null, callback, parser);
   }
 
@@ -81,15 +70,12 @@ public abstract class AsyncBaseClient<T> {
     return sendRequest(endpoint, null, "HEAD", classOfT, callback, null);
   }
 
-  protected Future<Result<T>> sendHeadRequest(String endpoint, FutureCallback<Result<T>> callback,
-      ResponseParser<T> parser) {
+  protected Future<Result<T>> sendHeadRequest(String endpoint, FutureCallback<Result<T>> callback, ResponseParser<T> parser) {
     return sendRequest(endpoint, null, "HEAD", null, callback, parser);
   }
 
-  private Future<Result<T>> sendRequest(String endpoint, Object payload, String method, Class<T> classOfT,
-      FutureCallback<Result<T>> callback, ResponseParser<T> parser) {
-    return client.execute(SimpleRequestProducer.create(getRequest(endpoint, payload, method)),
-        new WeaviateResponseConsumer<>(classOfT, parser), callback);
+  private Future<Result<T>> sendRequest(String endpoint, Object payload, String method, Class<T> classOfT, FutureCallback<Result<T>> callback, ResponseParser<T> parser) {
+    return client.execute(SimpleRequestProducer.create(getRequest(endpoint, payload, method)), new WeaviateResponseConsumer<>(classOfT, parser), callback);
   }
 
   protected SimpleHttpRequest getRequest(String endpoint, Object payload, String method) {

--- a/src/main/java/io/weaviate/client/base/BaseClient.java
+++ b/src/main/java/io/weaviate/client/base/BaseClient.java
@@ -49,11 +49,7 @@ public abstract class BaseClient<T> {
       if (statusCode < 399) {
         return new Response<>(statusCode, toResponse(responseBody, classOfT), null);
       }
-      WeaviateErrorResponse error = toResponse(responseBody, WeaviateErrorResponse.class);
-      if (error == null) {
-        error = WeaviateErrorResponse.builder().code(statusCode).build();
-      }
-      return new Response<>(statusCode, null, error);
+      return new Response<>(statusCode, null, toResponse(responseBody, WeaviateErrorResponse.class));
     } catch (Exception e) {
       WeaviateErrorResponse errors = getWeaviateErrorResponse(e);
       return new Response<>(0, null, errors);

--- a/src/main/java/io/weaviate/client/base/BaseClient.java
+++ b/src/main/java/io/weaviate/client/base/BaseClient.java
@@ -47,11 +47,12 @@ public abstract class BaseClient<T> {
       int statusCode = response.getStatusCode();
       String responseBody = response.getBody();
       if (statusCode < 399) {
-        T body = toResponse(responseBody, classOfT);
-        return new Response<>(statusCode, body, null);
+        return new Response<>(statusCode, toResponse(responseBody, classOfT), null);
       }
-
       WeaviateErrorResponse error = toResponse(responseBody, WeaviateErrorResponse.class);
+      if (error == null) {
+        error = WeaviateErrorResponse.builder().code(statusCode).build();
+      }
       return new Response<>(statusCode, null, error);
     } catch (Exception e) {
       WeaviateErrorResponse errors = getWeaviateErrorResponse(e);

--- a/src/main/java/io/weaviate/client/base/Result.java
+++ b/src/main/java/io/weaviate/client/base/Result.java
@@ -1,8 +1,12 @@
 package io.weaviate.client.base;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.hc.core5.http.ContentType;
@@ -23,6 +27,10 @@ public class Result<T> {
 
   public Result(Response<T> response) {
     this(response.getStatusCode(), response.getBody(), response.getErrors());
+  }
+
+  public Result(Response<?> response, T body) {
+    this(response.getStatusCode(), body, response.getErrors());
   }
 
   public Result(int statusCode, T body, WeaviateErrorResponse errors) {
@@ -60,7 +68,7 @@ public class Result<T> {
 
   /**
    * Convert {@code Result<Void>} response to a {@code Result<Boolean>}.
-   * The result contains true if status code is 200.
+   * The result contains true if status code is in 100-299 range.
    *
    * @param response Response from a call that does not return a value, like
    *                 {@link BaseClient#sendDeleteRequest}.
@@ -69,6 +77,22 @@ public class Result<T> {
   public static Result<Boolean> voidToBoolean(Response<Void> response) {
     int status = response.getStatusCode();
     return new Result<>(status, status < 299, response.getErrors());
+  }
+
+  /**
+   * Convert {@code Result<Void>} response to a {@code Result<Boolean>}.
+   * The result contains true if status code is in 100-299 range or is one of the
+   * allowed codes (e.g. HTTP 409 is used when the request has no effect, because
+   * a previous one has already succeeded).
+   *
+   * @param response Response from a call that does not return a value, like
+   *                 {@link BaseClient#sendDeleteRequest}.
+   * @return {@code Result<Boolean>}
+   */
+  public static Result<Boolean> voidToBoolean(Response<Void> response, int... allowCodes) {
+    Integer status = response.getStatusCode();
+    boolean allowedCode = Arrays.stream(allowCodes).anyMatch(status::equals);
+    return new Result<>(status, status < 299 || allowedCode, response.getErrors());
   }
 
   /**
@@ -81,10 +105,43 @@ public class Result<T> {
     return new ResponseParser<Boolean>() {
       @Override
       public Result<Boolean> parse(HttpResponse response, String body, ContentType contentType) {
-        Response<Object> resp = this.serializer.toResponse(response.getCode(), body, Object.class);
-        return new Result<>(resp.getStatusCode(), resp.getStatusCode() < 299, resp.getErrors());
+        Response<Void> resp = this.serializer.toResponse(response.getCode(), body, Void.class);
+        return voidToBoolean(resp);
       }
     };
   }
 
+  /**
+   * Get a custom parser to convert {@code Result<Void>} response as to a
+   * {@code Result<Void>}. The result contains true if status code is 200.
+   *
+   * @return {@code Result<Boolean>}
+   */
+  public static ResponseParser<Boolean> voidToBooleanParser(int... allowCodes) {
+    return new ResponseParser<Boolean>() {
+      @Override
+      public Result<Boolean> parse(HttpResponse response, String body, ContentType contentType) {
+        Response<Void> resp = this.serializer.toResponse(response.getCode(), body, Void.class);
+        return voidToBoolean(resp, allowCodes);
+      }
+    };
+  }
+
+  public static <T> ResponseParser<List<T>> arrayToListParser(Class<T[]> cls) {
+    return arrayToListParser(cls, Function.identity());
+  }
+
+  public static <T, R> ResponseParser<List<R>> arrayToListParser(Class<T[]> cls,
+      Function<? super T, ? extends R> mapper) {
+    return new ResponseParser<List<R>>() {
+      @Override
+      public Result<List<R>> parse(HttpResponse response, String body, ContentType contentType) {
+        Response<T[]> resp = this.serializer.toResponse(response.getCode(), body, cls);
+        List<R> roles = Optional.ofNullable(resp.getBody())
+            .map(Arrays::asList).orElse(new ArrayList<>())
+            .stream().map(mapper).collect(Collectors.toList());
+        return new Result<>(resp.getStatusCode(), roles, resp.getErrors());
+      }
+    };
+  }
 }

--- a/src/main/java/io/weaviate/client/base/Serializer.java
+++ b/src/main/java/io/weaviate/client/base/Serializer.java
@@ -46,7 +46,7 @@ public class Serializer {
     if (statusCode < 399) {
       return new Result<>(toResponse(statusCode, body, classOfT));
     }
-    return new Result<>(statusCode, null, toWeaviateError(body));
+    return new Result<>(statusCode, null, toWeaviateError(body, statusCode));
   }
 
   public <T> Response<T> toResponse(int statusCode, String body, Class<T> classOfT) {
@@ -54,7 +54,7 @@ public class Serializer {
       T obj = toResponse(body, classOfT);
       return new Response<>(statusCode, obj, null);
     }
-    return new Response<>(statusCode, null, toWeaviateError(body));
+    return new Response<>(statusCode, null, toWeaviateError(body, statusCode));
   }
 
   public <C> Response<GraphQLTypedResponse<C>> toGraphQLTypedResponse(int statusCode, String body, Class<C> classOfC) {
@@ -62,17 +62,21 @@ public class Serializer {
       GraphQLTypedResponse<C> obj = toGraphQLTypedResponse(body, classOfC);
       return new Response<>(statusCode, obj, null);
     }
-    return new Response<>(statusCode, null, toWeaviateError(body));
+    return new Response<>(statusCode, null, toWeaviateError(body, statusCode));
   }
 
   public <C> Result<GraphQLTypedResponse<C>> toGraphQLTypedResult(int statusCode, String body, Class<C> classOfC) {
     if (statusCode < 399) {
       return new Result<>(toGraphQLTypedResponse(statusCode, body, classOfC));
     }
-    return new Result<>(statusCode, null, toWeaviateError(body));
+    return new Result<>(statusCode, null, toWeaviateError(body, statusCode));
   }
 
-  public WeaviateErrorResponse toWeaviateError(String body) {
-    return toResponse(body, WeaviateErrorResponse.class);
+  public WeaviateErrorResponse toWeaviateError(String body, int statusCode) {
+    WeaviateErrorResponse error = toResponse(body, WeaviateErrorResponse.class);
+    if (error == null) {
+      error = WeaviateErrorResponse.builder().code(statusCode).build();
+    }
+    return error;
   }
 }

--- a/src/main/java/io/weaviate/client/base/Serializer.java
+++ b/src/main/java/io/weaviate/client/base/Serializer.java
@@ -46,7 +46,7 @@ public class Serializer {
     if (statusCode < 399) {
       return new Result<>(toResponse(statusCode, body, classOfT));
     }
-    return new Result<>(statusCode, null, toWeaviateError(body, statusCode));
+    return new Result<>(statusCode, null, toWeaviateError(body));
   }
 
   public <T> Response<T> toResponse(int statusCode, String body, Class<T> classOfT) {
@@ -54,7 +54,7 @@ public class Serializer {
       T obj = toResponse(body, classOfT);
       return new Response<>(statusCode, obj, null);
     }
-    return new Response<>(statusCode, null, toWeaviateError(body, statusCode));
+    return new Response<>(statusCode, null, toWeaviateError(body));
   }
 
   public <C> Response<GraphQLTypedResponse<C>> toGraphQLTypedResponse(int statusCode, String body, Class<C> classOfC) {
@@ -62,21 +62,17 @@ public class Serializer {
       GraphQLTypedResponse<C> obj = toGraphQLTypedResponse(body, classOfC);
       return new Response<>(statusCode, obj, null);
     }
-    return new Response<>(statusCode, null, toWeaviateError(body, statusCode));
+    return new Response<>(statusCode, null, toWeaviateError(body));
   }
 
   public <C> Result<GraphQLTypedResponse<C>> toGraphQLTypedResult(int statusCode, String body, Class<C> classOfC) {
     if (statusCode < 399) {
       return new Result<>(toGraphQLTypedResponse(statusCode, body, classOfC));
     }
-    return new Result<>(statusCode, null, toWeaviateError(body, statusCode));
+    return new Result<>(statusCode, null, toWeaviateError(body));
   }
 
-  public WeaviateErrorResponse toWeaviateError(String body, int statusCode) {
-    WeaviateErrorResponse error = toResponse(body, WeaviateErrorResponse.class);
-    if (error == null) {
-      error = WeaviateErrorResponse.builder().code(statusCode).build();
-    }
-    return error;
+  public WeaviateErrorResponse toWeaviateError(String body) {
+    return toResponse(body, WeaviateErrorResponse.class);
   }
 }

--- a/src/main/java/io/weaviate/client/base/http/impl/CommonsHttpClientImpl.java
+++ b/src/main/java/io/weaviate/client/base/http/impl/CommonsHttpClientImpl.java
@@ -1,13 +1,11 @@
 package io.weaviate.client.base.http.impl;
 
-import io.weaviate.client.base.http.HttpClient;
-import io.weaviate.client.base.http.HttpResponse;
-import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+
 import org.apache.hc.client5.http.classic.methods.HttpDelete;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpHead;
@@ -22,6 +20,10 @@ import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
 
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.base.http.HttpResponse;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+
 public class CommonsHttpClientImpl implements HttpClient, Closeable {
   private final Map<String, String> headers;
   private AccessTokenProvider tokenProvider;
@@ -31,7 +33,8 @@ public class CommonsHttpClientImpl implements HttpClient, Closeable {
     this(headers, null, clientBuilder);
   }
 
-  public CommonsHttpClientImpl(Map<String, String> headers, AccessTokenProvider tokenProvider, CloseableHttpClientBuilder clientBuilder) {
+  public CommonsHttpClientImpl(Map<String, String> headers, AccessTokenProvider tokenProvider,
+      CloseableHttpClientBuilder clientBuilder) {
     this.headers = headers;
     this.clientBuilder = clientBuilder;
     this.tokenProvider = tokenProvider;
@@ -44,6 +47,9 @@ public class CommonsHttpClientImpl implements HttpClient, Closeable {
 
   @Override
   public HttpResponse sendPostRequest(String url, String json) throws Exception {
+    if (json == null) {
+      return sendRequestWithoutPayload(new HttpPost(url));
+    }
     return sendRequestWithPayload(new HttpPost(url), json);
   }
 
@@ -95,10 +101,9 @@ public class CommonsHttpClientImpl implements HttpClient, Closeable {
 
     int statusCode = response.getCode();
     String body = response.getEntity() != null
-      ? EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8)
-      : "";
+        ? EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8)
+        : "";
     client.close();
-
     return new HttpResponse(statusCode, body);
   }
 

--- a/src/main/java/io/weaviate/client/v1/async/rbac/Roles.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/Roles.java
@@ -66,12 +66,27 @@ public class Roles {
     return new RoleGetter(client, config, tokenProvider);
   };
 
-  /** Get users assigned to a role. */
+  /**
+   * Get users assigned to a role.
+   * <p>
+   * Deprecated - prefer {@link #userAssignmentsGetter()}.
+   */
+  @Deprecated
   public AssignedUsersGetter assignedUsersGetter() {
     return new AssignedUsersGetter(client, config, tokenProvider);
   };
 
-  /** Get users assigned to a role. */
+  /**
+   * Get role assignments.
+   *
+   * <p>
+   * Note, that the result is not a list of unique users,
+   * but rather a list of all username+namespace combinations
+   * allowed for this role.
+   * In clusters with enabled OIDC authorization, users created dynamically
+   * (db_user) or configured in the environment (db_env_user) will appear twice:
+   * once as 'db_*' user and once as 'oidc' user.
+   */
   public UserAssignmentsGetter userAssignmentsGetter() {
     return new UserAssignmentsGetter(client, config, tokenProvider);
   };

--- a/src/main/java/io/weaviate/client/v1/async/rbac/Roles.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/Roles.java
@@ -12,6 +12,7 @@ import io.weaviate.client.v1.async.rbac.api.RoleCreator;
 import io.weaviate.client.v1.async.rbac.api.RoleDeleter;
 import io.weaviate.client.v1.async.rbac.api.RoleExists;
 import io.weaviate.client.v1.async.rbac.api.RoleGetter;
+import io.weaviate.client.v1.async.rbac.api.UserAssignmentsGetter;
 import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 import lombok.RequiredArgsConstructor;
 
@@ -68,6 +69,11 @@ public class Roles {
   /** Get users assigned to a role. */
   public AssignedUsersGetter assignedUsersGetter() {
     return new AssignedUsersGetter(client, config, tokenProvider);
+  };
+
+  /** Get users assigned to a role. */
+  public UserAssignmentsGetter userAssignmentsGetter() {
+    return new UserAssignmentsGetter(client, config, tokenProvider);
   };
 
   /** Check if a role exists. */

--- a/src/main/java/io/weaviate/client/v1/async/rbac/api/UserAssignmentsGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/api/UserAssignmentsGetter.java
@@ -1,0 +1,37 @@
+package io.weaviate.client.v1.async.rbac.api;
+
+import java.util.List;
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import io.weaviate.client.v1.rbac.model.UserAssignment;
+
+public class UserAssignmentsGetter extends AsyncBaseClient<List<UserAssignment>>
+    implements AsyncClientResult<List<UserAssignment>> {
+  private String role;
+
+  public UserAssignmentsGetter(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  public UserAssignmentsGetter withRole(String role) {
+    this.role = role;
+    return this;
+  }
+
+  @Override
+  public Future<Result<List<UserAssignment>>> run(FutureCallback<Result<List<UserAssignment>>> callback) {
+    return sendGetRequest(path(), callback, Result.arrayToListParser(UserAssignment[].class));
+  }
+
+  private String path() {
+    return String.format("/authz/roles/%s/user-assignments", this.role);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/users/DbUsers.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/DbUsers.java
@@ -1,0 +1,68 @@
+package io.weaviate.client.v1.async.users;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.v1.async.users.api.RoleAssigner;
+import io.weaviate.client.v1.async.users.api.RoleRevoker;
+import io.weaviate.client.v1.async.users.api.common.AssignedRolesGetter;
+import io.weaviate.client.v1.async.users.api.db.Activator;
+import io.weaviate.client.v1.async.users.api.db.AllGetter;
+import io.weaviate.client.v1.async.users.api.db.ByNameGetter;
+import io.weaviate.client.v1.async.users.api.db.Creator;
+import io.weaviate.client.v1.async.users.api.db.Deactivator;
+import io.weaviate.client.v1.async.users.api.db.Deleter;
+import io.weaviate.client.v1.async.users.api.db.KeyRotator;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class DbUsers {
+  private static final String USER_TYPE = "db";
+
+  private final CloseableHttpAsyncClient client;
+  private final Config config;
+  private final AccessTokenProvider tokenProvider;
+
+  /** Assign a role to a user. Note that 'root' cannot be assigned. */
+  public RoleAssigner assigner() {
+    return new RoleAssigner(client, config, tokenProvider, USER_TYPE);
+  }
+
+  /** Revoke a role from a user. Note that 'root' cannot be revoked. */
+  public RoleRevoker revoker() {
+    return new RoleRevoker(client, config, tokenProvider, USER_TYPE);
+  }
+
+  public AssignedRolesGetter assignedRoles() {
+    return new AssignedRolesGetter(client, config, tokenProvider, USER_TYPE);
+  }
+
+  public Creator creator() {
+    return new Creator(client, config, tokenProvider);
+  }
+
+  public Deleter deleter() {
+    return new Deleter(client, config, tokenProvider);
+  }
+
+  public Activator activator() {
+    return new Activator(client, config, tokenProvider);
+  }
+
+  public Deactivator deactivator() {
+    return new Deactivator(client, config, tokenProvider);
+  }
+
+  public KeyRotator keyRotator() {
+    return new KeyRotator(client, config, tokenProvider);
+  }
+
+  public ByNameGetter getUser() {
+    return new ByNameGetter(client, config, tokenProvider);
+  }
+
+  public AllGetter allGetter() {
+    return new AllGetter(client, config, tokenProvider);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/users/DbUsers.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/DbUsers.java
@@ -34,34 +34,46 @@ public class DbUsers {
     return new RoleRevoker(client, config, tokenProvider, USER_TYPE);
   }
 
-  public AssignedRolesGetter assignedRoles() {
+  /** Get roles assigned to a user. */
+  public AssignedRolesGetter userRolesGetter() {
     return new AssignedRolesGetter(client, config, tokenProvider, USER_TYPE);
   }
 
+  /** Create a new user. Returns API key for the user to authenticate by. */
   public Creator creator() {
     return new Creator(client, config, tokenProvider);
   }
 
+  /**
+   * Delete user.
+   * Users declared in the server environment config cannot be
+   * deleted ('db_env_user').
+   */
   public Deleter deleter() {
     return new Deleter(client, config, tokenProvider);
   }
 
+  /** Activate user account. */
   public Activator activator() {
     return new Activator(client, config, tokenProvider);
   }
 
+  /** Deactivate user account, optionally revoking its API key. */
   public Deactivator deactivator() {
     return new Deactivator(client, config, tokenProvider);
   }
 
+  /** Rotate user's API key. The old key will become invalid. */
   public KeyRotator keyRotator() {
     return new KeyRotator(client, config, tokenProvider);
   }
 
+  /** Get information about the user. */
   public ByNameGetter getUser() {
     return new ByNameGetter(client, config, tokenProvider);
   }
 
+  /** List all known (non-OIDC) users. */
   public AllGetter allGetter() {
     return new AllGetter(client, config, tokenProvider);
   }

--- a/src/main/java/io/weaviate/client/v1/async/users/OidcUsers.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/OidcUsers.java
@@ -27,7 +27,8 @@ public class OidcUsers {
     return new RoleRevoker(client, config, tokenProvider, USER_TYPE);
   }
 
-  public AssignedRolesGetter assignedRoles() {
+  /** Get roles assigned to a user. */
+  public AssignedRolesGetter userRolesGetter() {
     return new AssignedRolesGetter(client, config, tokenProvider, USER_TYPE);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/async/users/OidcUsers.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/OidcUsers.java
@@ -1,0 +1,33 @@
+package io.weaviate.client.v1.async.users;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.v1.async.users.api.RoleAssigner;
+import io.weaviate.client.v1.async.users.api.RoleRevoker;
+import io.weaviate.client.v1.async.users.api.common.AssignedRolesGetter;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class OidcUsers {
+  private static final String USER_TYPE = "oidc";
+
+  private final CloseableHttpAsyncClient client;
+  private final Config config;
+  private final AccessTokenProvider tokenProvider;
+
+  /** Assign a role to a user. Note that 'root' cannot be assigned. */
+  public RoleAssigner assigner() {
+    return new RoleAssigner(client, config, tokenProvider, USER_TYPE);
+  }
+
+  /** Revoke a role from a user. Note that 'root' cannot be revoked. */
+  public RoleRevoker revoker() {
+    return new RoleRevoker(client, config, tokenProvider, USER_TYPE);
+  }
+
+  public AssignedRolesGetter assignedRoles() {
+    return new AssignedRolesGetter(client, config, tokenProvider, USER_TYPE);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/users/Users.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/Users.java
@@ -34,4 +34,12 @@ public class Users {
   public RoleRevoker revoker() {
     return new RoleRevoker(client, config, tokenProvider);
   }
+
+  public DbUsers db() {
+    return new DbUsers(client, config, tokenProvider);
+  }
+
+  public OidcUsers oidc() {
+    return new OidcUsers(client, config, tokenProvider);
+  }
 }

--- a/src/main/java/io/weaviate/client/v1/async/users/Users.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/Users.java
@@ -22,23 +22,45 @@ public class Users {
     return new MyUserGetter(client, config, tokenProvider);
   };
 
-  /** Get roles assigned to a user. */
+  /**
+   * Get roles assigned to a user.
+   * <p>
+   * Deprecated - prefer {@link DbUsers#userRolesGetter()} or
+   * {@link OidcUsers#userRolesGetter()}.
+   */
+  @Deprecated
   public UserRolesGetter userRolesGetter() {
     return new UserRolesGetter(client, config, tokenProvider);
   };
 
+  /**
+   * Assign a role to a user. Note that 'root' cannot be assigned.
+   * <p>
+   * Deprecated - prefer {@link DbUsers#assigner()} or
+   * {@link OidcUsers#assigner()}.
+   */
+  @Deprecated
   public RoleAssigner assigner() {
     return new RoleAssigner(client, config, tokenProvider);
   }
 
+  /**
+   * Revoke a role from a user. Note that 'root' cannot be revoked.
+   * <p>
+   * Deprecated - prefer {@link DbUsers#revoker()} or
+   * {@link OidcUsers#revoker()}
+   */
+  @Deprecated
   public RoleRevoker revoker() {
     return new RoleRevoker(client, config, tokenProvider);
   }
 
+  /** Manage dynamic users, their roles and permissions. */
   public DbUsers db() {
     return new DbUsers(client, config, tokenProvider);
   }
 
+  /** Manage users authenticated via OIDC, their roles and permissions. */
   public OidcUsers oidc() {
     return new OidcUsers(client, config, tokenProvider);
   }

--- a/src/main/java/io/weaviate/client/v1/async/users/api/RoleAssigner.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/api/RoleAssigner.java
@@ -19,8 +19,16 @@ public class RoleAssigner extends AsyncBaseClient<Boolean> implements AsyncClien
   private String userId;
   private List<String> roles = new ArrayList<>();
 
+  private final String _userType;
+
   public RoleAssigner(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    this(httpClient, config, tokenProvider, null);
+  }
+
+  public RoleAssigner(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider,
+      String userType) {
     super(httpClient, config, tokenProvider);
+    this._userType = userType;
   }
 
   public RoleAssigner withUserId(String id) {
@@ -35,8 +43,9 @@ public class RoleAssigner extends AsyncBaseClient<Boolean> implements AsyncClien
 
   /** The API signature for this method is { "roles": [...] } */
   @AllArgsConstructor
-  private static class Body {
-    public final List<String> roles;
+  private class Body {
+    final String userType = _userType; // always inherit from the outer class
+    final List<String> roles;
   }
 
   @Override

--- a/src/main/java/io/weaviate/client/v1/async/users/api/RoleRevoker.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/api/RoleRevoker.java
@@ -20,8 +20,16 @@ public class RoleRevoker extends AsyncBaseClient<Boolean> implements AsyncClient
   private String userId;
   private List<String> roles = new ArrayList<>();
 
+  private final String _userType;
+
   public RoleRevoker(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    this(httpClient, config, tokenProvider, null);
+  }
+
+  public RoleRevoker(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider,
+      String userType) {
     super(httpClient, config, tokenProvider);
+    this._userType = userType;
   }
 
   public RoleRevoker withUserId(String id) {
@@ -36,8 +44,9 @@ public class RoleRevoker extends AsyncBaseClient<Boolean> implements AsyncClient
 
   /** The API signature for this method is { "roles": [...] } */
   @AllArgsConstructor
-  private static class Body {
-    public final List<String> roles;
+  private class Body {
+    final String userType = _userType; // always inherit from the outer class
+    final List<String> roles;
   }
 
   @Override

--- a/src/main/java/io/weaviate/client/v1/async/users/api/common/AssignedRolesGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/api/common/AssignedRolesGetter.java
@@ -1,0 +1,52 @@
+package io.weaviate.client.v1.async.users.api.common;
+
+import java.util.List;
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import io.weaviate.client.v1.rbac.api.WeaviateRole;
+import io.weaviate.client.v1.rbac.model.Role;
+
+public class AssignedRolesGetter extends AsyncBaseClient<List<Role>> implements AsyncClientResult<List<Role>> {
+  private String userId;
+  private boolean includePermissions = false;
+
+  private final String userType;
+
+  public AssignedRolesGetter(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider,
+      String userType) {
+    super(httpClient, config, tokenProvider);
+    this.userType = userType;
+  }
+
+  public AssignedRolesGetter withUserId(String userId) {
+    this.userId = userId;
+    return this;
+  }
+
+  public AssignedRolesGetter includePermissions() {
+    return includePermissions(true);
+  }
+
+  public AssignedRolesGetter includePermissions(boolean include) {
+    this.includePermissions = include;
+    return this;
+  }
+
+  @Override
+  public Future<Result<List<Role>>> run(FutureCallback<Result<List<Role>>> callback) {
+    return sendGetRequest(path(), callback, Result.arrayToListParser(WeaviateRole[].class, WeaviateRole::toRole));
+  }
+
+  private String path() {
+    return String.format("/authz/users/%s/roles/%s?includeFullRoles=%s",
+        userId, userType, includePermissions);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/users/api/common/AssignedRolesGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/api/common/AssignedRolesGetter.java
@@ -31,6 +31,10 @@ public class AssignedRolesGetter extends AsyncBaseClient<List<Role>> implements 
     return this;
   }
 
+  /**
+   * Include a full list of permissions for each role.
+   * If not set, only role names will be populated.
+   */
   public AssignedRolesGetter includePermissions() {
     return includePermissions(true);
   }

--- a/src/main/java/io/weaviate/client/v1/async/users/api/db/Activator.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/api/db/Activator.java
@@ -1,0 +1,32 @@
+package io.weaviate.client.v1.async.users.api.db;
+
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.HttpStatus;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+
+public class Activator extends AsyncBaseClient<Boolean> implements AsyncClientResult<Boolean> {
+  private String userId;
+
+  public Activator(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  public Activator withUserId(String userId) {
+    this.userId = userId;
+    return this;
+  }
+
+  @Override
+  public Future<Result<Boolean>> run(FutureCallback<Result<Boolean>> callback) {
+    return sendPostRequest("/users/db/" + userId + "/activate", null, callback,
+        Result.voidToBooleanParser(HttpStatus.SC_CONFLICT));
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/users/api/db/AllGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/api/db/AllGetter.java
@@ -1,0 +1,26 @@
+package io.weaviate.client.v1.async.users.api.db;
+
+import java.util.List;
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import io.weaviate.client.v1.users.model.UserDb;
+
+public class AllGetter extends AsyncBaseClient<List<UserDb>> implements AsyncClientResult<List<UserDb>> {
+
+  public AllGetter(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  @Override
+  public Future<Result<List<UserDb>>> run(FutureCallback<Result<List<UserDb>>> callback) {
+    return sendGetRequest("/users/db", callback, Result.arrayToListParser(UserDb[].class));
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/users/api/db/ByNameGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/api/db/ByNameGetter.java
@@ -1,0 +1,31 @@
+package io.weaviate.client.v1.async.users.api.db;
+
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import io.weaviate.client.v1.users.model.UserDb;
+
+public class ByNameGetter extends AsyncBaseClient<UserDb> implements AsyncClientResult<UserDb> {
+  private String userId;
+
+  public ByNameGetter(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  public ByNameGetter withUserId(String userId) {
+    this.userId = userId;
+    return this;
+  }
+
+  @Override
+  public Future<Result<UserDb>> run(FutureCallback<Result<UserDb>> callback) {
+    return sendGetRequest("/users/db/" + userId, UserDb.class, callback);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/users/api/db/Creator.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/api/db/Creator.java
@@ -41,7 +41,7 @@ public class Creator extends AsyncBaseClient<String> implements AsyncClientResul
       @Override
       public Result<String> parse(HttpResponse response, String body, ContentType contentType) {
         Response<ApiKey> resp = serializer.toResponse(response.getCode(), body, ApiKey.class);
-        return new Result<>(resp, resp.getBody().apiKey);
+        return new Result<>(resp, resp.getBody() != null ? resp.getBody().apiKey : null);
       }
     });
   }

--- a/src/main/java/io/weaviate/client/v1/async/users/api/db/Creator.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/api/db/Creator.java
@@ -1,0 +1,48 @@
+package io.weaviate.client.v1.async.users.api.db;
+
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpResponse;
+
+import com.google.gson.annotations.SerializedName;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Response;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.async.ResponseParser;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+
+/** Creates a new 'db' user and returns its API key. */
+public class Creator extends AsyncBaseClient<String> implements AsyncClientResult<String> {
+  private String userId;
+
+  public Creator(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  public Creator withUserId(String userId) {
+    this.userId = userId;
+    return this;
+  }
+
+  @Override
+  public Future<Result<String>> run(FutureCallback<Result<String>> callback) {
+    return sendPostRequest("/users/db/" + userId, null, callback, new ResponseParser<String>() {
+      class ApiKey {
+        @SerializedName("apikey")
+        String apiKey;
+      }
+
+      @Override
+      public Result<String> parse(HttpResponse response, String body, ContentType contentType) {
+        Response<ApiKey> resp = serializer.toResponse(response.getCode(), body, ApiKey.class);
+        return new Result<>(resp, resp.getBody().apiKey);
+      }
+    });
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/users/api/db/Deactivator.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/api/db/Deactivator.java
@@ -1,0 +1,51 @@
+package io.weaviate.client.v1.async.users.api.db;
+
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.HttpStatus;
+
+import com.google.gson.annotations.SerializedName;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import lombok.AllArgsConstructor;
+
+public class Deactivator extends AsyncBaseClient<Boolean> implements AsyncClientResult<Boolean> {
+  private String userId;
+  private boolean revokeKey = false;
+
+  public Deactivator(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  public Deactivator withUserId(String userId) {
+    this.userId = userId;
+    return this;
+  }
+
+  public Deactivator revokeKey() {
+    return revokeKey(true);
+  }
+
+  public Deactivator revokeKey(boolean revoke) {
+    this.revokeKey = revoke;
+    return this;
+  }
+
+  @AllArgsConstructor
+  private class Body {
+    @SerializedName("revoke_key")
+    private boolean revokeKey;
+  }
+
+  @Override
+  public Future<Result<Boolean>> run(FutureCallback<Result<Boolean>> callback) {
+    return sendPostRequest("/users/db/" + userId + "/deactivate", new Body(revokeKey), callback,
+        Result.voidToBooleanParser(HttpStatus.SC_CONFLICT));
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/users/api/db/Deleter.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/api/db/Deleter.java
@@ -1,0 +1,30 @@
+package io.weaviate.client.v1.async.users.api.db;
+
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+
+public class Deleter extends AsyncBaseClient<Boolean> implements AsyncClientResult<Boolean> {
+  private String userId;
+
+  public Deleter(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  public Deleter withUserId(String userId) {
+    this.userId = userId;
+    return this;
+  }
+
+  @Override
+  public Future<Result<Boolean>> run(FutureCallback<Result<Boolean>> callback) {
+    return sendDeleteRequest("/users/db/" + userId, null, callback, Result.voidToBooleanParser());
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/users/api/db/KeyRotator.java
+++ b/src/main/java/io/weaviate/client/v1/async/users/api/db/KeyRotator.java
@@ -1,0 +1,47 @@
+package io.weaviate.client.v1.async.users.api.db;
+
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpResponse;
+
+import com.google.gson.annotations.SerializedName;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Response;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.async.ResponseParser;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+
+public class KeyRotator extends AsyncBaseClient<String> implements AsyncClientResult<String> {
+  private String userId;
+
+  public KeyRotator(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  public KeyRotator withUserId(String userId) {
+    this.userId = userId;
+    return this;
+  }
+
+  @Override
+  public Future<Result<String>> run(FutureCallback<Result<String>> callback) {
+    return sendPostRequest("/users/db/" + userId + "/rotate-key", null, callback, new ResponseParser<String>() {
+      class ApiKey {
+        @SerializedName("apikey")
+        String apiKey;
+      }
+
+      @Override
+      public Result<String> parse(HttpResponse response, String body, ContentType contentType) {
+        Response<ApiKey> resp = serializer.toResponse(response.getCode(), body, ApiKey.class);
+        return new Result<>(resp, resp.getBody().apiKey);
+      }
+    });
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/Roles.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/Roles.java
@@ -74,7 +74,17 @@ public class Roles {
     return new AssignedUsersGetter(httpClient, config);
   };
 
-  /** Get users assigned to a role. */
+  /**
+   * Get role assignments.
+   *
+   * <p>
+   * Note, that the result is not a list of unique users,
+   * but rather a list of all username+namespace combinations
+   * allowed for this role.
+   * In clusters with enabled OIDC authorization, users created dynamically
+   * (db_user) or configured in the environment (db_env_user) will appear twice:
+   * once as 'db_*' user and once as 'oidc' user.
+   */
   public UserAssignmentsGetter userAssignmentsGetter() {
     return new UserAssignmentsGetter(httpClient, config);
   };

--- a/src/main/java/io/weaviate/client/v1/rbac/Roles.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/Roles.java
@@ -11,6 +11,7 @@ import io.weaviate.client.v1.rbac.api.RoleCreator;
 import io.weaviate.client.v1.rbac.api.RoleDeleter;
 import io.weaviate.client.v1.rbac.api.RoleExists;
 import io.weaviate.client.v1.rbac.api.RoleGetter;
+import io.weaviate.client.v1.rbac.api.UserAssignmentsGetter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -66,6 +67,11 @@ public class Roles {
   /** Get users assigned to a role. */
   public AssignedUsersGetter assignedUsersGetter() {
     return new AssignedUsersGetter(httpClient, config);
+  };
+
+  /** Get users assigned to a role. */
+  public UserAssignmentsGetter userAssignmentsGetter() {
+    return new UserAssignmentsGetter(httpClient, config);
   };
 
   /** Check if a role exists. */

--- a/src/main/java/io/weaviate/client/v1/rbac/Roles.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/Roles.java
@@ -64,7 +64,12 @@ public class Roles {
     return new RoleGetter(httpClient, config);
   };
 
-  /** Get users assigned to a role. */
+  /**
+   * Get users assigned to a role.
+   * <p>
+   * Deprecated - prefer {@link #userAssignmentsGetter()}
+   */
+  @Deprecated
   public AssignedUsersGetter assignedUsersGetter() {
     return new AssignedUsersGetter(httpClient, config);
   };

--- a/src/main/java/io/weaviate/client/v1/rbac/api/UserAssignmentsGetter.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/UserAssignmentsGetter.java
@@ -1,0 +1,39 @@
+package io.weaviate.client.v1.rbac.api;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Response;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.rbac.model.UserAssignment;
+
+public class UserAssignmentsGetter extends BaseClient<UserAssignment[]> implements ClientResult<List<UserAssignment>> {
+  private String role;
+
+  public UserAssignmentsGetter(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public UserAssignmentsGetter withRole(String role) {
+    this.role = role;
+    return this;
+  }
+
+  @Override
+  public Result<List<UserAssignment>> run() {
+    Response<UserAssignment[]> resp = sendGetRequest(path(), UserAssignment[].class);
+    List<UserAssignment> roles = Optional.ofNullable(resp.getBody())
+        .map(Arrays::asList).orElse(new ArrayList<>());
+    return new Result<>(resp.getStatusCode(), roles, resp.getErrors());
+  }
+
+  private String path() {
+    return String.format("/authz/roles/%s/user-assignments", this.role);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/WeaviateRole.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/WeaviateRole.java
@@ -2,6 +2,7 @@ package io.weaviate.client.v1.rbac.api;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import io.weaviate.client.v1.rbac.model.Permission;
@@ -29,7 +30,7 @@ public class WeaviateRole {
   public Role toRole() {
     List<Permission<?>> permissions = this.permissions.stream()
         .<Permission<?>>map(perm -> Permission.fromWeaviate(perm))
-        .collect(Collectors.toList());
+        .filter(Objects::nonNull).collect(Collectors.toList());
     return new Role(this.name, Permission.merge(permissions));
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/model/UserAssignment.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/UserAssignment.java
@@ -1,0 +1,18 @@
+package io.weaviate.client.v1.rbac.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor
+public class UserAssignment {
+  @SerializedName("userId")
+  String userId;
+
+  @SerializedName("userType")
+  String userType;
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/model/UsersPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/UsersPermission.java
@@ -15,7 +15,10 @@ public class UsersPermission extends Permission<UsersPermission> {
 
   @AllArgsConstructor
   public enum Action implements RbacAction {
+    CREATE("create_users"),
+    UPDATE("update_users"),
     READ("read_users"),
+    DELETE("delete_users"),
     ASSIGN_AND_REVOKE("assign_and_revoke_users");
 
     @Getter

--- a/src/main/java/io/weaviate/client/v1/users/DbUsers.java
+++ b/src/main/java/io/weaviate/client/v1/users/DbUsers.java
@@ -1,0 +1,65 @@
+package io.weaviate.client.v1.users;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.users.api.RoleAssigner;
+import io.weaviate.client.v1.users.api.RoleRevoker;
+import io.weaviate.client.v1.users.api.common.AssignedRolesGetter;
+import io.weaviate.client.v1.users.api.db.Activator;
+import io.weaviate.client.v1.users.api.db.AllGetter;
+import io.weaviate.client.v1.users.api.db.ByNameGetter;
+import io.weaviate.client.v1.users.api.db.Creator;
+import io.weaviate.client.v1.users.api.db.Deactivator;
+import io.weaviate.client.v1.users.api.db.Deleter;
+import io.weaviate.client.v1.users.api.db.KeyRotator;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class DbUsers {
+  private static final String USER_TYPE = "db";
+
+  private final HttpClient httpClient;
+  private final Config config;
+
+  /** Assign a role to a user. Note that 'root' cannot be assigned. */
+  public RoleAssigner assigner() {
+    return new RoleAssigner(httpClient, config, USER_TYPE);
+  }
+
+  /** Revoke a role from a user. Note that 'root' cannot be revoked. */
+  public RoleRevoker revoker() {
+    return new RoleRevoker(httpClient, config, USER_TYPE);
+  }
+
+  public AssignedRolesGetter assignedRoles() {
+    return new AssignedRolesGetter(httpClient, config, USER_TYPE);
+  }
+
+  public Creator creator() {
+    return new Creator(httpClient, config);
+  }
+
+  public Deleter deleter() {
+    return new Deleter(httpClient, config);
+  }
+
+  public Activator activator() {
+    return new Activator(httpClient, config);
+  }
+
+  public Deactivator deactivator() {
+    return new Deactivator(httpClient, config);
+  }
+
+  public KeyRotator keyRotator() {
+    return new KeyRotator(httpClient, config);
+  }
+
+  public ByNameGetter getUser() {
+    return new ByNameGetter(httpClient, config);
+  }
+
+  public AllGetter allGetter() {
+    return new AllGetter(httpClient, config);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/users/DbUsers.java
+++ b/src/main/java/io/weaviate/client/v1/users/DbUsers.java
@@ -31,34 +31,46 @@ public class DbUsers {
     return new RoleRevoker(httpClient, config, USER_TYPE);
   }
 
-  public AssignedRolesGetter assignedRoles() {
+  /** Get roles assigned to a user. */
+  public AssignedRolesGetter userRolesGetter() {
     return new AssignedRolesGetter(httpClient, config, USER_TYPE);
   }
 
+  /** Create a new user. Returns API key for the user to authenticate by. */
   public Creator creator() {
     return new Creator(httpClient, config);
   }
 
+  /**
+   * Delete user.
+   * Users declared in the server environment config cannot be
+   * deleted ('db_env_user').
+   */
   public Deleter deleter() {
     return new Deleter(httpClient, config);
   }
 
+  /** Activate user account. */
   public Activator activator() {
     return new Activator(httpClient, config);
   }
 
+  /** Deactivate user account, optionally revoking its API key. */
   public Deactivator deactivator() {
     return new Deactivator(httpClient, config);
   }
 
+  /** Rotate user's API key. The old key will become invalid. */
   public KeyRotator keyRotator() {
     return new KeyRotator(httpClient, config);
   }
 
+  /** Get information about the user. */
   public ByNameGetter getUser() {
     return new ByNameGetter(httpClient, config);
   }
 
+  /** List all known (non-OIDC) users. */
   public AllGetter allGetter() {
     return new AllGetter(httpClient, config);
   }

--- a/src/main/java/io/weaviate/client/v1/users/OidcUsers.java
+++ b/src/main/java/io/weaviate/client/v1/users/OidcUsers.java
@@ -24,7 +24,8 @@ public class OidcUsers {
     return new RoleRevoker(httpClient, config, USER_TYPE);
   }
 
-  public AssignedRolesGetter assignedRoles() {
+  /** Get roles assigned to a user. */
+  public AssignedRolesGetter userRolesGetter() {
     return new AssignedRolesGetter(httpClient, config, USER_TYPE);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/users/OidcUsers.java
+++ b/src/main/java/io/weaviate/client/v1/users/OidcUsers.java
@@ -1,0 +1,30 @@
+package io.weaviate.client.v1.users;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.users.api.RoleAssigner;
+import io.weaviate.client.v1.users.api.RoleRevoker;
+import io.weaviate.client.v1.users.api.common.AssignedRolesGetter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class OidcUsers {
+  private static final String USER_TYPE = "oidc";
+
+  private final HttpClient httpClient;
+  private final Config config;
+
+  /** Assign a role to a user. Note that 'root' cannot be assigned. */
+  public RoleAssigner assigner() {
+    return new RoleAssigner(httpClient, config, USER_TYPE);
+  }
+
+  /** Revoke a role from a user. Note that 'root' cannot be revoked. */
+  public RoleRevoker revoker() {
+    return new RoleRevoker(httpClient, config, USER_TYPE);
+  }
+
+  public AssignedRolesGetter assignedRoles() {
+    return new AssignedRolesGetter(httpClient, config, USER_TYPE);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/users/Users.java
+++ b/src/main/java/io/weaviate/client/v1/users/Users.java
@@ -19,25 +19,45 @@ public class Users {
     return new MyUserGetter(httpClient, config);
   };
 
-  /** Get roles assigned to a user. */
+  /**
+   * Get roles assigned to a user.
+   * <p>
+   * Deprecated - prefer {@link DbUsers#userRolesGetter()} or
+   * {@link OidcUsers#userRolesGetter()}.
+   */
+  @Deprecated
   public UserRolesGetter userRolesGetter() {
     return new UserRolesGetter(httpClient, config);
   };
 
-  /** Assign a role to a user. Note that 'root' cannot be assigned. */
+  /**
+   * Assign a role to a user. Note that 'root' cannot be assigned.
+   * <p>
+   * Deprecated - prefer {@link DbUsers#assigner()} or
+   * {@link OidcUsers#assigner()}.
+   */
+  @Deprecated
   public RoleAssigner assigner() {
     return new RoleAssigner(httpClient, config);
   }
 
-  /** Revoke a role from a user. Note that 'root' cannot be revoked. */
+  /**
+   * Revoke a role from a user. Note that 'root' cannot be revoked.
+   * <p>
+   * Deprecated - prefer {@link DbUsers#revoker()} or
+   * {@link OidcUsers#revoker()}
+   */
+  @Deprecated
   public RoleRevoker revoker() {
     return new RoleRevoker(httpClient, config);
   }
 
+  /** Manage dynamic users, their roles and permissions. */
   public DbUsers db() {
     return new DbUsers(httpClient, config);
   }
 
+  /** Manage users authenticated via OIDC, their roles and permissions. */
   public OidcUsers oidc() {
     return new OidcUsers(httpClient, config);
   }

--- a/src/main/java/io/weaviate/client/v1/users/Users.java
+++ b/src/main/java/io/weaviate/client/v1/users/Users.java
@@ -33,4 +33,12 @@ public class Users {
   public RoleRevoker revoker() {
     return new RoleRevoker(httpClient, config);
   }
+
+  public DbUsers db() {
+    return new DbUsers(httpClient, config);
+  }
+
+  public OidcUsers oidc() {
+    return new OidcUsers(httpClient, config);
+  }
 }

--- a/src/main/java/io/weaviate/client/v1/users/api/RoleAssigner.java
+++ b/src/main/java/io/weaviate/client/v1/users/api/RoleAssigner.java
@@ -7,7 +7,6 @@ import java.util.List;
 import io.weaviate.client.Config;
 import io.weaviate.client.base.BaseClient;
 import io.weaviate.client.base.ClientResult;
-import io.weaviate.client.base.Response;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.base.http.HttpClient;
 import lombok.AllArgsConstructor;
@@ -16,8 +15,15 @@ public class RoleAssigner extends BaseClient<Void> implements ClientResult<Boole
   private String userId;
   private List<String> roles = new ArrayList<>();
 
+  private final String _userType;
+
   public RoleAssigner(HttpClient httpClient, Config config) {
+    this(httpClient, config, null);
+  }
+
+  public RoleAssigner(HttpClient httpClient, Config config, String userType) {
     super(httpClient, config);
+    this._userType = userType;
   }
 
   public RoleAssigner withUserId(String id) {
@@ -32,15 +38,14 @@ public class RoleAssigner extends BaseClient<Void> implements ClientResult<Boole
 
   /** The API signature for this method is { "roles": [...] } */
   @AllArgsConstructor
-  private static class Body {
-    public final List<String> roles;
+  private class Body {
+    final String userType = _userType;
+    final List<String> roles;
   }
 
   @Override
   public Result<Boolean> run() {
-    Response<Void> resp = sendPostRequest(path(), new Body(this.roles), Void.class);
-    int status = resp.getStatusCode();
-    return new Result<Boolean>(status, status == 200, resp.getErrors());
+    return Result.voidToBoolean(sendPostRequest(path(), new Body(this.roles), Void.class));
   }
 
   private String path() {

--- a/src/main/java/io/weaviate/client/v1/users/api/RoleRevoker.java
+++ b/src/main/java/io/weaviate/client/v1/users/api/RoleRevoker.java
@@ -16,8 +16,15 @@ public class RoleRevoker extends BaseClient<Void> implements ClientResult<Boolea
   private String userId;
   private List<String> roles = new ArrayList<>();
 
+  private final String _userType;
+
   public RoleRevoker(HttpClient httpClient, Config config) {
+    this(httpClient, config, null);
+  }
+
+  public RoleRevoker(HttpClient httpClient, Config config, String userType) {
     super(httpClient, config);
+    this._userType = userType;
   }
 
   public RoleRevoker withUserId(String id) {
@@ -32,8 +39,9 @@ public class RoleRevoker extends BaseClient<Void> implements ClientResult<Boolea
 
   /** The API signature for this method is { "roles": [...] } */
   @AllArgsConstructor
-  private static class Body {
-    public final List<String> roles;
+  private class Body {
+    final String userType = _userType;
+    final List<String> roles;
   }
 
   @Override

--- a/src/main/java/io/weaviate/client/v1/users/api/WeaviateUser.java
+++ b/src/main/java/io/weaviate/client/v1/users/api/WeaviateUser.java
@@ -20,7 +20,10 @@ public class WeaviateUser {
   List<WeaviateRole> roles = new ArrayList<>();
 
   public User toUser() {
-    return new User(id != null ? id : username,
-        roles.stream().map(WeaviateRole::toRole).collect(Collectors.toList()));
+    return new User(
+        id != null ? id : username,
+        roles != null
+            ? roles.stream().map(WeaviateRole::toRole).collect(Collectors.toList())
+            : new ArrayList<>());
   }
 }

--- a/src/main/java/io/weaviate/client/v1/users/api/common/AssignedRolesGetter.java
+++ b/src/main/java/io/weaviate/client/v1/users/api/common/AssignedRolesGetter.java
@@ -1,4 +1,4 @@
-package io.weaviate.client.v1.users.api;
+package io.weaviate.client.v1.users.api.common;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -15,16 +15,27 @@ import io.weaviate.client.base.http.HttpClient;
 import io.weaviate.client.v1.rbac.api.WeaviateRole;
 import io.weaviate.client.v1.rbac.model.Role;
 
-public class UserRolesGetter extends BaseClient<WeaviateRole[]> implements ClientResult<List<Role>> {
+public class AssignedRolesGetter extends BaseClient<WeaviateRole[]> implements ClientResult<List<Role>> {
   private String userId;
+  private boolean includePermissions = false;
+  private final String userType;
 
-  public UserRolesGetter(HttpClient httpClient, Config config) {
+  public AssignedRolesGetter(HttpClient httpClient, Config config, String userType) {
     super(httpClient, config);
+    this.userType = userType;
   }
 
-  /** Leave unset to fetch roles assigned to the current user. */
-  public UserRolesGetter withUserId(String id) {
-    this.userId = id;
+  public AssignedRolesGetter withUserId(String userId) {
+    this.userId = userId;
+    return this;
+  }
+
+  public AssignedRolesGetter includePermissions() {
+    return includePermissions(true);
+  }
+
+  public AssignedRolesGetter includePermissions(boolean include) {
+    this.includePermissions = include;
     return this;
   }
 
@@ -36,9 +47,11 @@ public class UserRolesGetter extends BaseClient<WeaviateRole[]> implements Clien
         .stream().map(WeaviateRole::toRole)
         .collect(Collectors.toList());
     return new Result<>(resp.getStatusCode(), roles, resp.getErrors());
+
   }
 
   private String path() {
-    return String.format("/authz/users/%s/roles", this.userId);
+    return String.format("/authz/users/%s/roles/%s?includeFullRoles=%s",
+        userId, userType, includePermissions);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/users/api/common/AssignedRolesGetter.java
+++ b/src/main/java/io/weaviate/client/v1/users/api/common/AssignedRolesGetter.java
@@ -30,6 +30,10 @@ public class AssignedRolesGetter extends BaseClient<WeaviateRole[]> implements C
     return this;
   }
 
+  /**
+   * Include a full list of permissions for each role.
+   * If not set, only role names will be populated.
+   */
   public AssignedRolesGetter includePermissions() {
     return includePermissions(true);
   }

--- a/src/main/java/io/weaviate/client/v1/users/api/db/Activator.java
+++ b/src/main/java/io/weaviate/client/v1/users/api/db/Activator.java
@@ -1,0 +1,28 @@
+package io.weaviate.client.v1.users.api.db;
+
+import org.apache.hc.core5.http.HttpStatus;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+
+public class Activator extends BaseClient<Void> implements ClientResult<Boolean> {
+  private String userId;
+
+  public Activator(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public Activator withUserId(String userId) {
+    this.userId = userId;
+    return this;
+  }
+
+  @Override
+  public Result<Boolean> run() {
+    return Result.voidToBoolean(sendPostRequest("/users/db/" + userId + "/activate", null, Void.class),
+        HttpStatus.SC_CONFLICT);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/users/api/db/AllGetter.java
+++ b/src/main/java/io/weaviate/client/v1/users/api/db/AllGetter.java
@@ -1,0 +1,25 @@
+package io.weaviate.client.v1.users.api.db;
+
+import java.util.Arrays;
+import java.util.List;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Response;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.users.model.UserDb;
+
+public class AllGetter extends BaseClient<UserDb[]> implements ClientResult<List<UserDb>> {
+
+  public AllGetter(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  @Override
+  public Result<List<UserDb>> run() {
+    Response<UserDb[]> resp = sendGetRequest("/users/db", UserDb[].class);
+    return new Result<>(resp.getStatusCode(), Arrays.asList(resp.getBody()), resp.getErrors());
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/users/api/db/ByNameGetter.java
+++ b/src/main/java/io/weaviate/client/v1/users/api/db/ByNameGetter.java
@@ -1,0 +1,26 @@
+package io.weaviate.client.v1.users.api.db;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.users.model.UserDb;
+
+public class ByNameGetter extends BaseClient<UserDb> implements ClientResult<UserDb> {
+  private String userId;
+
+  public ByNameGetter(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public ByNameGetter withUserId(String userId) {
+    this.userId = userId;
+    return this;
+  }
+
+  @Override
+  public Result<UserDb> run() {
+    return new Result<>(sendGetRequest("/users/db/" + userId, UserDb.class));
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/users/api/db/Creator.java
+++ b/src/main/java/io/weaviate/client/v1/users/api/db/Creator.java
@@ -31,6 +31,6 @@ public class Creator extends BaseClient<ApiKey> implements ClientResult<String> 
   @Override
   public Result<String> run() {
     Response<ApiKey> resp = sendPostRequest("/users/db/" + userId, null, ApiKey.class);
-    return new Result<>(resp, resp.getBody().apiKey);
+    return new Result<>(resp, resp.getBody() != null ? resp.getBody().apiKey : null);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/users/api/db/Creator.java
+++ b/src/main/java/io/weaviate/client/v1/users/api/db/Creator.java
@@ -1,0 +1,36 @@
+package io.weaviate.client.v1.users.api.db;
+
+import com.google.gson.annotations.SerializedName;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Response;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.users.api.db.Creator.ApiKey;
+
+/** Creates a new 'db' user and returns its API key. */
+public class Creator extends BaseClient<ApiKey> implements ClientResult<String> {
+  private String userId;
+
+  public Creator(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public Creator withUserId(String userId) {
+    this.userId = userId;
+    return this;
+  }
+
+  static class ApiKey {
+    @SerializedName("apikey")
+    String apiKey;
+  }
+
+  @Override
+  public Result<String> run() {
+    Response<ApiKey> resp = sendPostRequest("/users/db/" + userId, null, ApiKey.class);
+    return new Result<>(resp, resp.getBody().apiKey);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/users/api/db/Deactivator.java
+++ b/src/main/java/io/weaviate/client/v1/users/api/db/Deactivator.java
@@ -1,0 +1,47 @@
+package io.weaviate.client.v1.users.api.db;
+
+import org.apache.hc.core5.http.HttpStatus;
+
+import com.google.gson.annotations.SerializedName;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import lombok.AllArgsConstructor;
+
+public class Deactivator extends BaseClient<Void> implements ClientResult<Boolean> {
+  private String userId;
+  private boolean revokeKey = false;
+
+  public Deactivator(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public Deactivator withUserId(String userId) {
+    this.userId = userId;
+    return this;
+  }
+
+  public Deactivator revokeKey() {
+    return revokeKey(true);
+  }
+
+  public Deactivator revokeKey(boolean revoke) {
+    this.revokeKey = revoke;
+    return this;
+  }
+
+  @AllArgsConstructor
+  private class Body {
+    @SerializedName("revoke_key")
+    private boolean revokeKey;
+  }
+
+  @Override
+  public Result<Boolean> run() {
+    return Result.voidToBoolean(sendPostRequest("/users/db/" + userId + "/deactivate", new Body(revokeKey), Void.class),
+        HttpStatus.SC_CONFLICT);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/users/api/db/Deleter.java
+++ b/src/main/java/io/weaviate/client/v1/users/api/db/Deleter.java
@@ -1,0 +1,25 @@
+package io.weaviate.client.v1.users.api.db;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+
+public class Deleter extends BaseClient<Void> implements ClientResult<Boolean> {
+  private String userId;
+
+  public Deleter(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public Deleter withUserId(String userId) {
+    this.userId = userId;
+    return this;
+  }
+
+  @Override
+  public Result<Boolean> run() {
+    return Result.voidToBoolean(sendDeleteRequest("/users/db/" + userId, null, Void.class));
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/users/api/db/KeyRotator.java
+++ b/src/main/java/io/weaviate/client/v1/users/api/db/KeyRotator.java
@@ -1,0 +1,35 @@
+package io.weaviate.client.v1.users.api.db;
+
+import com.google.gson.annotations.SerializedName;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Response;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.users.api.db.KeyRotator.ApiKey;
+
+public class KeyRotator extends BaseClient<ApiKey> implements ClientResult<String> {
+  private String userId;
+
+  public KeyRotator(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public KeyRotator withUserId(String userId) {
+    this.userId = userId;
+    return this;
+  }
+
+  static class ApiKey {
+    @SerializedName("apikey")
+    String apiKey;
+  }
+
+  @Override
+  public Result<String> run() {
+    Response<ApiKey> resp = sendPostRequest("/users/db/" + userId + "/rotate-key", null, ApiKey.class);
+    return new Result<>(resp, resp.getBody().apiKey);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/users/model/UserDb.java
+++ b/src/main/java/io/weaviate/client/v1/users/model/UserDb.java
@@ -1,0 +1,22 @@
+package io.weaviate.client.v1.users.model;
+
+import java.util.List;
+
+import com.google.gson.annotations.SerializedName;
+
+import lombok.Getter;
+
+@Getter
+public class UserDb {
+  @SerializedName("roles")
+  List<String> roleNames;
+
+  @SerializedName("userId")
+  String userId;
+
+  @SerializedName("dbUserType")
+  String userType;
+
+  @SerializedName("active")
+  boolean active;
+}

--- a/src/main/java/io/weaviate/client/v1/users/model/UserDb.java
+++ b/src/main/java/io/weaviate/client/v1/users/model/UserDb.java
@@ -4,9 +4,11 @@ import java.util.List;
 
 import com.google.gson.annotations.SerializedName;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
+@EqualsAndHashCode
 public class UserDb {
   @SerializedName("roles")
   List<String> roleNames;

--- a/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
@@ -8,7 +8,7 @@ public class WeaviateVersion {
   // to be set according to weaviate docker image
   public static final String EXPECTED_WEAVIATE_VERSION = "1.30.0";
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_GIT_HASH = "35d800d";
+  public static final String EXPECTED_WEAVIATE_GIT_HASH = "b7b7715";
 
   private WeaviateVersion() {
   }

--- a/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
@@ -3,10 +3,10 @@ package io.weaviate.integration.client;
 public class WeaviateVersion {
 
   // docker image version
-  public static final String WEAVIATE_IMAGE = "1.29.0";
+  public static final String WEAVIATE_IMAGE = "1.30.0";
 
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_VERSION = "1.29.0";
+  public static final String EXPECTED_WEAVIATE_VERSION = "1.30.0";
   // to be set according to weaviate docker image
   public static final String EXPECTED_WEAVIATE_GIT_HASH = "35d800d";
 

--- a/src/test/java/io/weaviate/integration/client/WeaviateWithOidcContainer.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateWithOidcContainer.java
@@ -16,11 +16,11 @@ public class WeaviateWithOidcContainer extends WeaviateContainer {
     withEnv("AUTHENTICATION_OIDC_USERNAME_CLAIM", "email");
     withEnv("AUTHENTICATION_OIDC_GROUPS_CLAIM", "groups");
     withEnv("AUTHORIZATION_ADMINLIST_ENABLED", "true");
-    withEnv("AUTHORIZATION_ADMINLIST_USERS", "ms_2d0e007e7136de11d5f29fce7a53dae219a51458@existiert.net");
+    withEnv("AUTHORIZATION_ADMINLIST_USERS", "oidc-test-user@weaviate.io");
     withEnv("AUTHENTICATION_OIDC_SCOPES", "openid,email");
     withEnv("AUTHENTICATION_APIKEY_ENABLED", "true");
     withEnv("AUTHENTICATION_APIKEY_ALLOWED_KEYS", "my-secret-key");
-    withEnv("AUTHENTICATION_APIKEY_USERS", "ms_2d0e007e7136de11d5f29fce7a53dae219a51458@existiert.net");
+    withEnv("AUTHENTICATION_APIKEY_USERS", "oidc-test-user@weaviate.io");
     withEnv("DISABLE_TELEMETRY", "true");
   }
 }

--- a/src/test/java/io/weaviate/integration/client/WeaviateWithRbacContainer.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateWithRbacContainer.java
@@ -18,7 +18,12 @@ public class WeaviateWithRbacContainer extends WeaviateContainer {
     withEnv("ENABLE_MODULES", "backup-filesystem");
     withEnv("CLUSTER_GOSSIP_BIND_PORT", "7100");
     withEnv("CLUSTER_DATA_BIND_PORT", "7101");
-
+    withEnv("AUTHENTICATION_DB_USERS_ENABLED", "true");
+    withEnv("AUTHENTICATION_OIDC_ENABLED", "true");
+    withEnv("AUTHENTICATION_OIDC_CLIENT_ID", "wcs");
+    withEnv("AUTHENTICATION_OIDC_ISSUER", "https://auth.wcs.api.weaviate.io/auth/realms/SeMI");
+    withEnv("AUTHENTICATION_OIDC_USERNAME_CLAIM", "email");
+    withEnv("AUTHENTICATION_OIDC_GROUPS_CLAIM", "groups");
     if (viewers.length > 0) {
       withEnv("AUTHORIZATION_VIEWER_USERS", String.join(",", viewers));
     }

--- a/src/test/java/io/weaviate/integration/client/async/rbac/ClientRbacTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/rbac/ClientRbacTest.java
@@ -11,6 +11,7 @@ import io.weaviate.client.v1.async.rbac.Roles;
 import io.weaviate.client.v1.auth.exception.AuthException;
 import io.weaviate.client.v1.rbac.model.Permission;
 import io.weaviate.client.v1.rbac.model.Role;
+import io.weaviate.client.v1.rbac.model.UserAssignment;
 import io.weaviate.integration.tests.rbac.ClientRbacTestSuite;
 import io.weaviate.integration.tests.users.ClientUsersTestSuite;
 
@@ -87,5 +88,10 @@ public class ClientRbacTest implements ClientRbacTestSuite.Rbac {
   @Override
   public Result<?> removePermissions(String role, Permission<?>... permissions) {
     return rethrow(() -> roles.permissionRemover().withRole(role).withPermissions(permissions).run());
+  }
+
+  @Override
+  public Result<List<UserAssignment>> getUserAssignments(String role) {
+    return rethrow(() -> roles.userAssignmentsGetter().withRole(role).run());
   }
 }

--- a/src/test/java/io/weaviate/integration/client/async/schema/ClientSchemaTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/schema/ClientSchemaTest.java
@@ -468,7 +468,7 @@ public class ClientSchemaTest {
       //then
       assertResultTrue(createStatus);
 
-      assertResultError("tokenization in body should be one of [word lowercase whitespace field trigram gse kagome_kr kagome_ja]", notExistingTokenizationCreateStatus);
+      assertResultError("tokenization in body should be one of [word lowercase whitespace field trigram gse kagome_kr kagome_ja gse_ch]", notExistingTokenizationCreateStatus);
       assertResultError("Tokenization is not allowed for data type 'int'", notSupportedTokenizationForIntCreateStatus);
     }
   }

--- a/src/test/java/io/weaviate/integration/client/async/users/ClientUsersTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/users/ClientUsersTest.java
@@ -94,10 +94,10 @@ public class ClientUsersTest extends ClientRbacTest implements ClientUsersTestSu
     }
 
     @Override
-    public Result<List<Role>> assignedRoles(String user, boolean includePermissions) {
+    public Result<List<Role>> getAssignedRoles(String user, boolean includePermissions) {
       return useOidc
-          ? rethrow(() -> oidc.assignedRoles().withUserId(user).includePermissions(includePermissions).run())
-          : rethrow(() -> db.assignedRoles().withUserId(user).includePermissions(includePermissions).run());
+          ? rethrow(() -> oidc.userRolesGetter().withUserId(user).includePermissions(includePermissions).run())
+          : rethrow(() -> db.userRolesGetter().withUserId(user).includePermissions(includePermissions).run());
     }
 
     @Override

--- a/src/test/java/io/weaviate/integration/client/async/users/ClientUsersTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/users/ClientUsersTest.java
@@ -5,10 +5,12 @@ import java.util.List;
 import io.weaviate.client.Config;
 import io.weaviate.client.WeaviateAuthClient;
 import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.async.users.DbUsers;
 import io.weaviate.client.v1.async.users.Users;
 import io.weaviate.client.v1.auth.exception.AuthException;
 import io.weaviate.client.v1.rbac.model.Role;
 import io.weaviate.client.v1.users.model.User;
+import io.weaviate.client.v1.users.model.UserDb;
 import io.weaviate.integration.client.async.rbac.ClientRbacTest;
 import io.weaviate.integration.tests.users.ClientUsersTestSuite;
 
@@ -47,5 +49,68 @@ public class ClientUsersTest extends ClientRbacTest implements ClientUsersTestSu
   @Override
   public Result<?> revokeRoles(String user, String... roles) {
     return rethrow(() -> this.users.revoker().withUserId(user).witRoles(roles).run());
+  }
+
+  @Override
+  public io.weaviate.integration.tests.users.ClientUsersTestSuite.DbUsers db() {
+    return new DbUsersImpl();
+  }
+
+  private class DbUsersImpl implements ClientUsersTestSuite.DbUsers {
+    private final DbUsers db;
+
+    public DbUsersImpl() {
+      this.db = users.db();
+    }
+
+    @Override
+    public Result<?> assignRoles(String user, String... roles) {
+      return rethrow(() -> db.assigner().withUserId(user).witRoles(roles).run());
+    }
+
+    @Override
+    public Result<?> revokeRoles(String user, String... roles) {
+      return rethrow(() -> db.revoker().withUserId(user).witRoles(roles).run());
+    }
+
+    @Override
+    public Result<List<Role>> assignedRoles(String user, boolean includePermissions) {
+      return rethrow(() -> db.assignedRoles().withUserId(user).includePermissions(includePermissions).run());
+    }
+
+    @Override
+    public Result<String> create(String user) {
+      return rethrow(() -> db.creator().withUserId(user).run());
+    }
+
+    @Override
+    public Result<String> rotateKey(String user) {
+      return rethrow(() -> db.keyRotator().withUserId(user).run());
+    }
+
+    @Override
+    public Result<Boolean> delete(String user) {
+      return rethrow(() -> db.deleter().withUserId(user).run());
+    }
+
+    @Override
+    public Result<Boolean> activate(String user) {
+      return rethrow(() -> db.activator().withUserId(user).run());
+    }
+
+    @Override
+    public Result<Boolean> deactivate(String user, boolean revokeKey) {
+      return rethrow(() -> db.deactivator().withUserId(user).run());
+    }
+
+    @Override
+    public Result<UserDb> getUser(String user) {
+      return rethrow(() -> db.getUser().withUserId(user).run());
+    }
+
+    @Override
+    public Result<List<UserDb>> getAll() {
+      return rethrow(() -> db.allGetter().run());
+    }
   }
 }

--- a/src/test/java/io/weaviate/integration/client/auth/AuthWCSUsersResourceOwnerTest.java
+++ b/src/test/java/io/weaviate/integration/client/auth/AuthWCSUsersResourceOwnerTest.java
@@ -35,7 +35,7 @@ public class AuthWCSUsersResourceOwnerTest {
     String password = System.getenv("WCS_DUMMY_CI_PW");
     if (StringUtils.isNotBlank(password)) {
       Config config = new Config("http", address);
-      String username = "ms_2d0e007e7136de11d5f29fce7a53dae219a51458@existiert.net";
+      String username = "oidc-test-user@weaviate.io";
       ResourceOwnerPasswordFlow resourceOwnerPasswordFlow = new ResourceOwnerPasswordFlow(username, password);
       WeaviateClient client = resourceOwnerPasswordFlow.getAuthClient(config, null);
       Result<Meta> meta = client.misc().metaGetter().run();

--- a/src/test/java/io/weaviate/integration/client/auth/provider/NimbusAuthRefreshTokenTest.java
+++ b/src/test/java/io/weaviate/integration/client/auth/provider/NimbusAuthRefreshTokenTest.java
@@ -49,7 +49,7 @@ public class NimbusAuthRefreshTokenTest {
     String password = System.getenv("WCS_DUMMY_CI_PW");
     if (StringUtils.isNotBlank(password)) {
       Config config = new Config("http", address);
-      String username = "ms_2d0e007e7136de11d5f29fce7a53dae219a51458@existiert.net";
+      String username = "oidc-test-user@weaviate.io";
       assertThat(tokenProvider).isNull();
       NimbusAuthAuthImpl nimbusAuth = new NimbusAuthAuthImpl();
       AccessTokenProvider provider = nimbusAuth.getAccessTokenProvider(config, "", username, password, null, AuthType.USER_PASSWORD);

--- a/src/test/java/io/weaviate/integration/client/rbac/ClientRbacTest.java
+++ b/src/test/java/io/weaviate/integration/client/rbac/ClientRbacTest.java
@@ -9,6 +9,7 @@ import io.weaviate.client.v1.auth.exception.AuthException;
 import io.weaviate.client.v1.rbac.Roles;
 import io.weaviate.client.v1.rbac.model.Permission;
 import io.weaviate.client.v1.rbac.model.Role;
+import io.weaviate.client.v1.rbac.model.UserAssignment;
 import io.weaviate.integration.tests.rbac.ClientRbacTestSuite;
 
 public class ClientRbacTest implements ClientRbacTestSuite.Rbac {
@@ -65,5 +66,10 @@ public class ClientRbacTest implements ClientRbacTestSuite.Rbac {
   @Override
   public Result<?> removePermissions(String role, Permission<?>... permissions) {
     return roles.permissionRemover().withRole(role).withPermissions(permissions).run();
+  }
+
+  @Override
+  public Result<List<UserAssignment>> getUserAssignments(String role) {
+    return roles.userAssignmentsGetter().withRole(role).run();
   }
 }

--- a/src/test/java/io/weaviate/integration/client/schema/ClientSchemaTest.java
+++ b/src/test/java/io/weaviate/integration/client/schema/ClientSchemaTest.java
@@ -361,7 +361,7 @@ public class ClientSchemaTest {
     //then
     assertResultTrue(createStatus);
 
-    assertResultError("tokenization in body should be one of [word lowercase whitespace field trigram gse kagome_kr kagome_ja]", notExistingTokenizationCreateStatus);
+    assertResultError("tokenization in body should be one of [word lowercase whitespace field trigram gse kagome_kr kagome_ja gse_ch]", notExistingTokenizationCreateStatus);
     assertResultError("Tokenization is not allowed for data type 'int'", notSupportedTokenizationForIntCreateStatus);
   }
 

--- a/src/test/java/io/weaviate/integration/client/users/ClientUsersTest.java
+++ b/src/test/java/io/weaviate/integration/client/users/ClientUsersTest.java
@@ -89,10 +89,10 @@ public class ClientUsersTest extends ClientRbacTest implements ClientUsersTestSu
     }
 
     @Override
-    public Result<List<Role>> assignedRoles(String user, boolean includePermissions) {
+    public Result<List<Role>> getAssignedRoles(String user, boolean includePermissions) {
       return useOidc
-          ? oidc.assignedRoles().withUserId(user).includePermissions(includePermissions).run()
-          : db.assignedRoles().withUserId(user).includePermissions(includePermissions).run();
+          ? oidc.userRolesGetter().withUserId(user).includePermissions(includePermissions).run()
+          : db.userRolesGetter().withUserId(user).includePermissions(includePermissions).run();
     }
 
     @Override

--- a/src/test/java/io/weaviate/integration/client/users/ClientUsersTest.java
+++ b/src/test/java/io/weaviate/integration/client/users/ClientUsersTest.java
@@ -7,13 +7,15 @@ import io.weaviate.client.WeaviateAuthClient;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.v1.auth.exception.AuthException;
 import io.weaviate.client.v1.rbac.model.Role;
+import io.weaviate.client.v1.users.DbUsers;
 import io.weaviate.client.v1.users.Users;
 import io.weaviate.client.v1.users.model.User;
+import io.weaviate.client.v1.users.model.UserDb;
 import io.weaviate.integration.client.rbac.ClientRbacTest;
 import io.weaviate.integration.tests.users.ClientUsersTestSuite;
 
 public class ClientUsersTest extends ClientRbacTest implements ClientUsersTestSuite.Users {
-  private Users users;
+  private final Users users;
 
   public ClientUsersTest(Config config, String apiKey) {
     super(config, apiKey);
@@ -42,5 +44,68 @@ public class ClientUsersTest extends ClientRbacTest implements ClientUsersTestSu
   @Override
   public Result<?> revokeRoles(String user, String... roles) {
     return this.users.revoker().withUserId(user).witRoles(roles).run();
+  }
+
+  @Override
+  public ClientUsersTestSuite.DbUsers db() {
+    return new DbUsersImpl();
+  }
+
+  private class DbUsersImpl implements ClientUsersTestSuite.DbUsers {
+    private final DbUsers db;
+
+    public DbUsersImpl() {
+      this.db = users.db();
+    }
+
+    @Override
+    public Result<?> assignRoles(String user, String... roles) {
+      return db.assigner().withUserId(user).witRoles(roles).run();
+    }
+
+    @Override
+    public Result<?> revokeRoles(String user, String... roles) {
+      return db.revoker().withUserId(user).witRoles(roles).run();
+    }
+
+    @Override
+    public Result<List<Role>> assignedRoles(String user, boolean includePermissions) {
+      return db.assignedRoles().withUserId(user).includePermissions(includePermissions).run();
+    }
+
+    @Override
+    public Result<String> create(String user) {
+      return db.creator().withUserId(user).run();
+    }
+
+    @Override
+    public Result<String> rotateKey(String user) {
+      return db.keyRotator().withUserId(user).run();
+    }
+
+    @Override
+    public Result<Boolean> delete(String user) {
+      return db.deleter().withUserId(user).run();
+    }
+
+    @Override
+    public Result<Boolean> activate(String user) {
+      return db.activator().withUserId(user).run();
+    }
+
+    @Override
+    public Result<Boolean> deactivate(String user, boolean revokeKey) {
+      return db.deactivator().withUserId(user).run();
+    }
+
+    @Override
+    public Result<UserDb> getUser(String user) {
+      return db.getUser().withUserId(user).run();
+    }
+
+    @Override
+    public Result<List<UserDb>> getAll() {
+      return db.allGetter().run();
+    }
   }
 }

--- a/src/test/java/io/weaviate/integration/tests/users/ClientUsersTestSuite.java
+++ b/src/test/java/io/weaviate/integration/tests/users/ClientUsersTestSuite.java
@@ -142,7 +142,11 @@ public class ClientUsersTestSuite {
 
     db.delete("dynamic-dave");
     WeaviateError error = db.getUser("dynamic-dave").getError();
-    assertEquals(404, error.getStatusCode(), "user not found after deletion");
+    // We do not return 404 errors, or any errors without an error message.
+    // Changing that would mean breaking existing code.
+    // assertEquals(404, error.getStatusCode(), "user not found after deletion");
+    assertNull("getting a deleted user produces no error", error);
+    assertNull("user is deleted", db.getUser("dynamic-dave").getResult());
   }
 
   /** Admin can obtain and rotate API keys for users. */

--- a/src/test/java/io/weaviate/integration/tests/users/ClientUsersTestSuite.java
+++ b/src/test/java/io/weaviate/integration/tests/users/ClientUsersTestSuite.java
@@ -131,14 +131,14 @@ public class ClientUsersTestSuite {
     assertTrue("created user is active", dave.isActive());
 
     boolean ok = db.activate("dynamic-dave").getResult();
-    assertTrue("second activation is a no-op", ok);
+    assertFalse("second activation is a no-op", ok);
 
     db.deactivate("dynamic-dave", true);
     dave = db.getUser("dynamic-dave").getResult();
     assertFalse("user deactivated", dave.isActive());
 
     ok = db.deactivate("dynamic-dave", true).getResult();
-    assertTrue("second deactivation is a no-op", ok);
+    assertFalse("second deactivation is a no-op", ok);
 
     db.delete("dynamic-dave");
     WeaviateError error = db.getUser("dynamic-dave").getError();

--- a/src/test/java/io/weaviate/integration/tests/users/ClientUsersTestSuite.java
+++ b/src/test/java/io/weaviate/integration/tests/users/ClientUsersTestSuite.java
@@ -259,7 +259,7 @@ public class ClientUsersTestSuite {
     db.create("permission-peter");
     db.assignRoles("permission-peter", "TestRole");
 
-    List<Role> roles = db.assignedRoles("permission-peter", true).getResult();
+    List<Role> roles = db.getAssignedRoles("permission-peter", true).getResult();
     assertEquals(1, roles.size(), "expected n. of roles");
     Role testRole = roles.get(0);
     assertEquals(2, testRole.permissions.size(), "expected n. of permissions");
@@ -304,7 +304,7 @@ public class ClientUsersTestSuite {
 
     Result<?> revokeRoles(String user, String... roles);
 
-    Result<List<Role>> assignedRoles(String user, boolean includePermissions);
+    Result<List<Role>> getAssignedRoles(String user, boolean includePermissions);
 
     Result<String> create(String user);
 
@@ -326,6 +326,6 @@ public class ClientUsersTestSuite {
 
     Result<?> revokeRoles(String user, String... roles);
 
-    Result<List<Role>> assignedRoles(String user, boolean includePermissions);
+    Result<List<Role>> getAssignedRoles(String user, boolean includePermissions);
   }
 }


### PR DESCRIPTION
This PR brings support for dynamic user management features introduced in `v1.30`.

Adds (sync/async):
- `DbUsers` and `OidcUsers` clients accessible via `client.users().db()` and `client.users().oidc()`
- `UserAssignemntsGetter` to retrieve uses assigned to the role from /user-assignments endpoint
- Another `Result` constructor that allows to override the body while reusing the HTTP response
- `Result.voidToBoolean` helpers now accept a list of allowed failure codes that still should produce `true` in the result
- array-to-list parsers for `Result`
- Extends `RoleAssigner` and `RoleRevoker` to take an optional namespace argument. This allows re-using the existing classes for legacy, db-, and oidc- users.

Deprecates (sync/async):
- `assigner`, `revoker`, and `userRolesGetter` on the root `Users` client (not namaspaced)
- `assignedUsersGetter` in `Roles` client (in favor of `userAssignmentsGetter`)
- [Enables](https://github.com/weaviate/java-client/pull/369/files#diff-1e1ac07b523354ca6b71494adf6ef29047a261ec4f79ae41623eff926259a9baR21-R26) OIDC and dynamic user management in WeaviateWithRbac testcontainer

Updates:
- Weaviate version and commit hash for integration tests
- WCS_DUMMY email used for OIDC tests (see [thread](https://weaviate-org.slack.com/archives/C0887L0KL3S/p1743418558463299))
