### PR TITLE
spike(v6): add factory methods to Vectorizer namespace

### DIFF
--- a/src/it/java/io/weaviate/integration/AggregationITest.java
+++ b/src/it/java/io/weaviate/integration/AggregationITest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import io.weaviate.ConcurrentTest;
 import io.weaviate.client6.v1.api.WeaviateClient;
 import io.weaviate.client6.v1.api.collections.Property;
+import io.weaviate.client6.v1.api.collections.Vectorizer;
 import io.weaviate.client6.v1.api.collections.Vectors;
 import io.weaviate.client6.v1.api.collections.aggregate.AggregateResponseGroup;
 import io.weaviate.client6.v1.api.collections.aggregate.AggregateResponseGrouped;
@@ -21,8 +22,6 @@ import io.weaviate.client6.v1.api.collections.aggregate.Aggregation;
 import io.weaviate.client6.v1.api.collections.aggregate.GroupBy;
 import io.weaviate.client6.v1.api.collections.aggregate.GroupedBy;
 import io.weaviate.client6.v1.api.collections.aggregate.IntegerAggregation;
-import io.weaviate.client6.v1.api.collections.vectorindex.Hnsw;
-import io.weaviate.client6.v1.api.collections.vectorizers.NoneVectorizer;
 import io.weaviate.containers.Container;
 
 public class AggregationITest extends ConcurrentTest {
@@ -36,7 +35,7 @@ public class AggregationITest extends ConcurrentTest {
             .properties(
                 Property.text("category"),
                 Property.integer("price"))
-            .vector(Hnsw.of(new NoneVectorizer())));
+            .vectors(Vectorizer.none()));
 
     var things = client.collections.use(COLLECTION);
     for (var category : List.of("Shoes", "Hat", "Jacket")) {

--- a/src/it/java/io/weaviate/integration/CollectionsITest.java
+++ b/src/it/java/io/weaviate/integration/CollectionsITest.java
@@ -10,6 +10,7 @@ import io.weaviate.ConcurrentTest;
 import io.weaviate.client6.v1.api.WeaviateClient;
 import io.weaviate.client6.v1.api.collections.Property;
 import io.weaviate.client6.v1.api.collections.VectorIndex;
+import io.weaviate.client6.v1.api.collections.Vectorizer;
 import io.weaviate.client6.v1.api.collections.WeaviateCollection;
 import io.weaviate.client6.v1.api.collections.vectorindex.Hnsw;
 import io.weaviate.client6.v1.api.collections.vectorizers.NoneVectorizer;
@@ -24,7 +25,7 @@ public class CollectionsITest extends ConcurrentTest {
     client.collections.create(collectionName,
         col -> col
             .properties(Property.text("username"), Property.integer("age"))
-            .vector(Hnsw.of(new NoneVectorizer())));
+            .vectors(Vectorizer.none()));
 
     var thingsCollection = client.collections.getConfig(collectionName);
 

--- a/src/it/java/io/weaviate/integration/DataITest.java
+++ b/src/it/java/io/weaviate/integration/DataITest.java
@@ -11,11 +11,10 @@ import org.junit.Test;
 import io.weaviate.ConcurrentTest;
 import io.weaviate.client6.v1.api.WeaviateClient;
 import io.weaviate.client6.v1.api.collections.Property;
+import io.weaviate.client6.v1.api.collections.Vectorizer;
 import io.weaviate.client6.v1.api.collections.Vectors;
 import io.weaviate.client6.v1.api.collections.WeaviateObject;
 import io.weaviate.client6.v1.api.collections.query.Metadata;
-import io.weaviate.client6.v1.api.collections.vectorindex.Hnsw;
-import io.weaviate.client6.v1.api.collections.vectorizers.NoneVectorizer;
 import io.weaviate.containers.Container;
 
 public class DataITest extends ConcurrentTest {
@@ -99,6 +98,6 @@ public class DataITest extends ConcurrentTest {
                 Property.integer("age"))
             .references(
                 Property.reference("hasAwards", awardsGrammy, awardsOscar))
-            .vectors(named -> named.vector(VECTOR_INDEX, Hnsw.of(new NoneVectorizer()))));
+            .vectors(Vectorizer.none(VECTOR_INDEX)));
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/VectorIndex.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/VectorIndex.java
@@ -82,7 +82,8 @@ public interface VectorIndex {
       }
 
       final var vectorizerAdapter = gson.getDelegateAdapter(this, TypeToken.get(Vectorizer.class));
