### PR TITLE
v6: Add, replace, and delete object references

### DIFF
--- a/src/main/java/io/weaviate/client6/v1/api/collections/data/Reference.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/data/Reference.java
@@ -27,7 +27,12 @@ public record Reference(String collection, List<String> uuids) {
     return new Reference(null, Arrays.asList(uuids));
   }
 
-  /** Create references to {@link WeaviateObject}. */
+  /** Create references to single {@link WeaviateObject}. */
+  public static Reference object(WeaviateObject<?, ?, ?> object) {
+    return new Reference(object.collection(), object.metadata().uuid());
+  }
+
+  /** Create references to multiple {@link WeaviateObject}. */
   public static Reference[] objects(WeaviateObject<?, ?, ?>... objects) {
     return Arrays.stream(objects)
         .map(o -> new Reference(o.collection(), o.metadata().uuid()))

--- a/src/main/java/io/weaviate/client6/v1/api/collections/data/ReferenceAddRequest.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/data/ReferenceAddRequest.java
@@ -1,0 +1,23 @@
+package io.weaviate.client6.v1.api.collections.data;
+
+import java.util.Collections;
+
+import org.apache.hc.core5.http.HttpStatus;
+
+import io.weaviate.client6.v1.internal.json.JSON;
+import io.weaviate.client6.v1.internal.orm.CollectionDescriptor;
+import io.weaviate.client6.v1.internal.rest.Endpoint;
+
+public record ReferenceAddRequest(String fromUuid, String fromProperty, Reference reference) {
+
+  public static final Endpoint<ReferenceAddRequest, Void> endpoint(
+      CollectionDescriptor<?> descriptor) {
+    return Endpoint.of(
+        request -> "POST",
+        request -> "/objects/" + descriptor.name() + "/" + request.fromUuid + "/references/" + request.fromProperty,
+        (gson, request) -> JSON.serialize(request.reference),
+        request -> Collections.emptyMap(),
+        code -> code != HttpStatus.SC_SUCCESS,
+        (gson, response) -> null);
+  }
+}

--- a/src/main/java/io/weaviate/client6/v1/api/collections/data/ReferenceDeleteRequest.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/data/ReferenceDeleteRequest.java
@@ -1,0 +1,23 @@
+package io.weaviate.client6.v1.api.collections.data;
+
+import java.util.Collections;
+
+import org.apache.hc.core5.http.HttpStatus;
+
+import io.weaviate.client6.v1.internal.json.JSON;
+import io.weaviate.client6.v1.internal.orm.CollectionDescriptor;
+import io.weaviate.client6.v1.internal.rest.Endpoint;
+
+public record ReferenceDeleteRequest(String fromUuid, String fromProperty, Reference reference) {
+
+  public static final Endpoint<ReferenceDeleteRequest, Void> endpoint(
+      CollectionDescriptor<?> descriptor) {
+    return Endpoint.of(
+        request -> "DELETE",
+        request -> "/objects/" + descriptor.name() + "/" + request.fromUuid + "/references/" + request.fromProperty,
+        (gson, request) -> JSON.serialize(request.reference),
+        request -> Collections.emptyMap(),
+        code -> code != HttpStatus.SC_SUCCESS,
+        (gson, response) -> null);
+  }
+}

--- a/src/main/java/io/weaviate/client6/v1/api/collections/data/ReferenceReplaceRequest.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/data/ReferenceReplaceRequest.java
@@ -1,0 +1,24 @@
+package io.weaviate.client6.v1.api.collections.data;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.hc.core5.http.HttpStatus;
+
+import io.weaviate.client6.v1.internal.json.JSON;
+import io.weaviate.client6.v1.internal.orm.CollectionDescriptor;
+import io.weaviate.client6.v1.internal.rest.Endpoint;
+
+public record ReferenceReplaceRequest(String fromUuid, String fromProperty, Reference reference) {
+
+  public static final Endpoint<ReferenceReplaceRequest, Void> endpoint(
+      CollectionDescriptor<?> descriptor) {
+    return Endpoint.of(
+        request -> "PUT",
+        request -> "/objects/" + descriptor.name() + "/" + request.fromUuid + "/references/" + request.fromProperty,
+        (gson, request) -> JSON.serialize(List.of(request.reference)),
+        request -> Collections.emptyMap(),
+        code -> code != HttpStatus.SC_SUCCESS,
+        (gson, response) -> null);
+  }
+}

--- a/src/main/java/io/weaviate/client6/v1/api/collections/data/WeaviateDataClient.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/data/WeaviateDataClient.java
@@ -36,4 +36,28 @@ public class WeaviateDataClient<T> {
     this.restTransport.performRequest(new DeleteObjectRequest(collectionDescriptor.name(), uuid),
         DeleteObjectRequest._ENDPOINT);
   }
+
+  public void referenceAdd(String fromUuid, String fromProperty, Reference reference) throws IOException {
+    for (var uuid : reference.uuids()) {
+      var singleRef = new Reference(reference.collection(), uuid);
+      this.restTransport.performRequest(new ReferenceAddRequest(fromUuid, fromProperty, singleRef),
+          ReferenceAddRequest.endpoint(collectionDescriptor));
+    }
+  }
+
+  public void referenceDelete(String fromUuid, String fromProperty, Reference reference) throws IOException {
+    for (var uuid : reference.uuids()) {
+      var singleRef = new Reference(reference.collection(), uuid);
+      this.restTransport.performRequest(new ReferenceDeleteRequest(fromUuid, fromProperty, singleRef),
+          ReferenceDeleteRequest.endpoint(collectionDescriptor));
+    }
+  }
+
+  public void referenceReplace(String fromUuid, String fromProperty, Reference reference) throws IOException {
+    for (var uuid : reference.uuids()) {
+      var singleRef = new Reference(reference.collection(), uuid);
+      this.restTransport.performRequest(new ReferenceReplaceRequest(fromUuid, fromProperty, singleRef),
+          ReferenceReplaceRequest.endpoint(collectionDescriptor));
+    }
+  }
 }


### PR DESCRIPTION
This PR adds 3 new methods to the `data` namespace:

```java
things.data.referenceAdd("from-uuid", "belongsTo", Reference.collection("Owners, "to-uuid"));

things.data.referenceReplace("from-uuid", "belongsTo", Reference.collection("Owners, "to-uuid"));

things.data.referenceDelete("from-uuid", "belongsTo", Reference.collection("Owners, "to-uuid"));
```

In the next PRs we will also add -Many counterparts to other data methods: insertMany, deleteMany, referencesAddMany.