### PR TITLE
chore: bump httpclient to 5.4.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <maven.compiler.release>8</maven.compiler.release>
     <lombok.version>1.18.36</lombok.version>
     <gson.version>2.12.1</gson.version>
-    <httpclient.version>5.4.2</httpclient.version>
+    <httpclient.version>5.4.3</httpclient.version>
     <lang3.version>3.17.0</lang3.version>
     <junit.version>5.12.0</junit.version>
     <testcontainers.version>1.20.5</testcontainers.version>


### PR DESCRIPTION
This patch includes a fix for a high severity vulnerability. For details see this Dependabot alert: https://github.com/weaviate/java-client/security/dependabot/4