### PR TITLE
Adding named vectors to collections

### DIFF
--- a/src/main/java/io/weaviate/client/v1/async/schema/Schema.java
+++ b/src/main/java/io/weaviate/client/v1/async/schema/Schema.java
@@ -1,5 +1,7 @@
 package io.weaviate.client.v1.async.schema;
 
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+
 import io.weaviate.client.Config;
 import io.weaviate.client.base.util.DbVersionSupport;
 import io.weaviate.client.v1.async.schema.api.ClassCreator;
@@ -7,20 +9,19 @@ import io.weaviate.client.v1.async.schema.api.ClassDeleter;
 import io.weaviate.client.v1.async.schema.api.ClassExists;
 import io.weaviate.client.v1.async.schema.api.ClassGetter;
 import io.weaviate.client.v1.async.schema.api.ClassUpdater;
-import io.weaviate.client.v1.async.schema.api.SchemaGetter;
 import io.weaviate.client.v1.async.schema.api.PropertyCreator;
 import io.weaviate.client.v1.async.schema.api.SchemaDeleter;
-import io.weaviate.client.v1.async.schema.api.ShardsGetter;
+import io.weaviate.client.v1.async.schema.api.SchemaGetter;
 import io.weaviate.client.v1.async.schema.api.ShardUpdater;
+import io.weaviate.client.v1.async.schema.api.ShardsGetter;
 import io.weaviate.client.v1.async.schema.api.ShardsUpdater;
 import io.weaviate.client.v1.async.schema.api.TenantsCreator;
-import io.weaviate.client.v1.async.schema.api.TenantsGetter;
-import io.weaviate.client.v1.async.schema.api.TenantsUpdater;
 import io.weaviate.client.v1.async.schema.api.TenantsDeleter;
 import io.weaviate.client.v1.async.schema.api.TenantsExists;
-
+import io.weaviate.client.v1.async.schema.api.TenantsGetter;
+import io.weaviate.client.v1.async.schema.api.TenantsUpdater;
+import io.weaviate.client.v1.async.schema.api.VectorAdder;
 import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