-      final var writeAdapter = gson.getDelegateAdapter(this, TypeToken.get(rawType));
+      // final var writeAdapter = gson.getDelegateAdapter(this,
+      // TypeToken.get(rawType));
       return (TypeAdapter<T>) new TypeAdapter<VectorIndex>() {
 
         @Override
@@ -91,10 +92,13 @@ public interface VectorIndex {
           out.name("vectorIndexType");
           out.value(value._kind().jsonValue());
 
-          var config = writeAdapter.toJsonTree((T) value.config());
-          config.getAsJsonObject().remove("vectorizer");
-          out.name("vectorIndexConfig");
-          Streams.write(config, out);
+          var adapter = (TypeAdapter<T>) readAdapters.get(value._kind());
+          if (adapter != null) {
+            var config = adapter.toJsonTree((T) value.config());
+            config.getAsJsonObject().remove("vectorizer");
+            out.name("vectorIndexConfig");
+            Streams.write(config, out);
+          }
 
           out.name("vectorizer");
           vectorizerAdapter.write(out, value.vectorizer());

--- a/src/main/java/io/weaviate/client6/v1/api/collections/VectorIndex.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/VectorIndex.java
@@ -3,6 +3,7 @@ package io.weaviate.client6.v1.api.collections;
 import java.io.IOException;
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.function.Function;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonParser;
@@ -18,6 +19,7 @@ import io.weaviate.client6.v1.api.collections.vectorindex.Hnsw;
 import io.weaviate.client6.v1.internal.json.JsonEnum;
 
 public interface VectorIndex {
+  static final Function<Vectorizer, VectorIndex> DEFAULT_VECTOR_INDEX = Hnsw::of;
   static final String DEFAULT_VECTOR_NAME = "default";
 
   public enum Kind implements JsonEnum<Kind> {

--- a/src/main/java/io/weaviate/client6/v1/api/collections/Vectorizer.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/Vectorizer.java
@@ -3,6 +3,7 @@ package io.weaviate.client6.v1.api.collections;
 import java.io.IOException;
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.function.Function;
 
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
@@ -17,6 +18,7 @@ import io.weaviate.client6.v1.api.collections.vectorizers.Multi2VecClipVectorize
 import io.weaviate.client6.v1.api.collections.vectorizers.NoneVectorizer;
 import io.weaviate.client6.v1.api.collections.vectorizers.Text2VecContextionaryVectorizer;
 import io.weaviate.client6.v1.api.collections.vectorizers.Text2VecWeaviateVectorizer;
+import io.weaviate.client6.v1.internal.ObjectBuilder;
 import io.weaviate.client6.v1.internal.json.JsonEnum;
 
 public interface Vectorizer {
@@ -47,6 +49,84 @@ public interface Vectorizer {
   Kind _kind();
 
   Object _self();
+
+  public static Map.Entry<String, VectorIndex> none() {
+    return Map.entry(VectorIndex.DEFAULT_VECTOR_NAME,
+        VectorIndex.DEFAULT_VECTOR_INDEX.apply(new NoneVectorizer()));
+  }
+
+  public static Map.Entry<String, VectorIndex> none(String vectorName) {
+    return Map.entry(vectorName,
+        VectorIndex.DEFAULT_VECTOR_INDEX.apply(new NoneVectorizer()));
+  }
+
+  public static Map.Entry<String, VectorIndex> text2vecWeaviate() {
+    return Map.entry(VectorIndex.DEFAULT_VECTOR_NAME,
+        VectorIndex.DEFAULT_VECTOR_INDEX.apply(Text2VecWeaviateVectorizer.of()));
+  }
+
+  public static Map.Entry<String, VectorIndex> text2vecWeaviate(
+      Function<Text2VecWeaviateVectorizer.Builder, ObjectBuilder<Text2VecWeaviateVectorizer>> fn) {
+    return Map.entry(VectorIndex.DEFAULT_VECTOR_NAME,
+        VectorIndex.DEFAULT_VECTOR_INDEX.apply(Text2VecWeaviateVectorizer.of(fn)));
+  }
+
+  public static Map.Entry<String, VectorIndex> text2vecWeaviate(String vectorName,
+      Function<Text2VecWeaviateVectorizer.Builder, ObjectBuilder<Text2VecWeaviateVectorizer>> fn) {
+    return Map.entry(vectorName,
+        VectorIndex.DEFAULT_VECTOR_INDEX.apply(Text2VecWeaviateVectorizer.of(fn)));
+  }
+
+  public static Map.Entry<String, VectorIndex> text2VecContextionary() {
+    return Map.entry(VectorIndex.DEFAULT_VECTOR_NAME,
+        VectorIndex.DEFAULT_VECTOR_INDEX.apply(Text2VecContextionaryVectorizer.of()));
+  }
+
+  public static Map.Entry<String, VectorIndex> text2VecContextionary(
+      Function<Text2VecContextionaryVectorizer.Builder, ObjectBuilder<Text2VecContextionaryVectorizer>> fn) {
+    return Map.entry(VectorIndex.DEFAULT_VECTOR_NAME,
+        VectorIndex.DEFAULT_VECTOR_INDEX.apply(Text2VecContextionaryVectorizer.of(fn)));
+  }
+
+  public static Map.Entry<String, VectorIndex> text2VecContextionary(String vectorName,
+      Function<Text2VecContextionaryVectorizer.Builder, ObjectBuilder<Text2VecContextionaryVectorizer>> fn) {
+    return Map.entry(vectorName,
+        VectorIndex.DEFAULT_VECTOR_INDEX.apply(Text2VecContextionaryVectorizer.of(fn)));
+  }
+
+  public static Map.Entry<String, VectorIndex> multi2vecClip() {
+    return Map.entry(VectorIndex.DEFAULT_VECTOR_NAME,
+        VectorIndex.DEFAULT_VECTOR_INDEX.apply(Multi2VecClipVectorizer.of()));
+  }
+
+  public static Map.Entry<String, VectorIndex> multi2vecClip(
+      Function<Multi2VecClipVectorizer.Builder, ObjectBuilder<Multi2VecClipVectorizer>> fn) {
+    return Map.entry(VectorIndex.DEFAULT_VECTOR_NAME,
+        VectorIndex.DEFAULT_VECTOR_INDEX.apply(Multi2VecClipVectorizer.of(fn)));
+  }
+
+  public static Map.Entry<String, VectorIndex> multi2vecClip(String vectorName,
+      Function<Multi2VecClipVectorizer.Builder, ObjectBuilder<Multi2VecClipVectorizer>> fn) {
+    return Map.entry(vectorName,
+        VectorIndex.DEFAULT_VECTOR_INDEX.apply(Multi2VecClipVectorizer.of(fn)));
+  }
+
+  public static Map.Entry<String, VectorIndex> img2vecNeural() {
+    return Map.entry(VectorIndex.DEFAULT_VECTOR_NAME,
+        VectorIndex.DEFAULT_VECTOR_INDEX.apply(Img2VecNeuralVectorizer.of()));
+  }
+
+  public static Map.Entry<String, VectorIndex> img2vecNeural(
+      Function<Img2VecNeuralVectorizer.Builder, ObjectBuilder<Img2VecNeuralVectorizer>> fn) {
+    return Map.entry(VectorIndex.DEFAULT_VECTOR_NAME,
+        VectorIndex.DEFAULT_VECTOR_INDEX.apply(Img2VecNeuralVectorizer.of(fn)));
+  }
+
+  public static Map.Entry<String, VectorIndex> img2vecNeural(String vectorName,
+      Function<Img2VecNeuralVectorizer.Builder, ObjectBuilder<Img2VecNeuralVectorizer>> fn) {
+    return Map.entry(vectorName,
+        VectorIndex.DEFAULT_VECTOR_INDEX.apply(Img2VecNeuralVectorizer.of(fn)));
+  }
 
   public static enum CustomTypeAdapterFactory implements TypeAdapterFactory {
     INSTANCE;

--- a/src/main/java/io/weaviate/client6/v1/api/collections/Vectorizer.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/Vectorizer.java
@@ -3,6 +3,7 @@ package io.weaviate.client6.v1.api.collections;
 import java.io.IOException;
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import com.google.gson.Gson;
@@ -97,6 +98,13 @@ public interface Vectorizer {
       Function<Text2VecContextionaryVectorizer.Builder, ObjectBuilder<Text2VecContextionaryVectorizer>> fn) {
     return Map.entry(vectorName,
         VectorIndex.DEFAULT_VECTOR_INDEX.apply(Text2VecContextionaryVectorizer.of(fn)));
+  }
+
+  public static <B, I extends VectorIndex> Map.Entry<String, VectorIndex> text2VecContextionary(
+      BiFunction<Vectorizer, Function<B, ObjectBuilder<I>>, VectorIndex> ctor,
+      Function<Text2VecContextionaryVectorizer.Builder, ObjectBuilder<Text2VecContextionaryVectorizer>> fnVectorizer,
+      Function<B, ObjectBuilder<I>> fnIndex) {
+    return Map.entry("default", ctor.apply(null, null));
   }
 
   public static Map.Entry<String, VectorIndex> multi2vecClip() {

--- a/src/main/java/io/weaviate/client6/v1/api/collections/Vectorizer.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/Vectorizer.java
@@ -13,6 +13,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 
+import io.weaviate.client6.v1.api.collections.vectorindex.WrappedVectorIndex;
 import io.weaviate.client6.v1.api.collections.vectorizers.Img2VecNeuralVectorizer;
 import io.weaviate.client6.v1.api.collections.vectorizers.Multi2VecClipVectorizer;
 import io.weaviate.client6.v1.api.collections.vectorizers.NoneVectorizer;
@@ -51,13 +52,17 @@ public interface Vectorizer {
   Object _self();
 
   public static Map.Entry<String, VectorIndex> none() {
-    return Map.entry(VectorIndex.DEFAULT_VECTOR_NAME,
-        VectorIndex.DEFAULT_VECTOR_INDEX.apply(new NoneVectorizer()));
+    return buildVectorIndex(VectorIndex.DEFAULT_VECTOR_NAME, new NoneVectorizer.Builder(), ObjectBuilder.identity());
   }
 
-  public static Map.Entry<String, VectorIndex> none(String vectorName) {
-    return Map.entry(vectorName,
-        VectorIndex.DEFAULT_VECTOR_INDEX.apply(new NoneVectorizer()));
+  public static Map.Entry<String, VectorIndex> none(
+      Function<NoneVectorizer.Builder, ObjectBuilder<NoneVectorizer>> fn) {
+    return buildVectorIndex(VectorIndex.DEFAULT_VECTOR_NAME, new NoneVectorizer.Builder(), ObjectBuilder.identity());
+  }
+
+  public static Map.Entry<String, VectorIndex> none(String vectorName,
+      Function<NoneVectorizer.Builder, ObjectBuilder<NoneVectorizer>> fn) {
+    return buildVectorIndex(vectorName, new NoneVectorizer.Builder(), ObjectBuilder.identity());
   }
 
   public static Map.Entry<String, VectorIndex> text2vecWeaviate() {
@@ -95,37 +100,41 @@ public interface Vectorizer {
   }
 
   public static Map.Entry<String, VectorIndex> multi2vecClip() {
-    return Map.entry(VectorIndex.DEFAULT_VECTOR_NAME,
-        VectorIndex.DEFAULT_VECTOR_INDEX.apply(Multi2VecClipVectorizer.of()));
+    return buildVectorIndex(VectorIndex.DEFAULT_VECTOR_NAME, new Multi2VecClipVectorizer.Builder(),
+        ObjectBuilder.identity());
   }
 
   public static Map.Entry<String, VectorIndex> multi2vecClip(
       Function<Multi2VecClipVectorizer.Builder, ObjectBuilder<Multi2VecClipVectorizer>> fn) {
-    return Map.entry(VectorIndex.DEFAULT_VECTOR_NAME,
-        VectorIndex.DEFAULT_VECTOR_INDEX.apply(Multi2VecClipVectorizer.of(fn)));
+    return buildVectorIndex(VectorIndex.DEFAULT_VECTOR_NAME, new Multi2VecClipVectorizer.Builder(), fn);
   }
 
   public static Map.Entry<String, VectorIndex> multi2vecClip(String vectorName,
       Function<Multi2VecClipVectorizer.Builder, ObjectBuilder<Multi2VecClipVectorizer>> fn) {
-    return Map.entry(vectorName,
-        VectorIndex.DEFAULT_VECTOR_INDEX.apply(Multi2VecClipVectorizer.of(fn)));
+    return buildVectorIndex(vectorName, new Multi2VecClipVectorizer.Builder(), fn);
   }
 
   public static Map.Entry<String, VectorIndex> img2vecNeural() {
-    return Map.entry(VectorIndex.DEFAULT_VECTOR_NAME,
-        VectorIndex.DEFAULT_VECTOR_INDEX.apply(Img2VecNeuralVectorizer.of()));
+    return buildVectorIndex(VectorIndex.DEFAULT_VECTOR_NAME, new Img2VecNeuralVectorizer.Builder(),
+        ObjectBuilder.identity());
   }
 
   public static Map.Entry<String, VectorIndex> img2vecNeural(
       Function<Img2VecNeuralVectorizer.Builder, ObjectBuilder<Img2VecNeuralVectorizer>> fn) {
-    return Map.entry(VectorIndex.DEFAULT_VECTOR_NAME,
-        VectorIndex.DEFAULT_VECTOR_INDEX.apply(Img2VecNeuralVectorizer.of(fn)));
+    return buildVectorIndex(VectorIndex.DEFAULT_VECTOR_NAME, new Img2VecNeuralVectorizer.Builder(), fn);
   }
 
   public static Map.Entry<String, VectorIndex> img2vecNeural(String vectorName,
       Function<Img2VecNeuralVectorizer.Builder, ObjectBuilder<Img2VecNeuralVectorizer>> fn) {
-    return Map.entry(vectorName,
-        VectorIndex.DEFAULT_VECTOR_INDEX.apply(Img2VecNeuralVectorizer.of(fn)));
+    return buildVectorIndex(vectorName, new Img2VecNeuralVectorizer.Builder(), fn);
+  }
+
+  private static <B extends WrappedVectorIndex.Builder<B, V>, V extends Vectorizer> Map.Entry<String, VectorIndex> buildVectorIndex(
+      String key,
+      B builder, Function<B, ObjectBuilder<V>> fn) {
+    @SuppressWarnings("unchecked")
+    B b = (B) fn.apply(builder);
+    return Map.entry(key, b.buildVectorIndex());
   }
 
   public static enum CustomTypeAdapterFactory implements TypeAdapterFactory {

--- a/src/main/java/io/weaviate/client6/v1/api/collections/WeaviateCollection.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/WeaviateCollection.java
@@ -81,20 +81,29 @@ public record WeaviateCollection(
       return this;
     }
 
-    public Builder vector(VectorIndex vector) {
-      this.vectors.put(VectorIndex.DEFAULT_VECTOR_NAME, vector);
+    @SafeVarargs
+    public final Builder vectors(Map.Entry<String, VectorIndex>... vectors) {
+      for (final var vector : vectors) {
+        this.vectors.put(vector.getKey(), vector.getValue());
+      }
       return this;
     }
 
-    public Builder vector(String name, VectorIndex vector) {
-      this.vectors.put(name, vector);
-      return this;
-    }
-
-    public Builder vectors(Function<VectorsBuilder, ObjectBuilder<Map<String, VectorIndex>>> fn) {
-      this.vectors = fn.apply(new VectorsBuilder()).build();
-      return this;
-    }
+    // public Builder vector(VectorIndex vector) {
+    // this.vectors.put(VectorIndex.DEFAULT_VECTOR_NAME, vector);
+    // return this;
+    // }
+    //
+    // public Builder vector(String name, VectorIndex vector) {
+    // this.vectors.put(name, vector);
+    // return this;
+    // }
+    //
+    // public Builder vectors(Function<VectorsBuilder, ObjectBuilder<Map<String,
+    // VectorIndex>>> fn) {
+    // this.vectors = fn.apply(new VectorsBuilder()).build();
+    // return this;
+    // }
 
     public static class VectorsBuilder implements ObjectBuilder<Map<String, VectorIndex>> {
       private Map<String, VectorIndex> vectors = new HashMap<>();

--- a/src/main/java/io/weaviate/client6/v1/api/collections/vectorindex/WrappedVectorIndex.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/vectorindex/WrappedVectorIndex.java
@@ -1,0 +1,57 @@
+package io.weaviate.client6.v1.api.collections.vectorindex;
+
+import java.util.function.Function;
+
+import io.weaviate.client6.v1.api.collections.VectorIndex;
+import io.weaviate.client6.v1.api.collections.Vectorizer;
+import io.weaviate.client6.v1.internal.ObjectBuilder;
+
+public class WrappedVectorIndex extends BaseVectorIndex {
+  private final VectorIndex vectorIndex;
+
+  public WrappedVectorIndex(Vectorizer vectorizer, VectorIndex vectorIndex) {
+    super(vectorizer);
+    this.vectorIndex = vectorIndex != null
+        ? vectorIndex
+        : VectorIndex.DEFAULT_VECTOR_INDEX.apply(vectorizer);
+  }
+
+  public WrappedVectorIndex(Vectorizer vectorizer) {
+    this(vectorizer, null);
+  }
+
+  @Override
+  public Kind _kind() {
+    return this.vectorIndex._kind();
+  }
+
+  @Override
+  public Object config() {
+    return this.vectorIndex.config();
+  }
+
+  @Override
+  public Vectorizer vectorizer() {
+    return super.vectorizer;
+  }
+
+  public static abstract class Builder<SELF extends Builder<SELF, V>, V extends Vectorizer>
+      implements ObjectBuilder<V> {
+    private VectorIndex vectorIndex;
+
+    @SuppressWarnings("unchecked")
+    public SELF vectorIndex(VectorIndex vectorIndex) {
+      this.vectorIndex = vectorIndex;
+      return (SELF) this;
+    }
+
+    public VectorIndex buildVectorIndex() {
+      var vectorizer = build();
+      return new WrappedVectorIndex(vectorizer, vectorIndex);
+    }
+
+    public static <B extends Builder<B, V>, V extends Vectorizer> Function<B, Builder<B, V>> identity() {
+      return builder -> builder;
+    }
+  }
+}

--- a/src/main/java/io/weaviate/client6/v1/api/collections/vectorizers/Img2VecNeuralVectorizer.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/vectorizers/Img2VecNeuralVectorizer.java
@@ -8,6 +8,7 @@ import java.util.function.Function;
 import com.google.gson.annotations.SerializedName;
 
 import io.weaviate.client6.v1.api.collections.Vectorizer;
+import io.weaviate.client6.v1.api.collections.vectorindex.WrappedVectorIndex;
 import io.weaviate.client6.v1.internal.ObjectBuilder;
 
 public record Img2VecNeuralVectorizer(
@@ -35,7 +36,7 @@ public record Img2VecNeuralVectorizer(
     this(builder.imageFields);
   }
 
-  public static class Builder implements ObjectBuilder<Img2VecNeuralVectorizer> {
+  public static class Builder extends WrappedVectorIndex.Builder<Builder, Img2VecNeuralVectorizer> {
     private List<String> imageFields = new ArrayList<>();
 
     public Builder imageFields(List<String> fields) {

--- a/src/main/java/io/weaviate/client6/v1/api/collections/vectorizers/Multi2VecClipVectorizer.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/vectorizers/Multi2VecClipVectorizer.java
@@ -9,6 +9,7 @@ import java.util.function.Function;
 import com.google.gson.annotations.SerializedName;
 
 import io.weaviate.client6.v1.api.collections.Vectorizer;
+import io.weaviate.client6.v1.api.collections.vectorindex.WrappedVectorIndex;
 import io.weaviate.client6.v1.internal.ObjectBuilder;
 
 public record Multi2VecClipVectorizer(
@@ -52,7 +53,7 @@ public record Multi2VecClipVectorizer(
             builder.textFields.values().stream().toList()));
   }
 
-  public static class Builder implements ObjectBuilder<Multi2VecClipVectorizer> {
+  public static class Builder extends WrappedVectorIndex.Builder<Builder, Multi2VecClipVectorizer> {
     private boolean vectorizeCollectionName = false;
     private String inferenceUrl;
     private Map<String, Float> imageFields = new HashMap<>();

--- a/src/main/java/io/weaviate/client6/v1/api/collections/vectorizers/NoneVectorizer.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/vectorizers/NoneVectorizer.java
@@ -8,6 +8,7 @@ import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 
 import io.weaviate.client6.v1.api.collections.Vectorizer;
+import io.weaviate.client6.v1.api.collections.vectorindex.WrappedVectorIndex;
 
 public record NoneVectorizer() implements Vectorizer {
   @Override
@@ -18,6 +19,14 @@ public record NoneVectorizer() implements Vectorizer {
   @Override
   public Object _self() {
     return this;
+  }
+
+  public static class Builder extends WrappedVectorIndex.Builder<Builder, NoneVectorizer> {
+
+    @Override
+    public NoneVectorizer build() {
+      return new NoneVectorizer();
+    }
   }
 
   public static final TypeAdapter<NoneVectorizer> TYPE_ADAPTER = new TypeAdapter<NoneVectorizer>() {

--- a/src/test/java/io/weaviate/client6/v1/internal/json/JSONTest.java
+++ b/src/test/java/io/weaviate/client6/v1/internal/json/JSONTest.java
@@ -192,9 +192,8 @@ public class JSONTest {
                     Property.integer("size"))
                 .references(
                     Property.reference("owner", "Person", "Company"))
-                .vectors(named -> named
-                    .vector("v-shape", Hnsw.of(Img2VecNeuralVectorizer.of(
-                        i2v -> i2v.imageFields("img")))))),
+                .vectors(Vectorizer.img2vecNeural("v-shape",
+                    i2v -> i2v.imageFields("img")))),
             """
                 {
                   "class": "Things",
@@ -229,7 +228,7 @@ public class JSONTest {
             "{\"beacon\": \"weaviate://localhost/Doodlebops/id-1\"}",
         },
 
-        // WeaviateObject.CustomTypeAdapterFactory.INSTANCE
+        // WeaviateObject.CustomTypeAdapterFactory
         {
             new TypeToken<WeaviateObject<Map<String, Object>, Reference, ObjectMetadata>>() {
             },


### PR DESCRIPTION
Allows vectorizer-first syntax like:

```java
client.collections.create("VectorizedThings",
  c -> c.vectors(
    Vectorizer.none("supplied"),
    Vectorizer.text2vecWeaviate("custom", t2v -> t2v.dimensions(1))));
```

This PR is more of a POC I put together quickly, as underneath the library still has the "hierarchy" `VectorIndex --has-> Vectorizer` and not the other way around.

I haven't found a good way to add `.vectorIndex` to all vectorizer builders without rewriting that hierarchy.