### PR TITLE
v6: fix async toolchain

### DIFF
--- a/src/main/java/io/weaviate/client6/v1/api/collections/WeaviateCollectionsClientAsync.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/WeaviateCollectionsClientAsync.java
@@ -19,8 +19,8 @@ public class WeaviateCollectionsClientAsync {
     this.grpcTransport = grpcTransport;
   }
 
-  public CollectionHandle<Map<String, Object>> use(String collectionName) {
-    return new CollectionHandle<>(restTransport, grpcTransport,
+  public CollectionHandleAsync<Map<String, Object>> use(String collectionName) {
+    return new CollectionHandleAsync<>(restTransport, grpcTransport,
         CollectionDescriptor.ofMap(collectionName));
   }
 

--- a/src/main/java/io/weaviate/client6/v1/internal/rest/DefaultRestTransport.java
+++ b/src/main/java/io/weaviate/client6/v1/internal/rest/DefaultRestTransport.java
@@ -83,7 +83,7 @@ public class DefaultRestTransport implements RestTransport {
 
     });
     // FIXME: we need to differentiate between "no body" and "soumething's wrong"
-    return completable.thenApply(r -> r.getBody() == null
+    return completable.thenApply(r -> r.getBody() != null
         ? endpoint.deserializeResponse(gson, r.getBody().getBodyText())
         : null);
   }


### PR DESCRIPTION
WeaviateCollectionsClientAsync should construct CollectionHandleAsync.
Also fixed a typo in DefaultRestTransport which was preventing deserialization of a perfectly valid return value.