### PR TITLE
feat: add searchOperator (minimum_should_match) to bm25 and hybrid arguments

### DIFF
--- a/src/main/java/io/weaviate/client/v1/graphql/query/argument/Bm25Argument.java
+++ b/src/main/java/io/weaviate/client/v1/graphql/query/argument/Bm25Argument.java
@@ -1,15 +1,16 @@
 package io.weaviate.client.v1.graphql.query.argument;
 
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 import io.weaviate.client.v1.graphql.query.util.Serializer;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.experimental.FieldDefaults;
-
-import java.util.LinkedHashSet;
-import java.util.Set;
 
 @Getter
 @Builder
@@ -19,6 +20,7 @@ import java.util.Set;
 public class Bm25Argument implements Argument {
   String query;
   String[] properties;
+  SearchOperator searchOperator;
 
   @Override
   public String build() {
@@ -28,7 +30,37 @@ public class Bm25Argument implements Argument {
     if (properties != null) {
       arg.add(String.format("properties:%s", Serializer.arrayWithQuotes(properties)));
     }
+    if (searchOperator != null) {
+      arg.add(String.format("searchOperator:%s", searchOperator.build()));
+    }
 
     return String.format("bm25:{%s}", String.join(" ", arg));
+  }
+
+  @AllArgsConstructor(access = AccessLevel.PRIVATE)
+  public static class SearchOperator implements Argument {
+    private static final String OR = "Or";
+    private static final String AND = "And";
+
+    private String operator;
+    private int minimumMatch;
+
+    public static SearchOperator and() {
+      return new SearchOperator(AND, 0); // minimumMatch ignored for And
+    }
+
+    public static SearchOperator or(int minimumMatch) {
+      return new SearchOperator(OR, minimumMatch);
+    }
+
+    @Override
+    public String build() {
+      String query = "{operator:" + operator;
+      if (operator != AND) {
+        query += " minimumOrTokensMatch:" + minimumMatch;
+      }
+      query += "}";
+      return query;
+    }
   }
 }

--- a/src/main/java/io/weaviate/client/v1/graphql/query/argument/HybridArgument.java
+++ b/src/main/java/io/weaviate/client/v1/graphql/query/argument/HybridArgument.java
@@ -29,6 +29,7 @@ public class HybridArgument implements Argument {
   String[] targetVectors;
   Searches searches;
   Targets targets;
+  Bm25Argument.SearchOperator bm25SearchOperator;
 
   @Override
   public String build() {
@@ -62,6 +63,9 @@ public class HybridArgument implements Argument {
         searchesArgs.add(searches.nearText.build());
       }
       arg.add(String.format("searches:{%s}", String.join(" ", searchesArgs)));
+    }
+    if (bm25SearchOperator != null) {
+      arg.add(String.format("bm25SearchOperator:%s", bm25SearchOperator.build()));
     }
     if (targets != null) {
       arg.add(String.format("%s", targets.build()));

--- a/src/test/java/io/weaviate/client/v1/graphql/query/argument/Bm25ArgumentTest.java
+++ b/src/test/java/io/weaviate/client/v1/graphql/query/argument/Bm25ArgumentTest.java
@@ -1,16 +1,16 @@
 package io.weaviate.client.v1.graphql.query.argument;
 
-import org.junit.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
 
 public class Bm25ArgumentTest {
 
   @Test
   public void shouldCreateArgument() {
     Bm25Argument bm25 = Bm25Argument.builder()
-      .query("I'm a simple string")
-      .build();
+        .query("I'm a simple string")
+        .build();
 
     String str = bm25.build();
 
@@ -20,26 +20,50 @@ public class Bm25ArgumentTest {
   @Test
   public void shouldCreateArgumentWithProperties() {
     Bm25Argument bm25 = Bm25Argument.builder()
-      .query("I'm a simple string")
-      .properties(new String[]{"prop1", "prop2"})
-      .build();
+        .query("I'm a simple string")
+        .properties(new String[] { "prop1", "prop2" })
+        .build();
 
     String str = bm25.build();
 
     assertThat(str).isEqualTo("bm25:{query:\"I'm a simple string\" " +
-      "properties:[\"prop1\",\"prop2\"]}");
+        "properties:[\"prop1\",\"prop2\"]}");
+  }
+
+  @Test
+  public void shouldCreateArgumentWithSearchOperator_And() {
+    Bm25Argument bm25 = Bm25Argument.builder()
+        .query("hello")
+        .searchOperator(Bm25Argument.SearchOperator.and())
+        .build();
+
+    String str = bm25.build();
+
+    assertThat(str).isEqualTo("bm25:{query:\"hello\" searchOperator:{operator:And}}");
+  }
+
+  @Test
+  public void shouldCreateArgumentWithSearchOperator_Or() {
+    Bm25Argument bm25 = Bm25Argument.builder()
+        .query("hello")
+        .searchOperator(Bm25Argument.SearchOperator.or(2))
+        .build();
+
+    String str = bm25.build();
+
+    assertThat(str).isEqualTo("bm25:{query:\"hello\" searchOperator:{operator:Or minimumOrTokensMatch:2}}");
   }
 
   @Test
   public void shouldCreateArgumentWithChars() {
     Bm25Argument bm25 = Bm25Argument.builder()
-      .query("\"I'm a complex string\" says the {'`:string:`'}")
-      .properties(new String[]{"prop:\"'`{0}`'\""})
-      .build();
+        .query("\"I'm a complex string\" says the {'`:string:`'}")
+        .properties(new String[] { "prop:\"'`{0}`'\"" })
+        .build();
 
     String str = bm25.build();
 
     assertThat(str).isEqualTo("bm25:{query:\"\\\"I'm a complex string\\\" says the {'`:string:`'}\" " +
-      "properties:[\"prop:\\\"'`{0}`'\\\"\"]}");
+        "properties:[\"prop:\\\"'`{0}`'\\\"\"]}");
   }
 }

--- a/src/test/java/io/weaviate/client/v1/graphql/query/argument/HybridArgumentTest.java
+++ b/src/test/java/io/weaviate/client/v1/graphql/query/argument/HybridArgumentTest.java
@@ -133,7 +133,23 @@ public class HybridArgumentTest {
                     .build())
                 .build(),
             "hybrid:{query:\"ColBERT me if you can!\" searches:{nearVector:{vector:[[1.0,2.0,3.0],[4.0,5.0,6.0]] targetVectors:[\"colbert\"]}}}",
-        }
+        },
+        {
+            "bm25 search operator And",
+            HybridArgument.builder()
+                .query("hello")
+                .bm25SearchOperator(Bm25Argument.SearchOperator.and())
+                .build(),
+            "hybrid:{query:\"hello\" bm25SearchOperator:{operator:And}}",
+        },
+        {
+            "bm25 search operator Or",
+            HybridArgument.builder()
+                .query("hello")
+                .bm25SearchOperator(Bm25Argument.SearchOperator.or(2))
+                .build(),
+            "hybrid:{query:\"hello\" bm25SearchOperator:{operator:Or minimumOrTokensMatch:2}}",
+        },
     };
   }
 


### PR DESCRIPTION
This PR adds `searchOperator` and `bm25SearchOperator` builder methods to `Bm25Argument` and `HybridArgument` builders respectively.

Tested via unit tests.