-import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 
 public class Schema {
   private final CloseableHttpAsyncClient client;
@@ -28,7 +29,8 @@ public class Schema {
   private final AccessTokenProvider tokenProvider;
   private final DbVersionSupport dbVersionSupport;
 
-  public Schema(CloseableHttpAsyncClient client, Config config, AccessTokenProvider tokenProvider, DbVersionSupport dbVersionSupport) {
+  public Schema(CloseableHttpAsyncClient client, Config config, AccessTokenProvider tokenProvider,
+      DbVersionSupport dbVersionSupport) {
     this.client = client;
     this.config = config;
     this.tokenProvider = tokenProvider;
@@ -63,8 +65,13 @@ public class Schema {
     return new PropertyCreator(client, config, tokenProvider);
   }
 
+  public VectorAdder vectorAdder() {
+    return new VectorAdder(client, config, tokenProvider);
+  }
+
   public SchemaDeleter allDeleter() {
-    return new SchemaDeleter(new SchemaGetter(client, config, tokenProvider), new ClassDeleter(client, config, tokenProvider));
+    return new SchemaDeleter(new SchemaGetter(client, config, tokenProvider),
+        new ClassDeleter(client, config, tokenProvider));
   }
 
   public ShardsGetter shardsGetter() {

--- a/src/main/java/io/weaviate/client/v1/async/schema/api/VectorAdder.java
+++ b/src/main/java/io/weaviate/client/v1/async/schema/api/VectorAdder.java
@@ -1,5 +1,6 @@
 package io.weaviate.client.v1.async.schema.api;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -53,7 +54,7 @@ public class VectorAdder extends AsyncBaseClient<Boolean> implements AsyncClient
    * previously.
    */
   public VectorAdder withVector(Map<String, VectorConfig> vectors) {
-    this.addedVectors = Map.copyOf(vectors);
+    this.addedVectors = Collections.unmodifiableMap(vectors);
     return this;
   }
 

--- a/src/main/java/io/weaviate/client/v1/async/schema/api/VectorAdder.java
+++ b/src/main/java/io/weaviate/client/v1/async/schema/api/VectorAdder.java
@@ -35,7 +35,7 @@ public class VectorAdder extends AsyncBaseClient<Boolean> implements AsyncClient
     this.getter = new ClassGetter(client, config, tokenProvider);
   }
 
-  public VectorAdder withClass(String className) {
+  public VectorAdder withClassName(String className) {
     this.className = className;
     return this;
   }

--- a/src/main/java/io/weaviate/client/v1/async/schema/api/VectorAdder.java
+++ b/src/main/java/io/weaviate/client/v1/async/schema/api/VectorAdder.java
@@ -1,0 +1,95 @@
+package io.weaviate.client.v1.async.schema.api;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpResponse;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Response;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.async.ResponseParser;
+import io.weaviate.client.base.util.UrlEncoder;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import io.weaviate.client.v1.schema.model.WeaviateClass;
+import io.weaviate.client.v1.schema.model.WeaviateClass.VectorConfig;
+
+public class VectorAdder extends AsyncBaseClient<Boolean> implements AsyncClientResult<Boolean> {
+  private final ClassGetter getter;
+
+  private String className;
+  private Map<String, VectorConfig> addedVectors = new HashMap<>();
+
+  public VectorAdder(CloseableHttpAsyncClient client, Config config, AccessTokenProvider tokenProvider) {
+    super(client, config, tokenProvider);
+    this.getter = new ClassGetter(client, config, tokenProvider);
+  }
+
+  public VectorAdder withClass(String className) {
+    this.className = className;
+    return this;
+  }
+
+  /**
+   * Add a named vectors. This method can be chained to add multiple named vectors
+   * without using a {@link Map}.
+   */
+  public VectorAdder withVector(String name, VectorConfig vector) {
+    this.addedVectors.put(name, vector);
+    return this;
+  }
+
+  /**
+   * Add all vectors from the map. This will overwrite any vectors added
+   * previously.
+   */
+  public VectorAdder withVector(Map<String, VectorConfig> vectors) {
+    this.addedVectors = Map.copyOf(vectors);
+    return this;
+  }
+
+  @Override
+  public Future<Result<Boolean>> run(FutureCallback<Result<Boolean>> callback) {
+    CompletableFuture<Result<WeaviateClass>> getClass = CompletableFuture.supplyAsync(() -> {
+      try {
+        return getter.withClassName(className).run().get();
+      } catch (InterruptedException | ExecutionException e) {
+        throw new CompletionException(e);
+      }
+    });
+    CompletableFuture<Result<Boolean>> addVectors = getClass.<Result<Boolean>>thenApplyAsync(result -> {
+      if (result.getError() != null) {
+        return result.toErrorResult();
+      }
+      WeaviateClass cls = result.getResult();
+      addedVectors.entrySet().stream()
+          .forEach(vector -> cls.getVectorConfig()
+              .putIfAbsent(vector.getKey(), vector.getValue()));
+
+      String path = String.format("/schema/%s", UrlEncoder.encodePathParam(className));
+      try {
+        return sendPutRequest(path, cls, callback, new ResponseParser<Boolean>() {
+
+          @Override
+          public Result<Boolean> parse(HttpResponse response, String body, ContentType contentType) {
+            Response<WeaviateClass> resp = this.serializer.toResponse(response.getCode(), body, WeaviateClass.class);
+            return new Result<>(response.getCode(), response.getCode() <= 299, resp.getErrors());
+          }
+        }).get();
+      } catch (InterruptedException | ExecutionException e) {
+        throw new CompletionException(e);
+      }
+    });
+
+    return addVectors;
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/schema/api/VectorAdder.java
+++ b/src/main/java/io/weaviate/client/v1/async/schema/api/VectorAdder.java
@@ -44,7 +44,7 @@ public class VectorAdder extends AsyncBaseClient<Boolean> implements AsyncClient
    * Add a named vectors. This method can be chained to add multiple named vectors
    * without using a {@link Map}.
    */
-  public VectorAdder withVector(String name, VectorConfig vector) {
+  public VectorAdder withVectorConfig(String name, VectorConfig vector) {
     this.addedVectors.put(name, vector);
     return this;
   }
@@ -53,7 +53,7 @@ public class VectorAdder extends AsyncBaseClient<Boolean> implements AsyncClient
    * Add all vectors from the map. This will overwrite any vectors added
    * previously.
    */
-  public VectorAdder withVector(Map<String, VectorConfig> vectors) {
+  public VectorAdder withVectorConfig(Map<String, VectorConfig> vectors) {
     this.addedVectors = Collections.unmodifiableMap(vectors);
     return this;
   }

--- a/src/main/java/io/weaviate/client/v1/schema/Schema.java
+++ b/src/main/java/io/weaviate/client/v1/schema/Schema.java
@@ -19,6 +19,7 @@ import io.weaviate.client.v1.schema.api.TenantsDeleter;
 import io.weaviate.client.v1.schema.api.TenantsExists;
 import io.weaviate.client.v1.schema.api.TenantsGetter;
 import io.weaviate.client.v1.schema.api.TenantsUpdater;
+import io.weaviate.client.v1.schema.api.VectorAdder;
 
 public class Schema {
   private final Config config;
@@ -57,6 +58,10 @@ public class Schema {
 
   public PropertyCreator propertyCreator() {
     return new PropertyCreator(httpClient, config);
+  }
+
+  public VectorAdder vectorAdder() {
+    return new VectorAdder(httpClient, config);
   }
 
   public SchemaDeleter allDeleter() {

--- a/src/main/java/io/weaviate/client/v1/schema/api/VectorAdder.java
+++ b/src/main/java/io/weaviate/client/v1/schema/api/VectorAdder.java
@@ -1,0 +1,66 @@
+package io.weaviate.client.v1.schema.api;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Response;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.base.util.UrlEncoder;
+import io.weaviate.client.v1.schema.model.WeaviateClass;
+import io.weaviate.client.v1.schema.model.WeaviateClass.VectorConfig;
+
+public class VectorAdder extends BaseClient<WeaviateClass> implements ClientResult<Boolean> {
+  private final ClassGetter getter;
+
+  private String className;
+  private Map<String, VectorConfig> addedVectors = new HashMap<>();
+
+  public VectorAdder(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+    this.getter = new ClassGetter(httpClient, config);
+  }
+
+  public VectorAdder withClass(String className) {
+    this.className = className;
+    return this;
+  }
+
+  /**
+   * Add a named vectors. This method can be chained to add multiple named vectors
+   * without using a {@link Map}.
+   */
+  public VectorAdder withVector(String name, VectorConfig vector) {
+    this.addedVectors.put(name, vector);
+    return this;
+  }
+
+  /**
+   * Add all vectors from the map. This will overwrite any vectors added
+   * previously.
+   */
+  public VectorAdder withVector(Map<String, VectorConfig> vectors) {
+    this.addedVectors = Map.copyOf(vectors);
+    return this;
+  }
+
+  @Override
+  public Result<Boolean> run() {
+    Result<WeaviateClass> result = getter.withClassName(className).run();
+    if (result.hasErrors()) {
+      result.toErrorResult();
+    }
+
+    WeaviateClass cls = result.getResult();
+    addedVectors.entrySet().stream()
+        .forEach(vector -> cls.getVectorConfig()
+            .putIfAbsent(vector.getKey(), vector.getValue()));
+
+    String path = String.format("/schema/%s", UrlEncoder.encodePathParam(className));
+    Response<WeaviateClass> resp = sendPutRequest(path, cls, WeaviateClass.class);
+    return new Result<>(resp.getStatusCode(), resp.getStatusCode() == 200, resp.getErrors());
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/schema/api/VectorAdder.java
+++ b/src/main/java/io/weaviate/client/v1/schema/api/VectorAdder.java
@@ -1,5 +1,6 @@
 package io.weaviate.client.v1.schema.api;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -43,7 +44,7 @@ public class VectorAdder extends BaseClient<WeaviateClass> implements ClientResu
    * previously.
    */
   public VectorAdder withVector(Map<String, VectorConfig> vectors) {
-    this.addedVectors = Map.copyOf(vectors);
+    this.addedVectors = Collections.unmodifiableMap(vectors);
     return this;
   }
 

--- a/src/main/java/io/weaviate/client/v1/schema/api/VectorAdder.java
+++ b/src/main/java/io/weaviate/client/v1/schema/api/VectorAdder.java
@@ -25,7 +25,7 @@ public class VectorAdder extends BaseClient<WeaviateClass> implements ClientResu
     this.getter = new ClassGetter(httpClient, config);
   }
 
-  public VectorAdder withClass(String className) {
+  public VectorAdder withClassName(String className) {
     this.className = className;
     return this;
   }

--- a/src/main/java/io/weaviate/client/v1/schema/api/VectorAdder.java
+++ b/src/main/java/io/weaviate/client/v1/schema/api/VectorAdder.java
@@ -34,7 +34,7 @@ public class VectorAdder extends BaseClient<WeaviateClass> implements ClientResu
    * Add a named vectors. This method can be chained to add multiple named vectors
    * without using a {@link Map}.
    */
-  public VectorAdder withVector(String name, VectorConfig vector) {
+  public VectorAdder withVectorConfig(String name, VectorConfig vector) {
     this.addedVectors.put(name, vector);
     return this;
   }
@@ -43,7 +43,7 @@ public class VectorAdder extends BaseClient<WeaviateClass> implements ClientResu
    * Add all vectors from the map. This will overwrite any vectors added
    * previously.
    */
-  public VectorAdder withVector(Map<String, VectorConfig> vectors) {
+  public VectorAdder withVectorConfig(Map<String, VectorConfig> vectors) {
     this.addedVectors = Collections.unmodifiableMap(vectors);
     return this;
   }

--- a/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
@@ -8,7 +8,7 @@ public class WeaviateVersion {
   // to be set according to weaviate docker image
   public static final String EXPECTED_WEAVIATE_VERSION = "1.31.0";
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_GIT_HASH = "5ff7495";
+  public static final String EXPECTED_WEAVIATE_GIT_HASH = "79499d6";
 
   private WeaviateVersion() {
   }

--- a/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
@@ -3,12 +3,13 @@ package io.weaviate.integration.client;
 public class WeaviateVersion {
 
   // docker image version
-  public static final String WEAVIATE_IMAGE = "1.31.0-rc.0-5ff7495";
+  public static final String WEAVIATE_IMAGE = "1.31.0";
 
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_VERSION = "1.31.0-rc.0";
+  public static final String EXPECTED_WEAVIATE_VERSION = "1.31.0";
   // to be set according to weaviate docker image
   public static final String EXPECTED_WEAVIATE_GIT_HASH = "5ff7495";
 
-  private WeaviateVersion() {}
+  private WeaviateVersion() {
+  }
 }

--- a/src/test/java/io/weaviate/integration/client/async/schema/ClientSchemaTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/schema/ClientSchemaTest.java
@@ -300,8 +300,8 @@ public class ClientSchemaTest {
       };
       Result<Boolean> add = client.schema().vectorAdder()
           .withClass(className)
-          .withVector("vector-a", vector)
-          .withVector("vector-b", vector)
+          .withVectorConfig("vector-a", v
+
           .run(callback).get();
       assertNull("error adding new vectors", add.getError());
 

--- a/src/test/java/io/weaviate/integration/client/async/schema/ClientSchemaTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/schema/ClientSchemaTest.java
@@ -299,7 +299,7 @@ public class ClientSchemaTest {
         }
       };
       Result<Boolean> add = client.schema().vectorAdder()
-          .withClass(className)
+          .withClassName(className)
           .withVectorConfig("vector-a", vector)
           .withVectorConfig("vector-b", vector)
           .run(callback).get();

--- a/src/test/java/io/weaviate/integration/client/async/schema/ClientSchemaTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/schema/ClientSchemaTest.java
@@ -1,5 +1,29 @@
 package io.weaviate.integration.client.async.schema;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.MAP;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
 import io.weaviate.client.Config;
 import io.weaviate.client.WeaviateClient;
 import io.weaviate.client.base.Result;
@@ -17,29 +41,9 @@ import io.weaviate.client.v1.schema.model.ShardStatus;
 import io.weaviate.client.v1.schema.model.ShardStatuses;
 import io.weaviate.client.v1.schema.model.Tokenization;
 import io.weaviate.client.v1.schema.model.WeaviateClass;
+import io.weaviate.client.v1.schema.model.WeaviateClass.VectorConfig;
 import io.weaviate.integration.client.WeaviateDockerCompose;
 import io.weaviate.integration.tests.schema.SchemaTestSuite;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import org.apache.hc.core5.concurrent.FutureCallback;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.InstanceOfAssertFactories.MAP;
-import org.junit.After;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
 
 public class ClientSchemaTest {
   private WeaviateClient syncClient;
@@ -83,8 +87,7 @@ public class ClientSchemaTest {
       // given
       WeaviateClass clazz = SchemaTestSuite.testSchemaCreateBandClass.clazz;
       // when
-      Future<Result<Boolean>> createStatusFuture =
-          client.schema().classCreator().withClass(clazz).run();
+      Future<Result<Boolean>> createStatusFuture = client.schema().classCreator().withClass(clazz).run();
       Result<Boolean> createStatus = createStatusFuture.get();
       Future<Result<Schema>> schemaFuture = client.schema().getter().run();
       Result<Schema> schema = schemaFuture.get();
@@ -130,7 +133,8 @@ public class ClientSchemaTest {
         }
 
         @Override
-        public void cancelled() {}
+        public void cancelled() {
+        }
       }).get();
       client.schema().classCreator().withClass(chickenSoup)
           .run(new FutureCallback<Result<Boolean>>() {
@@ -190,7 +194,6 @@ public class ClientSchemaTest {
         }
       }).get();
 
-
       client.schema().getter().run(new FutureCallback<Result<Schema>>() {
         @Override
         public void completed(Result<Schema> schemaResult) {
@@ -219,10 +222,8 @@ public class ClientSchemaTest {
       WeaviateClass pizza = SchemaTestSuite.testSchemaDeleteAllSchema.pizza;
       WeaviateClass chickenSoup = SchemaTestSuite.testSchemaDeleteAllSchema.chickenSoup;
       // when
-      Result<Boolean> pizzaCreateStatus =
-          client.schema().classCreator().withClass(pizza).run().get();
-      Result<Boolean> chickenSoupCreateStatus =
-          client.schema().classCreator().withClass(chickenSoup).run().get();
+      Result<Boolean> pizzaCreateStatus = client.schema().classCreator().withClass(pizza).run().get();
+      Result<Boolean> chickenSoupCreateStatus = client.schema().classCreator().withClass(chickenSoup).run().get();
       Result<Schema> schemaAfterCreate = client.schema().getter().run().get();
       Result<Boolean> deleteAllStatus = client.schema().allDeleter().run().get();
       Result<Schema> schemaAfterDelete = client.schema().getter().run().get();
@@ -241,10 +242,8 @@ public class ClientSchemaTest {
       WeaviateClass chickenSoup = SchemaTestSuite.testSchemaCreateClassesAddProperties.chickenSoup;
       Property newProperty = SchemaTestSuite.testSchemaCreateClassesAddProperties.newProperty;
       // when
-      Result<Boolean> pizzaCreateStatus =
-          client.schema().classCreator().withClass(pizza).run().get();
-      Result<Boolean> chickenSoupCreateStatus =
-          client.schema().classCreator().withClass(chickenSoup).run().get();
+      Result<Boolean> pizzaCreateStatus = client.schema().classCreator().withClass(pizza).run().get();
+      Result<Boolean> chickenSoupCreateStatus = client.schema().classCreator().withClass(chickenSoup).run().get();
       Result<Boolean> pizzaPropertyCreateStatus = client.schema().propertyCreator()
           .withProperty(newProperty).withClassName(pizza.getClassName()).run().get();
       Result<Boolean> chickenSoupPropertyCreateStatus = client.schema().propertyCreator()
@@ -257,6 +256,62 @@ public class ClientSchemaTest {
       SchemaTestSuite.testSchemaCreateClassesAddProperties.assertResults(pizzaCreateStatus,
           chickenSoupCreateStatus, pizzaPropertyCreateStatus, chickenSoupPropertyCreateStatus,
           schemaAfterCreate, deleteAllStatus, schemaAfterDelete);
+    }
+  }
+
+  @Test
+  public void testSchemaAddVectors() throws ExecutionException, InterruptedException {
+    // Arrange
+    VectorConfig vector = VectorConfig.builder()
+        .vectorIndexType("hnsw")
+        .vectorizer(Collections.singletonMap("none", Collections.emptyMap()))
+        .vectorIndexConfig(VectorIndexConfig.builder().build())
+        .build();
+    String className = "Pizza_testSchemaAddVectors";
+    try (WeaviateAsyncClient client = syncClient.async()) {
+      client.schema().classCreator()
+          .withClass(WeaviateClass.builder()
+              .className(className)
+              .properties(Collections.singletonList(
+                  Property.builder()
+                      .name("title").dataType(Collections.singletonList(DataType.TEXT))
+                      .build()))
+              .vectorConfig(Collections.singletonMap("default", vector))
+              .build())
+          .run().get();
+
+      // Act
+      AtomicBoolean completed = new AtomicBoolean(false);
+      FutureCallback<Result<Boolean>> callback = new FutureCallback<Result<Boolean>>() {
+
+        @Override
+        public void completed(Result<Boolean> result) {
+          completed.set(true);
+        }
+
+        @Override
+        public void failed(Exception ex) {
+          completed.set(true);
+        }
+
+        @Override
+        public void cancelled() {
+        }
+      };
+      Result<Boolean> add = client.schema().vectorAdder()
+          .withClass(className)
+          .withVector("vector-a", vector)
+          .withVector("vector-b", vector)
+          .run(callback).get();
+      assertNull("error adding new vectors", add.getError());
+
+      Result<WeaviateClass> result = client.schema().classGetter()
+          .withClassName(className).run().get();
+      WeaviateClass pizza = result.getResult();
+      assertThat(pizza.getVectorConfig())
+          .as("has all 3 vectors")
+          .containsKeys("default", "vector-a", "vector-b");
+      assertTrue("callback called on completion", completed.get());
     }
   }
 
@@ -440,19 +495,17 @@ public class ClientSchemaTest {
           .description("A delicious religion like food and arguably the best export of Italy.")
           .build();
 
-      Property notExistingTokenization =
-          Property.builder().dataType(Collections.singletonList(DataType.TEXT))
-              .description("someString").name("someString").tokenization("not-existing").build();
-      Property notSupportedTokenizationForInt =
-          Property.builder().dataType(Collections.singletonList(DataType.INT))
-              .description("someInt").name("someInt").tokenization(Tokenization.WORD).build();
+      Property notExistingTokenization = Property.builder().dataType(Collections.singletonList(DataType.TEXT))
+          .description("someString").name("someString").tokenization("not-existing").build();
+      Property notSupportedTokenizationForInt = Property.builder().dataType(Collections.singletonList(DataType.INT))
+          .description("someInt").name("someInt").tokenization(Tokenization.WORD).build();
       // when
       Result<Boolean> createStatus = client.schema().classCreator().withClass(pizza).run().get();
       Result<Boolean> notExistingTokenizationCreateStatus = client.schema().propertyCreator()
           .withProperty(notExistingTokenization).withClassName(pizza.getClassName()).run().get();
-      Result<Boolean> notSupportedTokenizationForIntCreateStatus =
-          client.schema().propertyCreator().withProperty(notSupportedTokenizationForInt)
-              .withClassName(pizza.getClassName()).run().get();
+      Result<Boolean> notSupportedTokenizationForIntCreateStatus = client.schema().propertyCreator()
+          .withProperty(notSupportedTokenizationForInt)
+          .withClassName(pizza.getClassName()).run().get();
 
       // then
       assertResultTrue(createStatus);
@@ -474,10 +527,9 @@ public class ClientSchemaTest {
           .vectorizer("text2vec-contextionary").build();
       // when
       Result<Boolean> createStatus = client.schema().classCreator().withClass(clazz).run().get();
-      Result<WeaviateClass> bandClass =
-          client.schema().classGetter().withClassName(clazz.getClassName()).run().get();
-      Result<WeaviateClass> nonExistentClass =
-          client.schema().classGetter().withClassName("nonExistentClass").run().get();
+      Result<WeaviateClass> bandClass = client.schema().classGetter().withClassName(clazz.getClassName()).run().get();
+      Result<WeaviateClass> nonExistentClass = client.schema().classGetter().withClassName("nonExistentClass").run()
+          .get();
       // then
       assertNotNull(createStatus);
       assertTrue(createStatus.getResult());
@@ -503,18 +555,15 @@ public class ClientSchemaTest {
           .vectorizer("text2vec-contextionary").build();
       // when
       Result<Boolean> createStatus = client.schema().classCreator().withClass(clazz).run().get();
-      Result<Boolean> bandClassExists =
-          client.schema().exists().withClassName(clazz.getClassName()).run().get();
-      Result<Boolean> nonExistentClassExists =
-          client.schema().exists().withClassName("nonExistentClass").run().get();
+      Result<Boolean> bandClassExists = client.schema().exists().withClassName(clazz.getClassName()).run().get();
+      Result<Boolean> nonExistentClassExists = client.schema().exists().withClassName("nonExistentClass").run().get();
       // then
       assertResultTrue(createStatus);
       assertResultTrue(bandClassExists);
       assertNotNull(nonExistentClassExists);
       assertFalse(nonExistentClassExists.getResult());
       assertNull(nonExistentClassExists.getError());
-      Result<Shard[]> shards =
-          client.schema().shardsGetter().withClassName(clazz.getClassName()).run().get();
+      Result<Shard[]> shards = client.schema().shardsGetter().withClassName(clazz.getClassName()).run().get();
       assertNotNull(shards);
       assertNotNull(shards.getResult());
       assertEquals(1, shards.getResult().length);
@@ -532,18 +581,15 @@ public class ClientSchemaTest {
           Property.builder().name("question").dataType(Arrays.asList(DataType.TEXT)).build(),
           Property.builder().name("answer").dataType(Arrays.asList(DataType.TEXT)).build());
 
-      WeaviateClass jeopardyClass =
-          WeaviateClass.builder().className(className).description("A Jeopardy! question")
-              .vectorizer("text2vec-contextionary").properties(properties).build();
+      WeaviateClass jeopardyClass = WeaviateClass.builder().className(className).description("A Jeopardy! question")
+          .vectorizer("text2vec-contextionary").properties(properties).build();
 
-      Result<Boolean> createResult =
-          client.schema().classCreator().withClass(jeopardyClass).run().get();
+      Result<Boolean> createResult = client.schema().classCreator().withClass(jeopardyClass).run().get();
 
       assertThat(createResult).isNotNull().withFailMessage(() -> createResult.getError().toString())
           .returns(false, Result::hasErrors).withFailMessage(null).returns(true, Result::getResult);
 
-      Result<WeaviateClass> createdClassResult =
-          client.schema().classGetter().withClassName(className).run().get();
+      Result<WeaviateClass> createdClassResult = client.schema().classGetter().withClassName(className).run().get();
 
       assertThat(createdClassResult).isNotNull()
           .withFailMessage(() -> createdClassResult.getError().toString())
@@ -561,14 +607,12 @@ public class ClientSchemaTest {
               .deletionStrategy(ReplicationConfig.DeletionStrategy.DELETE_ON_CONFLICT).build())
           .build();
 
-      Result<Boolean> updateResult =
-          client.schema().classUpdater().withClass(newJeopardyClass).run().get();
+      Result<Boolean> updateResult = client.schema().classUpdater().withClass(newJeopardyClass).run().get();
 
       assertThat(updateResult).isNotNull().withFailMessage(() -> updateResult.getError().toString())
           .returns(false, Result::hasErrors).withFailMessage(null).returns(true, Result::getResult);
 
-      Result<WeaviateClass> updatedClassResult =
-          client.schema().classGetter().withClassName(className).run().get();
+      Result<WeaviateClass> updatedClassResult = client.schema().classGetter().withClassName(className).run().get();
 
       assertThat(updatedClassResult).isNotNull()
           .withFailMessage(() -> updatedClassResult.getError().toString())

--- a/src/test/java/io/weaviate/integration/client/async/schema/ClientSchemaTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/schema/ClientSchemaTest.java
@@ -300,8 +300,8 @@ public class ClientSchemaTest {
       };
       Result<Boolean> add = client.schema().vectorAdder()
           .withClass(className)
-          .withVectorConfig("vector-a", v
-
+          .withVectorConfig("vector-a", vector)
+          .withVectorConfig("vector-b", vector)
           .run(callback).get();
       assertNull("error adding new vectors", add.getError());
 

--- a/src/test/java/io/weaviate/integration/client/schema/ClientSchemaTest.java
+++ b/src/test/java/io/weaviate/integration/client/schema/ClientSchemaTest.java
@@ -177,8 +177,8 @@ public class ClientSchemaTest {
     // Act
     Result<Boolean> add = client.schema().vectorAdder()
         .withClass(className)
-        .withVector("vector-a", vector)
-        .withVector("vector-b", vector)
+        .withVectorConfig("vector-a", vector)
+        .withVectorConfig("vector-b", vector)
         .run();
     assertNull("error adding new vectors", add.getError());
 
@@ -187,7 +187,6 @@ public class ClientSchemaTest {
     assertThat(pizza.getVectorConfig())
         .as("has all 3 vectors")
         .containsKeys("default", "vector-a", "vector-b");
-
   }
 
   @Test

--- a/src/test/java/io/weaviate/integration/client/schema/ClientSchemaTest.java
+++ b/src/test/java/io/weaviate/integration/client/schema/ClientSchemaTest.java
@@ -176,7 +176,7 @@ public class ClientSchemaTest {
 
     // Act
     Result<Boolean> add = client.schema().vectorAdder()
-        .withClass(className)
+        .withClassName(className)
         .withVectorConfig("vector-a", vector)
         .withVectorConfig("vector-b", vector)
         .run();


### PR DESCRIPTION
This PR adds a `client.schema().vectorAdder()` method, which lets users add named vectors in collections. The only pre-condition is that the collection must already define a named vector (during its creation).

Supported by both sync and async clients.