### PR TITLE
chore: add tests from WeaviateObject.Adapter

### DIFF
--- a/src/main/java/io/weaviate/client/v1/data/model/WeaviateObject.java
+++ b/src/main/java/io/weaviate/client/v1/data/model/WeaviateObject.java
@@ -80,8 +80,12 @@ public class WeaviateObject {
     public JsonElement serialize(WeaviateObject src, Type typeOfSrc, JsonSerializationContext ctx) {
       JsonObject result = gson.toJsonTree(src).getAsJsonObject();
 
+      if (result.has("vectors") && result.getAsJsonObject("vectors").isEmpty()) {
+        result.remove("vectors");
+      }
+
       // Add multi-vectors to the named vectors map.
-      if (src.multiVectors != null) {
+      if (src.multiVectors != null && !src.multiVectors.isEmpty()) {
         if (!result.has("vectors")) {
           result.add("vectors", new JsonObject());
         }

--- a/src/test/java/io/weaviate/client/v1/data/model/WeaviateObjectAdapterTest.java
+++ b/src/test/java/io/weaviate/client/v1/data/model/WeaviateObjectAdapterTest.java
@@ -19,7 +19,7 @@ public class WeaviateObjectAdapterTest {
       .registerTypeAdapter(WeaviateObject.class, WeaviateObject.Adapter.INSTANCE)
       .create();
 
-  public static Object[][] testCaseSerialize() {
+  public static Object[][] testCasesJson() {
     return new Object[][] {
         {
             WeaviateObject.builder().vector(new Float[] { 1f, 2f, 3f }).build(),
@@ -52,10 +52,17 @@ public class WeaviateObjectAdapterTest {
   }
 
   @Test
-  @DataMethod(source = WeaviateObjectAdapterTest.class, method = "testCaseSerialize")
+  @DataMethod(source = WeaviateObjectAdapterTest.class, method = "testCasesJson")
   public void test_toJson(WeaviateObject in, String want) {
     String got = gson.toJson(in);
     assertSameJson(got, want);
+  }
+
+  @Test
+  @DataMethod(source = WeaviateObjectAdapterTest.class, method = "testCasesJson")
+  public void test_fromJson(WeaviateObject want, String in) {
+    WeaviateObject got = gson.fromJson(in, WeaviateObject.class);
+    Assertions.assertThat(got).usingRecursiveComparison().isEqualTo(want);
   }
 
   private void assertSameJson(String got, String want) {

--- a/src/test/java/io/weaviate/client/v1/data/model/WeaviateObjectAdapterTest.java
+++ b/src/test/java/io/weaviate/client/v1/data/model/WeaviateObjectAdapterTest.java
@@ -1,0 +1,67 @@
+package io.weaviate.client.v1.data.model;
+
+import java.util.Collections;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.jparams.junit4.JParamsTestRunner;
+import com.jparams.junit4.data.DataMethod;
+
+@RunWith(JParamsTestRunner.class)
+public class WeaviateObjectAdapterTest {
+  private static final Gson gson = new GsonBuilder()
+      .registerTypeAdapter(WeaviateObject.class, WeaviateObject.Adapter.INSTANCE)
+      .create();
+
+  public static Object[][] testCaseSerialize() {
+    return new Object[][] {
+        {
+            WeaviateObject.builder().vector(new Float[] { 1f, 2f, 3f }).build(),
+            "{\"vector\":[1.0,2.0,3.0]}"
+        },
+        {
+            WeaviateObject.builder().vectors(Collections.singletonMap("single", new Float[] { 1f, 2f, 3f })).build(),
+            "{\"vectors\":{\"single\":[1.0,2.0,3.0]}}"
+        },
+        {
+            WeaviateObject.builder()
+                .multiVectors(Collections.singletonMap("multi", new Float[][] {
+                    { 1f, 2f, 3f },
+                    { 4f, 5f, 6f },
+                }))
+                .build(),
+            "{\"vectors\":{\"multi\":[[1.0,2.0,3.0],[4.0, 5.0, 6.0]]}}"
+        },
+        {
+            WeaviateObject.builder()
+                .vectors(Collections.singletonMap("single", new Float[] { 1f, 2f, 3f }))
+                .multiVectors(Collections.singletonMap("multi", new Float[][] {
+                    { 1f, 2f, 3f },
+                    { 4f, 5f, 6f },
+                }))
+                .build(),
+            "{\"vectors\":{\"single\":[1.0,2.0,3.0],\"multi\":[[1.0,2.0,3.0],[4.0, 5.0, 6.0]]}}"
+        },
+    };
+  }
+
+  @Test
+  @DataMethod(source = WeaviateObjectAdapterTest.class, method = "testCaseSerialize")
+  public void test_toJson(WeaviateObject in, String want) {
+    String got = gson.toJson(in);
+    assertSameJson(got, want);
+  }
+
+  private void assertSameJson(String got, String want) {
+    JsonElement gotEl = JsonParser.parseString(got);
+    JsonElement wantEl = JsonParser.parseString(want);
+    Assertions.assertThat(gotEl).isEqualTo(wantEl);
+
+  }
+}


### PR DESCRIPTION
Unit tests to make sure vectors in WeaviateObject are serialized correctly regardless of how they are combined.
Most importantly we want to make sure single- and multi-vectors can be combined under "vectors".

[This change](https://github.com/weaviate/java-client/compare/test/multi-vector-adapter?expand=1#diff-52cf02ed18bc0070aae3baf4484df74621d7bdc4052fbc585a8a0cfc558d52d3R83-R85) is a _cosmetic change_ to make sure the output JSON does not contain empty `"vector": {}` kv-pair.

