### PR TITLE
v6: NearObject, Near<Media>, and Hybrid queries

### DIFF
--- a/src/it/java/io/weaviate/integration/SearchITest.java
+++ b/src/it/java/io/weaviate/integration/SearchITest.java
@@ -19,6 +19,7 @@ import io.weaviate.ConcurrentTest;
 import io.weaviate.client6.v1.api.WeaviateClient;
 import io.weaviate.client6.v1.api.collections.Property;
 import io.weaviate.client6.v1.api.collections.Vectors;
+import io.weaviate.client6.v1.api.collections.WeaviateMetadata;
 import io.weaviate.client6.v1.api.collections.WeaviateObject;
 import io.weaviate.client6.v1.api.collections.data.Reference;
 import io.weaviate.client6.v1.api.collections.query.GroupBy;
@@ -314,5 +315,34 @@ public class SearchITest extends ConcurrentTest {
           .extracting(WeaviateObject::metadata).extracting(QueryMetadata::uuid)
           .containsOnly(want.metadata().uuid());
     }
+  }
+
+  @Test
+  public void testNearObject() throws IOException {
+    // Arrange
+    var nsAnimals = ns("Animals");
+
+    client.collections.create(nsAnimals,
+        collection -> collection
+            .properties(Property.text("kind"))
+            .vector(Hnsw.of(Text2VecContextionaryVectorizer.of())));
+
+    var animals = client.collections.use(nsAnimals);
+
+    // Terrestrial animals
+    var cat = animals.data.insert(Map.of("kind", "cat"));
+    var lion = animals.data.insert(Map.of("kind", "lion"));
+    // Aquatic animal
+    animals.data.insert(Map.of("kind", "dolphin"));
+
+    // Act
+    var terrestrial = animals.query.nearObject(cat.metadata().uuid(),
+        q -> q.excludeSelf().limit(1));
+
+    // Assert
+    Assertions.assertThat(terrestrial.objects())
+        .hasSize(1)
+        .extracting(WeaviateObject::metadata).extracting(WeaviateMetadata::uuid)
+        .containsOnly(lion.metadata().uuid());
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/aggregate/AbstractAggregateClient.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/aggregate/AbstractAggregateClient.java
@@ -3,6 +3,7 @@ package io.weaviate.client6.v1.api.collections.aggregate;
 import java.util.List;
 import java.util.function.Function;
 
+import io.weaviate.client6.v1.api.collections.query.Hybrid;
 import io.weaviate.client6.v1.api.collections.query.NearAudio;
 import io.weaviate.client6.v1.api.collections.query.NearDepth;
 import io.weaviate.client6.v1.api.collections.query.NearImage;
@@ -37,6 +38,36 @@ abstract class AbstractAggregateClient<ResponseT, GroupedResponseT> {
 
   public GroupedResponseT overAll(Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn, GroupBy groupBy) {
     return performRequest(Aggregation.of(fn), groupBy);
+  }
+
+  // Hybrid -------------------------------------------------------------------
+
+  public ResponseT hybrid(String query, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn) {
+    return hybrid(Hybrid.of(query), fn);
+  }
+
+  public ResponseT hybrid(String query, Function<Hybrid.Builder, ObjectBuilder<Hybrid>> nv,
+      Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn) {
+    return hybrid(Hybrid.of(query, nv), fn);
+  }
+
+  public ResponseT hybrid(Hybrid filter, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn) {
+    return performRequest(Aggregation.of(filter, fn));
+  }
+
+  public GroupedResponseT hybrid(String query, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn,
+      GroupBy groupBy) {
+    return hybrid(Hybrid.of(query), fn, groupBy);
+  }
+
+  public GroupedResponseT hybrid(String query, Function<Hybrid.Builder, ObjectBuilder<Hybrid>> nv,
+      Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn, GroupBy groupBy) {
+    return hybrid(Hybrid.of(query, nv), fn, groupBy);
+  }
+
+  public GroupedResponseT hybrid(Hybrid filter, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn,
+      GroupBy groupBy) {
+    return performRequest(Aggregation.of(filter, fn), groupBy);
   }
 
   // NearVector ---------------------------------------------------------------

--- a/src/main/java/io/weaviate/client6/v1/api/collections/aggregate/AbstractAggregateClient.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/aggregate/AbstractAggregateClient.java
@@ -7,6 +7,7 @@ import io.weaviate.client6.v1.api.collections.query.NearAudio;
 import io.weaviate.client6.v1.api.collections.query.NearDepth;
 import io.weaviate.client6.v1.api.collections.query.NearImage;
 import io.weaviate.client6.v1.api.collections.query.NearImu;
+import io.weaviate.client6.v1.api.collections.query.NearObject;
 import io.weaviate.client6.v1.api.collections.query.NearText;
 import io.weaviate.client6.v1.api.collections.query.NearThermal;
 import io.weaviate.client6.v1.api.collections.query.NearVector;
@@ -64,6 +65,36 @@ abstract class AbstractAggregateClient<ResponseT, GroupedResponseT> {
   }
 
   public GroupedResponseT nearVector(NearVector filter, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn,
+      GroupBy groupBy) {
+    return performRequest(Aggregation.of(filter, fn), groupBy);
+  }
+
+  // NearObject ---------------------------------------------------------------
+
+  public ResponseT nearObject(String uuid, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn) {
+    return nearObject(NearObject.of(uuid), fn);
+  }
+
+  public ResponseT nearObject(String uuid, Function<NearObject.Builder, ObjectBuilder<NearObject>> nv,
+      Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn) {
+    return nearObject(NearObject.of(uuid, nv), fn);
+  }
+
+  public ResponseT nearObject(NearObject filter, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn) {
+    return performRequest(Aggregation.of(filter, fn));
+  }
+
+  public GroupedResponseT nearObject(String uuid, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn,
+      GroupBy groupBy) {
+    return nearObject(NearObject.of(uuid), fn, groupBy);
+  }
+
+  public GroupedResponseT nearObject(String uuid, Function<NearObject.Builder, ObjectBuilder<NearObject>> nv,
+      Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn, GroupBy groupBy) {
+    return nearObject(NearObject.of(uuid, nv), fn, groupBy);
+  }
+
+  public GroupedResponseT nearObject(NearObject filter, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn,
       GroupBy groupBy) {
     return performRequest(Aggregation.of(filter, fn), groupBy);
   }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/aggregate/AbstractAggregateClient.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/aggregate/AbstractAggregateClient.java
@@ -3,9 +3,14 @@ package io.weaviate.client6.v1.api.collections.aggregate;
 import java.util.List;
 import java.util.function.Function;
 
+import io.weaviate.client6.v1.api.collections.query.NearAudio;
+import io.weaviate.client6.v1.api.collections.query.NearDepth;
 import io.weaviate.client6.v1.api.collections.query.NearImage;
+import io.weaviate.client6.v1.api.collections.query.NearImu;
 import io.weaviate.client6.v1.api.collections.query.NearText;
+import io.weaviate.client6.v1.api.collections.query.NearThermal;
 import io.weaviate.client6.v1.api.collections.query.NearVector;
+import io.weaviate.client6.v1.api.collections.query.NearVideo;
 import io.weaviate.client6.v1.internal.ObjectBuilder;
 import io.weaviate.client6.v1.internal.grpc.GrpcTransport;
 import io.weaviate.client6.v1.internal.orm.CollectionDescriptor;
@@ -138,6 +143,156 @@ abstract class AbstractAggregateClient<ResponseT, GroupedResponseT> {
   }
 
   public GroupedResponseT nearImage(NearImage filter, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn,
+      GroupBy groupBy) {
+    return performRequest(Aggregation.of(filter, fn), groupBy);
+  }
+
+  // NearAudio ----------------------------------------------------------------
+
+  public ResponseT nearAudio(String audio, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn) {
+    return nearAudio(NearAudio.of(audio), fn);
+  }
+
+  public ResponseT nearAudio(String audio, Function<NearAudio.Builder, ObjectBuilder<NearAudio>> nv,
+      Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn) {
+    return nearAudio(NearAudio.of(audio, nv), fn);
+  }
+
+  public ResponseT nearAudio(NearAudio filter, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn) {
+    return performRequest(Aggregation.of(filter, fn));
+  }
+
+  public GroupedResponseT nearAudio(String audio, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn,
+      GroupBy groupBy) {
+    return nearAudio(NearAudio.of(audio), fn, groupBy);
+  }
+
+  public GroupedResponseT nearAudio(String audio, Function<NearAudio.Builder, ObjectBuilder<NearAudio>> nv,
+      Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn, GroupBy groupBy) {
+    return nearAudio(NearAudio.of(audio, nv), fn, groupBy);
+  }
+
+  public GroupedResponseT nearAudio(NearAudio filter, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn,
+      GroupBy groupBy) {
+    return performRequest(Aggregation.of(filter, fn), groupBy);
+  }
+
+  // NearVideo ----------------------------------------------------------------
+
+  public ResponseT nearVideo(String video, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn) {
+    return nearVideo(NearVideo.of(video), fn);
+  }
+
+  public ResponseT nearVideo(String video, Function<NearVideo.Builder, ObjectBuilder<NearVideo>> nv,
+      Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn) {
+    return nearVideo(NearVideo.of(video, nv), fn);
+  }
+
+  public ResponseT nearVideo(NearVideo filter, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn) {
+    return performRequest(Aggregation.of(filter, fn));
+  }
+
+  public GroupedResponseT nearVideo(String video, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn,
+      GroupBy groupBy) {
+    return nearVideo(NearVideo.of(video), fn, groupBy);
+  }
+
+  public GroupedResponseT nearVideo(String video, Function<NearVideo.Builder, ObjectBuilder<NearVideo>> nv,
+      Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn, GroupBy groupBy) {
+    return nearVideo(NearVideo.of(video, nv), fn, groupBy);
+  }
+
+  public GroupedResponseT nearVideo(NearVideo filter, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn,
+      GroupBy groupBy) {
+    return performRequest(Aggregation.of(filter, fn), groupBy);
+  }
+
+  // NearThermal --------------------------------------------------------------
+
+  public ResponseT nearThermal(String thermal, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn) {
+    return nearThermal(NearThermal.of(thermal), fn);
+  }
+
+  public ResponseT nearThermal(String thermal, Function<NearThermal.Builder, ObjectBuilder<NearThermal>> nv,
+      Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn) {
+    return nearThermal(NearThermal.of(thermal, nv), fn);
+  }
+
+  public ResponseT nearThermal(NearThermal filter, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn) {
+    return performRequest(Aggregation.of(filter, fn));
+  }
+
+  public GroupedResponseT nearThermal(String thermal, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn,
+      GroupBy groupBy) {
+    return nearThermal(NearThermal.of(thermal), fn, groupBy);
+  }
+
+  public GroupedResponseT nearThermal(String thermal, Function<NearThermal.Builder, ObjectBuilder<NearThermal>> nv,
+      Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn, GroupBy groupBy) {
+    return nearThermal(NearThermal.of(thermal, nv), fn, groupBy);
+  }
+
+  public GroupedResponseT nearThermal(NearThermal filter, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn,
+      GroupBy groupBy) {
+    return performRequest(Aggregation.of(filter, fn), groupBy);
+  }
+
+  // NearDepth --------------------------------------------------------------
+
+  public ResponseT nearDepth(String depth, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn) {
+    return nearDepth(NearDepth.of(depth), fn);
+  }
+
+  public ResponseT nearDepth(String depth, Function<NearDepth.Builder, ObjectBuilder<NearDepth>> nv,
+      Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn) {
+    return nearDepth(NearDepth.of(depth, nv), fn);
+  }
+
+  public ResponseT nearDepth(NearDepth filter, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn) {
+    return performRequest(Aggregation.of(filter, fn));
+  }
+
+  public GroupedResponseT nearDepth(String depth, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn,
+      GroupBy groupBy) {
+    return nearDepth(NearDepth.of(depth), fn, groupBy);
+  }
+
+  public GroupedResponseT nearDepth(String depth, Function<NearDepth.Builder, ObjectBuilder<NearDepth>> nv,
+      Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn, GroupBy groupBy) {
+    return nearDepth(NearDepth.of(depth, nv), fn, groupBy);
+  }
+
+  public GroupedResponseT nearDepth(NearDepth filter, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn,
+      GroupBy groupBy) {
+    return performRequest(Aggregation.of(filter, fn), groupBy);
+  }
+
+  // NearImu ------------------------------------------------------------------
+
+  public ResponseT nearImu(String imu, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn) {
+    return nearImu(NearImu.of(imu), fn);
+  }
+
+  public ResponseT nearImu(String imu, Function<NearImu.Builder, ObjectBuilder<NearImu>> nv,
+      Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn) {
+    return nearImu(NearImu.of(imu, nv), fn);
+  }
+
+  public ResponseT nearImu(NearImu filter, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn) {
+    return performRequest(Aggregation.of(filter, fn));
+  }
+
+  public GroupedResponseT nearImu(String imu, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn,
+      GroupBy groupBy) {
+    return nearImu(NearImu.of(imu), fn, groupBy);
+  }
+
+  public GroupedResponseT nearImu(String imu, Function<NearImu.Builder, ObjectBuilder<NearImu>> nv,
+      Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn, GroupBy groupBy) {
+    return nearImu(NearImu.of(imu, nv), fn, groupBy);
+  }
+
+  public GroupedResponseT nearImu(NearImu filter, Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn,
       GroupBy groupBy) {
     return performRequest(Aggregation.of(filter, fn), groupBy);
   }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/AbstractQueryClient.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/AbstractQueryClient.java
@@ -82,6 +82,32 @@ abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedRespo
     return performRequest(query, groupBy);
   }
 
+  // Hybrid queries -----------------------------------------------------------
+
+  public ResponseT hybrid(String query) {
+    return hybrid(Hybrid.of(query));
+  }
+
+  public ResponseT hybrid(String query, Function<Hybrid.Builder, ObjectBuilder<Hybrid>> fn) {
+    return hybrid(Hybrid.of(query, fn));
+  }
+
+  public ResponseT hybrid(Hybrid query) {
+    return performRequest(query);
+  }
+
+  public GroupedResponseT hybrid(String query, GroupBy groupBy) {
+    return hybrid(Hybrid.of(query), groupBy);
+  }
+
+  public GroupedResponseT hybrid(String query, Function<Hybrid.Builder, ObjectBuilder<Hybrid>> fn, GroupBy groupBy) {
+    return hybrid(Hybrid.of(query, fn), groupBy);
+  }
+
+  public GroupedResponseT hybrid(Hybrid query, GroupBy groupBy) {
+    return performRequest(query, groupBy);
+  }
+
   // NearVector queries -------------------------------------------------------
 
   public ResponseT nearVector(Float[] vector) {

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/AbstractQueryClient.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/AbstractQueryClient.java
@@ -175,4 +175,139 @@ abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedRespo
   public GroupedResponseT nearImage(NearImage query, GroupBy groupBy) {
     return performRequest(query, groupBy);
   }
+
+  // NearAudio queries --------------------------------------------------------
+
+  public ResponseT nearAudio(String audio) {
+    return nearAudio(NearAudio.of(audio));
+  }
+
+  public ResponseT nearAudio(String audio, Function<NearAudio.Builder, ObjectBuilder<NearAudio>> fn) {
+    return nearAudio(NearAudio.of(audio, fn));
+  }
+
+  public ResponseT nearAudio(NearAudio query) {
+    return performRequest(query);
+  }
+
+  public GroupedResponseT nearAudio(String audio, GroupBy groupBy) {
+    return nearAudio(NearAudio.of(audio), groupBy);
+  }
+
+  public GroupedResponseT nearAudio(String audio, Function<NearAudio.Builder, ObjectBuilder<NearAudio>> fn,
+      GroupBy groupBy) {
+    return nearAudio(NearAudio.of(audio, fn), groupBy);
+  }
+
+  public GroupedResponseT nearAudio(NearAudio query, GroupBy groupBy) {
+    return performRequest(query, groupBy);
+  }
+
+  // NearVideo queries --------------------------------------------------------
+
+  public ResponseT nearVideo(String video) {
+    return nearVideo(NearVideo.of(video));
+  }
+
+  public ResponseT nearVideo(String video, Function<NearVideo.Builder, ObjectBuilder<NearVideo>> fn) {
+    return nearVideo(NearVideo.of(video, fn));
+  }
+
+  public ResponseT nearVideo(NearVideo query) {
+    return performRequest(query);
+  }
+
+  public GroupedResponseT nearVideo(String video, GroupBy groupBy) {
+    return nearVideo(NearVideo.of(video), groupBy);
+  }
+
+  public GroupedResponseT nearVideo(String video, Function<NearVideo.Builder, ObjectBuilder<NearVideo>> fn,
+      GroupBy groupBy) {
+    return nearVideo(NearVideo.of(video, fn), groupBy);
+  }
+
+  public GroupedResponseT nearVideo(NearVideo query, GroupBy groupBy) {
+    return performRequest(query, groupBy);
+  }
+
+  // NearThermal queries ------------------------------------------------------
+
+  public ResponseT nearThermal(String thermal) {
+    return nearThermal(NearThermal.of(thermal));
+  }
+
+  public ResponseT nearThermal(String thermal, Function<NearThermal.Builder, ObjectBuilder<NearThermal>> fn) {
+    return nearThermal(NearThermal.of(thermal, fn));
+  }
+
+  public ResponseT nearThermal(NearThermal query) {
+    return performRequest(query);
+  }
+
+  public GroupedResponseT nearThermal(String thermal, GroupBy groupBy) {
+    return nearThermal(NearThermal.of(thermal), groupBy);
+  }
+
+  public GroupedResponseT nearThermal(String thermal, Function<NearThermal.Builder, ObjectBuilder<NearThermal>> fn,
+      GroupBy groupBy) {
+    return nearThermal(NearThermal.of(thermal, fn), groupBy);
+  }
+
+  public GroupedResponseT nearThermal(NearThermal query, GroupBy groupBy) {
+    return performRequest(query, groupBy);
+  }
+
+  // NearDepth queries --------------------------------------------------------
+
+  public ResponseT nearDepth(String depth) {
+    return nearDepth(NearDepth.of(depth));
+  }
+
+  public ResponseT nearDepth(String depth, Function<NearDepth.Builder, ObjectBuilder<NearDepth>> fn) {
+    return nearDepth(NearDepth.of(depth, fn));
+  }
+
+  public ResponseT nearDepth(NearDepth query) {
+    return performRequest(query);
+  }
+
+  public GroupedResponseT nearDepth(String depth, GroupBy groupBy) {
+    return nearDepth(NearDepth.of(depth), groupBy);
+  }
+
+  public GroupedResponseT nearDepth(String depth, Function<NearDepth.Builder, ObjectBuilder<NearDepth>> fn,
+      GroupBy groupBy) {
+    return nearDepth(NearDepth.of(depth, fn), groupBy);
+  }
+
+  public GroupedResponseT nearDepth(NearDepth query, GroupBy groupBy) {
+    return performRequest(query, groupBy);
+  }
+
+  // NearImu queries ----------------------------------------------------------
+
+  public ResponseT nearImu(String imu) {
+    return nearImu(NearImu.of(imu));
+  }
+
+  public ResponseT nearImu(String imu, Function<NearImu.Builder, ObjectBuilder<NearImu>> fn) {
+    return nearImu(NearImu.of(imu, fn));
+  }
+
+  public ResponseT nearImu(NearImu query) {
+    return performRequest(query);
+  }
+
+  public GroupedResponseT nearImu(String imu, GroupBy groupBy) {
+    return nearImu(NearImu.of(imu), groupBy);
+  }
+
+  public GroupedResponseT nearImu(String imu, Function<NearImu.Builder, ObjectBuilder<NearImu>> fn,
+      GroupBy groupBy) {
+    return nearImu(NearImu.of(imu, fn), groupBy);
+  }
+
+  public GroupedResponseT nearImu(NearImu query, GroupBy groupBy) {
+    return performRequest(query, groupBy);
+  }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/AbstractQueryClient.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/AbstractQueryClient.java
@@ -109,6 +109,33 @@ abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedRespo
     return performRequest(query, groupBy);
   }
 
+  // NearObject queries -------------------------------------------------------
+
+  public ResponseT nearObject(String uuid) {
+    return nearObject(NearObject.of(uuid));
+  }
+
+  public ResponseT nearObject(String uuid, Function<NearObject.Builder, ObjectBuilder<NearObject>> fn) {
+    return nearObject(NearObject.of(uuid, fn));
+  }
+
+  public ResponseT nearObject(NearObject query) {
+    return performRequest(query);
+  }
+
+  public GroupedResponseT nearObject(String uuid, GroupBy groupBy) {
+    return nearObject(NearObject.of(uuid), groupBy);
+  }
+
+  public GroupedResponseT nearObject(String uuid, Function<NearObject.Builder, ObjectBuilder<NearObject>> fn,
+      GroupBy groupBy) {
+    return nearObject(NearObject.of(uuid, fn), groupBy);
+  }
+
+  public GroupedResponseT nearObject(NearObject query, GroupBy groupBy) {
+    return performRequest(query, groupBy);
+  }
+
   // NearText queries ---------------------------------------------------------
 
   public ResponseT nearText(String... text) {

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/BaseQueryOptions.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/BaseQueryOptions.java
@@ -72,8 +72,15 @@ public record BaseQueryOptions(
       return (SELF) this;
     }
 
+    /**
+     * Filter result set using traditional filtering operators: {@code eq},
+     * {@code gte}, {@code like}, etc.
+     * Subsequent calls to {@link #where} aggregate with an AND operator.
+     *
+     * @see {@link Where}
+     */
     public final SELF where(Where where) {
-      this.where = where;
+      this.where = this.where == null ? where : Where.and(this.where, where);
       return (SELF) this;
     }
 

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/BaseQueryOptions.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/BaseQueryOptions.java
@@ -77,7 +77,8 @@ public record BaseQueryOptions(
      * {@code gte}, {@code like}, etc.
      * Subsequent calls to {@link #where} aggregate with an AND operator.
      *
-     * @see {@link Where}
+     * <p>
+     * See: {@link Where}
      */
     public final SELF where(Where where) {
       this.where = this.where == null ? where : Where.and(this.where, where);

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/BaseVectorSearchBuilder.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/BaseVectorSearchBuilder.java
@@ -1,0 +1,21 @@
+package io.weaviate.client6.v1.api.collections.query;
+
+abstract class BaseVectorSearchBuilder<SelfT extends BaseVectorSearchBuilder<SelfT, NearT>, NearT extends Object>
+    extends BaseQueryOptions.Builder<SelfT, NearT> {
+
+  // Optional query parameters.
+  Float distance;
+  Float certainty;
+
+  @SuppressWarnings("unchecked")
+  public SelfT distance(float distance) {
+    this.distance = distance;
+    return (SelfT) this;
+  }
+
+  @SuppressWarnings("unchecked")
+  public SelfT certainty(float certainty) {
+    this.certainty = certainty;
+    return (SelfT) this;
+  }
+}

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/Bm25.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/Bm25.java
@@ -8,8 +8,11 @@ import io.weaviate.client6.v1.internal.ObjectBuilder;
 import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoBaseSearch;
 import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoSearchGet;
 
-public record Bm25(String query, List<String> queryProperties, BaseQueryOptions common)
-    implements QueryOperator {
+public record Bm25(
+    String query,
+    List<String> queryProperties,
+    SearchOperator searchOperator,
+    BaseQueryOptions common) implements QueryOperator {
 
   public static final Bm25 of(String query) {
     return of(query, ObjectBuilder.identity());
@@ -20,7 +23,7 @@ public record Bm25(String query, List<String> queryProperties, BaseQueryOptions 
   }
 
   public Bm25(Builder builder) {
-    this(builder.query, builder.queryProperties, builder.baseOptions());
+    this(builder.query, builder.queryProperties, builder.searchOperator, builder.baseOptions());
   }
 
   public static class Builder extends BaseQueryOptions.Builder<Builder, Bm25> {
@@ -58,8 +61,13 @@ public record Bm25(String query, List<String> queryProperties, BaseQueryOptions 
   @Override
   public final void appendTo(WeaviateProtoSearchGet.SearchRequest.Builder req) {
     common.appendTo(req);
-    req.setBm25Search(WeaviateProtoBaseSearch.BM25.newBuilder()
+    var bm25 = WeaviateProtoBaseSearch.BM25.newBuilder()
         .setQuery(query)
-        .addAllProperties(queryProperties));
+        .addAllProperties(queryProperties);
+
+    if (searchOperator != null) {
+      searchOperator.appendTo(bm25);
+    }
+    req.setBm25Search(bm25);
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/ById.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/ById.java
@@ -15,7 +15,7 @@ public record ById(
     List<QueryReference> returnReferences,
     List<Metadata> returnMetadata) implements QueryOperator {
 
-  private static final String ID_PROPERTY = "_id";
+  static final String ID_PROPERTY = "_id";
 
   public static ById of(String uuid) {
     return of(uuid, ObjectBuilder.identity());
@@ -67,7 +67,7 @@ public record ById(
 
   @Override
   public void appendTo(WeaviateProtoSearchGet.SearchRequest.Builder req) {
-    var where = Where.property(ID_PROPERTY).eq(uuid);
+    var where = Where.uuid().eq(uuid);
     var filter = WeaviateProtoBase.Filters.newBuilder();
     where.appendTo(filter);
     req.setFilters(filter);

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/Hybrid.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/Hybrid.java
@@ -1,0 +1,174 @@
+package io.weaviate.client6.v1.api.collections.query;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+import io.weaviate.client6.v1.api.collections.aggregate.AggregateObjectFilter;
+import io.weaviate.client6.v1.internal.ObjectBuilder;
+import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoAggregate;
+import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoBaseSearch;
+import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoSearchGet;
+
+public record Hybrid(
+    String query,
+    List<String> queryProperties,
+    SearchOperator searchOperator,
+    Float alpha,
+    QueryOperator near,
+    FusionType fusionType,
+    Float maxVectorDistance,
+    /**
+     * alpha: NUMBER = 0.7,
+     * vector: Optional[HybridVectorType] = None,
+     * query_properties: Optional[List[str]] = None,
+     * fusion_type: Optional[HybridFusion] = None,
+     * max_vector_distance: Optional[NUMBER] = None,
+     * limit: Optional[int] = None,
+     * offset: Optional[int] = None,
+     * bm25_operator: Optional[BM25OperatorOptions] = None,
+     * auto_limit: Optional[int] = None,
+     * filters: Optional[_Filters] = None,
+     * group_by: Optional[GroupBy] = None,
+     * rerank: Optional[Rerank] = None,
+     * target_vector: Optional[TargetVectorJoinType] = None,
+     * include_vector: INCLUDE_VECTOR = False,
+     * return_metadata: Optional[METADATA] = None,
+     * return_properties: Optional[ReturnProperties[TProperties]] = None,
+     * return_references: Optional[ReturnReferences[TReferences]] = None,
+     */
+    BaseQueryOptions common)
+    implements QueryOperator, AggregateObjectFilter {
+
+  public static enum FusionType {
+    RELATIVE_SCORE, RANKED;
+  }
+
+  public static final Hybrid of(String query) {
+    return of(query, ObjectBuilder.identity());
+  }
+
+  public static final Hybrid of(String query, Function<Builder, ObjectBuilder<Hybrid>> fn) {
+    return fn.apply(new Builder(query)).build();
+  }
+
+  public Hybrid(Builder builder) {
+    this(
+        builder.query,
+        builder.queryProperties,
+        builder.searchOperator,
+        builder.alpha,
+        builder.near,
+        builder.fusionType,
+        builder.maxVectorDistance,
+        builder.baseOptions());
+  }
+
+  public static class Builder extends BaseQueryOptions.Builder<Builder, Hybrid> {
+    // Required query parameters.
+    private final String query;
+
+    // Optional query parameters.
+    List<String> queryProperties;
+    SearchOperator searchOperator;
+    Float alpha;
+    QueryOperator near;
+    FusionType fusionType;
+    Float maxVectorDistance;
+
+    public Builder(String query) {
+      this.query = query;
+    }
+
+    public Builder queryProperties(String... properties) {
+      return queryProperties(Arrays.asList(properties));
+    }
+
+    public Builder queryProperties(List<String> properties) {
+      this.queryProperties = properties;
+      return this;
+    }
+
+    public Builder searchOperator(SearchOperator searchOperator) {
+      this.searchOperator = searchOperator;
+      return this;
+    }
+
+    public Builder alpha(float alpha) {
+      this.alpha = alpha;
+      return this;
+    }
+
+    public Builder fusionType(FusionType fusionType) {
+      this.fusionType = fusionType;
+      return this;
+    }
+
+    public Builder maxVectorDistance(float maxVectorDistance) {
+      this.maxVectorDistance = maxVectorDistance;
+      return this;
+    }
+
+    public Builder nearVector(NearVector nearVector) {
+      this.near = nearVector;
+      return this;
+    }
+
+    public Builder nearText(NearText nearText) {
+      this.near = nearText;
+      return this;
+    }
+
+    @Override
+    public final Hybrid build() {
+      return new Hybrid(this);
+    }
+  }
+
+  @Override
+  public void appendTo(WeaviateProtoAggregate.AggregateRequest.Builder req) {
+    if (common.limit() != null) {
+      req.setLimit(common.limit());
+    }
+    req.setHybrid(protoBuilder());
+  }
+
+  @Override
+  public final void appendTo(WeaviateProtoSearchGet.SearchRequest.Builder req) {
+    common.appendTo(req);
+    req.setHybridSearch(protoBuilder());
+  }
+
+  private WeaviateProtoBaseSearch.Hybrid.Builder protoBuilder() {
+    var hybrid = WeaviateProtoBaseSearch.Hybrid.newBuilder()
+        .setQuery(query)
+        .addAllProperties(queryProperties);
+
+    if (alpha != null) {
+      hybrid.setAlpha(alpha);
+    }
+
+    if (fusionType != null) {
+      switch (fusionType) {
+        case RANKED:
+          hybrid.setFusionType(WeaviateProtoBaseSearch.Hybrid.FusionType.FUSION_TYPE_RANKED);
+        case RELATIVE_SCORE:
+          hybrid.setFusionType(WeaviateProtoBaseSearch.Hybrid.FusionType.FUSION_TYPE_RELATIVE_SCORE);
+      }
+    }
+
+    if (maxVectorDistance != null) {
+      hybrid.setVectorDistance(maxVectorDistance);
+    }
+
+    if (near != null) {
+      if (near instanceof NearVector nv) {
+        hybrid.setNearVector(nv.protoBuilder());
+      } else if (near instanceof NearText nt) {
+        hybrid.setNearText(nt.protoBuilder());
+      }
+    }
+
+    return hybrid;
+  }
+}

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/Hybrid.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/Hybrid.java
@@ -1,5 +1,6 @@
 package io.weaviate.client6.v1.api.collections.query;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
@@ -18,25 +19,6 @@ public record Hybrid(
     QueryOperator near,
     FusionType fusionType,
     Float maxVectorDistance,
-    /**
-     * alpha: NUMBER = 0.7,
-     * vector: Optional[HybridVectorType] = None,
-     * query_properties: Optional[List[str]] = None,
-     * fusion_type: Optional[HybridFusion] = None,
-     * max_vector_distance: Optional[NUMBER] = None,
-     * limit: Optional[int] = None,
-     * offset: Optional[int] = None,
-     * bm25_operator: Optional[BM25OperatorOptions] = None,
-     * auto_limit: Optional[int] = None,
-     * filters: Optional[_Filters] = None,
-     * group_by: Optional[GroupBy] = None,
-     * rerank: Optional[Rerank] = None,
-     * target_vector: Optional[TargetVectorJoinType] = None,
-     * include_vector: INCLUDE_VECTOR = False,
-     * return_metadata: Optional[METADATA] = None,
-     * return_properties: Optional[ReturnProperties[TProperties]] = None,
-     * return_references: Optional[ReturnReferences[TReferences]] = None,
-     */
     BaseQueryOptions common)
     implements QueryOperator, AggregateObjectFilter {
 
@@ -69,7 +51,7 @@ public record Hybrid(
     private final String query;
 
     // Optional query parameters.
-    List<String> queryProperties;
+    List<String> queryProperties = new ArrayList<>();
     SearchOperator searchOperator;
     Float alpha;
     QueryOperator near;

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/NearAudio.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/NearAudio.java
@@ -8,18 +8,18 @@ import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoAggregate;
 import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoBaseSearch;
 import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoSearchGet;
 
-public record NearImage(String image, Float distance, Float certainty, BaseQueryOptions common)
+public record NearAudio(String audio, Float distance, Float certainty, BaseQueryOptions common)
     implements QueryOperator, AggregateObjectFilter {
 
-  public static NearImage of(String image) {
-    return of(image, ObjectBuilder.identity());
+  public static NearAudio of(String audio) {
+    return of(audio, ObjectBuilder.identity());
   }
 
-  public static NearImage of(String image, Function<Builder, ObjectBuilder<NearImage>> fn) {
-    return fn.apply(new Builder(image)).build();
+  public static NearAudio of(String audio, Function<Builder, ObjectBuilder<NearAudio>> fn) {
+    return fn.apply(new Builder(audio)).build();
   }
 
-  public NearImage(Builder builder) {
+  public NearAudio(Builder builder) {
     this(
         builder.media,
         builder.distance,
@@ -27,21 +27,21 @@ public record NearImage(String image, Float distance, Float certainty, BaseQuery
         builder.baseOptions());
   }
 
-  public static class Builder extends NearMediaBuilder<Builder, NearImage> {
-    public Builder(String image) {
-      super(image);
+  public static class Builder extends NearMediaBuilder<Builder, NearAudio> {
+    public Builder(String audio) {
+      super(audio);
     }
 
     @Override
-    public final NearImage build() {
-      return new NearImage(this);
+    public final NearAudio build() {
+      return new NearAudio(this);
     }
   }
 
   @Override
   public void appendTo(WeaviateProtoSearchGet.SearchRequest.Builder req) {
     common.appendTo(req);
-    req.setNearImage(protoBuilder());
+    req.setNearAudio(protoBuilder());
   }
 
   @Override
@@ -49,18 +49,18 @@ public record NearImage(String image, Float distance, Float certainty, BaseQuery
     if (common.limit() != null) {
       req.setLimit(common.limit());
     }
-    req.setNearImage(protoBuilder());
+    req.setNearAudio(protoBuilder());
   }
 
-  private WeaviateProtoBaseSearch.NearImageSearch.Builder protoBuilder() {
-    var nearImage = WeaviateProtoBaseSearch.NearImageSearch.newBuilder();
-    nearImage.setImage(image);
+  private WeaviateProtoBaseSearch.NearAudioSearch.Builder protoBuilder() {
+    var nearAudio = WeaviateProtoBaseSearch.NearAudioSearch.newBuilder();
+    nearAudio.setAudio(audio);
 
     if (certainty != null) {
-      nearImage.setCertainty(certainty);
+      nearAudio.setCertainty(certainty);
     } else if (distance != null) {
-      nearImage.setDistance(distance);
+      nearAudio.setDistance(distance);
     }
-    return nearImage;
+    return nearAudio;
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/NearDepth.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/NearDepth.java
@@ -8,18 +8,18 @@ import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoAggregate;
 import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoBaseSearch;
 import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoSearchGet;
 
-public record NearImage(String image, Float distance, Float certainty, BaseQueryOptions common)
+public record NearDepth(String depth, Float distance, Float certainty, BaseQueryOptions common)
     implements QueryOperator, AggregateObjectFilter {
 
-  public static NearImage of(String image) {
-    return of(image, ObjectBuilder.identity());
+  public static NearDepth of(String depth) {
+    return of(depth, ObjectBuilder.identity());
   }
 
-  public static NearImage of(String image, Function<Builder, ObjectBuilder<NearImage>> fn) {
-    return fn.apply(new Builder(image)).build();
+  public static NearDepth of(String depth, Function<Builder, ObjectBuilder<NearDepth>> fn) {
+    return fn.apply(new Builder(depth)).build();
   }
 
-  public NearImage(Builder builder) {
+  public NearDepth(Builder builder) {
     this(
         builder.media,
         builder.distance,
@@ -27,21 +27,21 @@ public record NearImage(String image, Float distance, Float certainty, BaseQuery
         builder.baseOptions());
   }
 
-  public static class Builder extends NearMediaBuilder<Builder, NearImage> {
-    public Builder(String image) {
-      super(image);
+  public static class Builder extends NearMediaBuilder<Builder, NearDepth> {
+    public Builder(String depth) {
+      super(depth);
     }
 
     @Override
-    public final NearImage build() {
-      return new NearImage(this);
+    public final NearDepth build() {
+      return new NearDepth(this);
     }
   }
 
   @Override
   public void appendTo(WeaviateProtoSearchGet.SearchRequest.Builder req) {
     common.appendTo(req);
-    req.setNearImage(protoBuilder());
+    req.setNearDepth(protoBuilder());
   }
 
   @Override
@@ -49,18 +49,18 @@ public record NearImage(String image, Float distance, Float certainty, BaseQuery
     if (common.limit() != null) {
       req.setLimit(common.limit());
     }
-    req.setNearImage(protoBuilder());
+    req.setNearDepth(protoBuilder());
   }
 
-  private WeaviateProtoBaseSearch.NearImageSearch.Builder protoBuilder() {
-    var nearImage = WeaviateProtoBaseSearch.NearImageSearch.newBuilder();
-    nearImage.setImage(image);
+  private WeaviateProtoBaseSearch.NearDepthSearch.Builder protoBuilder() {
+    var nearDepth = WeaviateProtoBaseSearch.NearDepthSearch.newBuilder();
+    nearDepth.setDepth(depth);
 
     if (certainty != null) {
-      nearImage.setCertainty(certainty);
+      nearDepth.setCertainty(certainty);
     } else if (distance != null) {
-      nearImage.setDistance(distance);
+      nearDepth.setDistance(distance);
     }
-    return nearImage;
+    return nearDepth;
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/NearImu.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/NearImu.java
@@ -8,18 +8,18 @@ import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoAggregate;
 import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoBaseSearch;
 import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoSearchGet;
 
-public record NearImage(String image, Float distance, Float certainty, BaseQueryOptions common)
+public record NearImu(String imu, Float distance, Float certainty, BaseQueryOptions common)
     implements QueryOperator, AggregateObjectFilter {
 
-  public static NearImage of(String image) {
-    return of(image, ObjectBuilder.identity());
+  public static NearImu of(String imu) {
+    return of(imu, ObjectBuilder.identity());
   }
 
-  public static NearImage of(String image, Function<Builder, ObjectBuilder<NearImage>> fn) {
-    return fn.apply(new Builder(image)).build();
+  public static NearImu of(String imu, Function<Builder, ObjectBuilder<NearImu>> fn) {
+    return fn.apply(new Builder(imu)).build();
   }
 
-  public NearImage(Builder builder) {
+  public NearImu(Builder builder) {
     this(
         builder.media,
         builder.distance,
@@ -27,21 +27,21 @@ public record NearImage(String image, Float distance, Float certainty, BaseQuery
         builder.baseOptions());
   }
 
-  public static class Builder extends NearMediaBuilder<Builder, NearImage> {
-    public Builder(String image) {
-      super(image);
+  public static class Builder extends NearMediaBuilder<Builder, NearImu> {
+    public Builder(String imu) {
+      super(imu);
     }
 
     @Override
-    public final NearImage build() {
-      return new NearImage(this);
+    public final NearImu build() {
+      return new NearImu(this);
     }
   }
 
   @Override
   public void appendTo(WeaviateProtoSearchGet.SearchRequest.Builder req) {
     common.appendTo(req);
-    req.setNearImage(protoBuilder());
+    req.setNearImu(protoBuilder());
   }
 
   @Override
@@ -49,18 +49,18 @@ public record NearImage(String image, Float distance, Float certainty, BaseQuery
     if (common.limit() != null) {
       req.setLimit(common.limit());
     }
-    req.setNearImage(protoBuilder());
+    req.setNearImu(protoBuilder());
   }
 
-  private WeaviateProtoBaseSearch.NearImageSearch.Builder protoBuilder() {
-    var nearImage = WeaviateProtoBaseSearch.NearImageSearch.newBuilder();
-    nearImage.setImage(image);
+  private WeaviateProtoBaseSearch.NearIMUSearch.Builder protoBuilder() {
+    var nearImu = WeaviateProtoBaseSearch.NearIMUSearch.newBuilder();
+    nearImu.setImu(imu);
 
     if (certainty != null) {
-      nearImage.setCertainty(certainty);
+      nearImu.setCertainty(certainty);
     } else if (distance != null) {
-      nearImage.setDistance(distance);
+      nearImu.setDistance(distance);
     }
-    return nearImage;
+    return nearImu;
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/NearMediaBuilder.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/NearMediaBuilder.java
@@ -1,0 +1,27 @@
+package io.weaviate.client6.v1.api.collections.query;
+
+abstract class NearMediaBuilder<SelfT, MediaT>
+    extends BaseQueryOptions.Builder<NearMediaBuilder<SelfT, MediaT>, MediaT> {
+  // Required query parameters.
+  final String media;
+
+  // Optional query parameters.
+  Float distance;
+  Float certainty;
+
+  public NearMediaBuilder(String media) {
+    this.media = media;
+  }
+
+  @SuppressWarnings("unchecked")
+  public SelfT distance(float distance) {
+    this.distance = distance;
+    return (SelfT) this;
+  }
+
+  @SuppressWarnings("unchecked")
+  public SelfT certainty(float certainty) {
+    this.certainty = certainty;
+    return (SelfT) this;
+  }
+}

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/NearMediaBuilder.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/NearMediaBuilder.java
@@ -1,27 +1,11 @@
 package io.weaviate.client6.v1.api.collections.query;
 
-abstract class NearMediaBuilder<SelfT, MediaT>
-    extends BaseQueryOptions.Builder<NearMediaBuilder<SelfT, MediaT>, MediaT> {
+abstract class NearMediaBuilder<SelfT extends NearMediaBuilder<SelfT, MediaT>, MediaT extends Object>
+    extends BaseVectorSearchBuilder<SelfT, MediaT> {
   // Required query parameters.
   final String media;
 
-  // Optional query parameters.
-  Float distance;
-  Float certainty;
-
   public NearMediaBuilder(String media) {
     this.media = media;
-  }
-
-  @SuppressWarnings("unchecked")
-  public SelfT distance(float distance) {
-    this.distance = distance;
-    return (SelfT) this;
-  }
-
-  @SuppressWarnings("unchecked")
-  public SelfT certainty(float certainty) {
-    this.certainty = certainty;
-    return (SelfT) this;
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/NearObject.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/NearObject.java
@@ -31,6 +31,10 @@ public record NearObject(String uuid, Float distance, Float certainty, BaseQuery
       this.uuid = uuid;
     }
 
+    public Builder excludeSelf() {
+      return where(Where.uuid().ne(uuid));
+    }
+
     @Override
     public final NearObject build() {
       return new NearObject(this);

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/NearObject.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/NearObject.java
@@ -23,26 +23,12 @@ public record NearObject(String uuid, Float distance, Float certainty, BaseQuery
     this(builder.uuid, builder.distance, builder.certainty, builder.baseOptions());
   }
 
-  public static class Builder extends BaseQueryOptions.Builder<Builder, NearObject> {
+  public static class Builder extends BaseVectorSearchBuilder<Builder, NearObject> {
     // Required query parameters.
     private final String uuid;
 
-    // Optional query parameters.
-    private Float distance;
-    private Float certainty;
-
     public Builder(String uuid) {
       this.uuid = uuid;
-    }
-
-    public final Builder distance(float distance) {
-      this.distance = distance;
-      return this;
-    }
-
-    public final Builder certainty(float certainty) {
-      this.certainty = certainty;
-      return this;
     }
 
     @Override

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/NearObject.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/NearObject.java
@@ -1,0 +1,79 @@
+package io.weaviate.client6.v1.api.collections.query;
+
+import java.util.function.Function;
+
+import io.weaviate.client6.v1.api.collections.aggregate.AggregateObjectFilter;
+import io.weaviate.client6.v1.internal.ObjectBuilder;
+import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoAggregate;
+import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoBaseSearch;
+import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoSearchGet;
+
+public record NearObject(String uuid, Float distance, Float certainty, BaseQueryOptions common)
+    implements QueryOperator, AggregateObjectFilter {
+
+  public static final NearObject of(String uuid) {
+    return of(uuid, ObjectBuilder.identity());
+  }
+
+  public static final NearObject of(String uuid, Function<Builder, ObjectBuilder<NearObject>> fn) {
+    return fn.apply(new Builder(uuid)).build();
+  }
+
+  public NearObject(Builder builder) {
+    this(builder.uuid, builder.distance, builder.certainty, builder.baseOptions());
+  }
+
+  public static class Builder extends BaseQueryOptions.Builder<Builder, NearObject> {
+    // Required query parameters.
+    private final String uuid;
+
+    // Optional query parameters.
+    private Float distance;
+    private Float certainty;
+
+    public Builder(String uuid) {
+      this.uuid = uuid;
+    }
+
+    public final Builder distance(float distance) {
+      this.distance = distance;
+      return this;
+    }
+
+    public final Builder certainty(float certainty) {
+      this.certainty = certainty;
+      return this;
+    }
+
+    @Override
+    public final NearObject build() {
+      return new NearObject(this);
+    }
+  }
+
+  @Override
+  public final void appendTo(WeaviateProtoSearchGet.SearchRequest.Builder req) {
+    common.appendTo(req);
+    req.setNearObject(protoBuilder());
+  }
+
+  @Override
+  public void appendTo(WeaviateProtoAggregate.AggregateRequest.Builder req) {
+    if (common.limit() != null) {
+      req.setLimit(common.limit());
+    }
+    req.setNearObject(protoBuilder());
+  }
+
+  private WeaviateProtoBaseSearch.NearObject.Builder protoBuilder() {
+    var nearObject = WeaviateProtoBaseSearch.NearObject.newBuilder()
+        .setId(uuid);
+
+    if (certainty != null) {
+      nearObject.setCertainty(certainty);
+    } else if (distance != null) {
+      nearObject.setDistance(distance);
+    }
+    return nearObject;
+  }
+}

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/NearText.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/NearText.java
@@ -40,28 +40,16 @@ public record NearText(List<String> concepts, Float distance, Float certainty, M
         builder.baseOptions());
   }
 
-  public static class Builder extends BaseQueryOptions.Builder<Builder, NearText> {
+  public static class Builder extends BaseVectorSearchBuilder<Builder, NearText> {
     // Required query parameters.
     private final List<String> concepts;
 
     // Optional query parameter.
-    private Float distance;
-    private Float certainty;
     private Move moveTo;
     private Move moveAway;
 
     public Builder(List<String> concepts) {
       this.concepts = concepts;
-    }
-
-    public final Builder distance(float distance) {
-      this.distance = distance;
-      return this;
-    }
-
-    public final Builder certainty(float certainty) {
-      this.certainty = certainty;
-      return this;
     }
 
     public final Builder moveTo(float force, Function<Move.Builder, ObjectBuilder<Move>> fn) {

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/NearText.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/NearText.java
@@ -125,7 +125,8 @@ public record NearText(List<String> concepts, Float distance, Float certainty, M
     req.setNearText(protoBuilder());
   }
 
-  private WeaviateProtoBaseSearch.NearTextSearch.Builder protoBuilder() {
+  // Package-private for Hybrid to see.
+  WeaviateProtoBaseSearch.NearTextSearch.Builder protoBuilder() {
     var nearText = WeaviateProtoBaseSearch.NearTextSearch.newBuilder();
     nearText.addAllQuery(concepts);
 

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/NearThermal.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/NearThermal.java
@@ -8,18 +8,18 @@ import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoAggregate;
 import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoBaseSearch;
 import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoSearchGet;
 
-public record NearImage(String image, Float distance, Float certainty, BaseQueryOptions common)
+public record NearThermal(String thermal, Float distance, Float certainty, BaseQueryOptions common)
     implements QueryOperator, AggregateObjectFilter {
 
-  public static NearImage of(String image) {
-    return of(image, ObjectBuilder.identity());
+  public static NearThermal of(String thermal) {
+    return of(thermal, ObjectBuilder.identity());
   }
 
-  public static NearImage of(String image, Function<Builder, ObjectBuilder<NearImage>> fn) {
-    return fn.apply(new Builder(image)).build();
+  public static NearThermal of(String thermal, Function<Builder, ObjectBuilder<NearThermal>> fn) {
+    return fn.apply(new Builder(thermal)).build();
   }
 
-  public NearImage(Builder builder) {
+  public NearThermal(Builder builder) {
     this(
         builder.media,
         builder.distance,
@@ -27,21 +27,21 @@ public record NearImage(String image, Float distance, Float certainty, BaseQuery
         builder.baseOptions());
   }
 
-  public static class Builder extends NearMediaBuilder<Builder, NearImage> {
-    public Builder(String image) {
-      super(image);
+  public static class Builder extends NearMediaBuilder<Builder, NearThermal> {
+    public Builder(String thermal) {
+      super(thermal);
     }
 
     @Override
-    public final NearImage build() {
-      return new NearImage(this);
+    public final NearThermal build() {
+      return new NearThermal(this);
     }
   }
 
   @Override
   public void appendTo(WeaviateProtoSearchGet.SearchRequest.Builder req) {
     common.appendTo(req);
-    req.setNearImage(protoBuilder());
+    req.setNearThermal(protoBuilder());
   }
 
   @Override
@@ -49,18 +49,18 @@ public record NearImage(String image, Float distance, Float certainty, BaseQuery
     if (common.limit() != null) {
       req.setLimit(common.limit());
     }
-    req.setNearImage(protoBuilder());
+    req.setNearThermal(protoBuilder());
   }
 
-  private WeaviateProtoBaseSearch.NearImageSearch.Builder protoBuilder() {
-    var nearImage = WeaviateProtoBaseSearch.NearImageSearch.newBuilder();
-    nearImage.setImage(image);
+  private WeaviateProtoBaseSearch.NearThermalSearch.Builder protoBuilder() {
+    var nearThermal = WeaviateProtoBaseSearch.NearThermalSearch.newBuilder();
+    nearThermal.setThermal(thermal);
 
     if (certainty != null) {
-      nearImage.setCertainty(certainty);
+      nearThermal.setCertainty(certainty);
     } else if (distance != null) {
-      nearImage.setDistance(distance);
+      nearThermal.setDistance(distance);
     }
-    return nearImage;
+    return nearThermal;
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/NearVector.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/NearVector.java
@@ -25,26 +25,12 @@ public record NearVector(Float[] vector, Float distance, Float certainty, BaseQu
     this(builder.vector, builder.distance, builder.certainty, builder.baseOptions());
   }
 
-  public static class Builder extends BaseQueryOptions.Builder<Builder, NearVector> {
+  public static class Builder extends BaseVectorSearchBuilder<Builder, NearVector> {
     // Required query parameters.
     private final Float[] vector;
 
-    // Optional query parameters.
-    private Float distance;
-    private Float certainty;
-
     public Builder(Float[] vector) {
       this.vector = vector;
-    }
-
-    public final Builder distance(float distance) {
-      this.distance = distance;
-      return this;
-    }
-
-    public final Builder certainty(float certainty) {
-      this.certainty = certainty;
-      return this;
     }
 
     @Override

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/NearVector.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/NearVector.java
@@ -53,7 +53,8 @@ public record NearVector(Float[] vector, Float distance, Float certainty, BaseQu
     req.setNearVector(protoBuilder());
   }
 
-  private WeaviateProtoBaseSearch.NearVector.Builder protoBuilder() {
+  // This is made package-private for Hybrid to see. Should we refactor?
+  WeaviateProtoBaseSearch.NearVector.Builder protoBuilder() {
     var nearVector = WeaviateProtoBaseSearch.NearVector.newBuilder();
     nearVector.addVectors(WeaviateProtoBase.Vectors.newBuilder()
         .setType(WeaviateProtoBase.Vectors.VectorType.VECTOR_TYPE_SINGLE_FP32)

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/NearVideo.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/NearVideo.java
@@ -8,18 +8,18 @@ import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoAggregate;
 import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoBaseSearch;
 import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoSearchGet;
 
-public record NearImage(String image, Float distance, Float certainty, BaseQueryOptions common)
+public record NearVideo(String video, Float distance, Float certainty, BaseQueryOptions common)
     implements QueryOperator, AggregateObjectFilter {
 
-  public static NearImage of(String image) {
-    return of(image, ObjectBuilder.identity());
+  public static NearVideo of(String video) {
+    return of(video, ObjectBuilder.identity());
   }
 
-  public static NearImage of(String image, Function<Builder, ObjectBuilder<NearImage>> fn) {
-    return fn.apply(new Builder(image)).build();
+  public static NearVideo of(String video, Function<Builder, ObjectBuilder<NearVideo>> fn) {
+    return fn.apply(new Builder(video)).build();
   }
 
-  public NearImage(Builder builder) {
+  public NearVideo(Builder builder) {
     this(
         builder.media,
         builder.distance,
@@ -27,21 +27,21 @@ public record NearImage(String image, Float distance, Float certainty, BaseQuery
         builder.baseOptions());
   }
 
-  public static class Builder extends NearMediaBuilder<Builder, NearImage> {
-    public Builder(String image) {
-      super(image);
+  public static class Builder extends NearMediaBuilder<Builder, NearVideo> {
+    public Builder(String video) {
+      super(video);
     }
 
     @Override
-    public final NearImage build() {
-      return new NearImage(this);
+    public final NearVideo build() {
+      return new NearVideo(this);
     }
   }
 
   @Override
   public void appendTo(WeaviateProtoSearchGet.SearchRequest.Builder req) {
     common.appendTo(req);
-    req.setNearImage(protoBuilder());
+    req.setNearVideo(protoBuilder());
   }
 
   @Override
@@ -49,18 +49,18 @@ public record NearImage(String image, Float distance, Float certainty, BaseQuery
     if (common.limit() != null) {
       req.setLimit(common.limit());
     }
-    req.setNearImage(protoBuilder());
+    req.setNearVideo(protoBuilder());
   }
 
-  private WeaviateProtoBaseSearch.NearImageSearch.Builder protoBuilder() {
-    var nearImage = WeaviateProtoBaseSearch.NearImageSearch.newBuilder();
-    nearImage.setImage(image);
+  private WeaviateProtoBaseSearch.NearVideoSearch.Builder protoBuilder() {
+    var nearVideo = WeaviateProtoBaseSearch.NearVideoSearch.newBuilder();
+    nearVideo.setVideo(video);
 
     if (certainty != null) {
-      nearImage.setCertainty(certainty);
+      nearVideo.setCertainty(certainty);
     } else if (distance != null) {
-      nearImage.setDistance(distance);
+      nearVideo.setDistance(distance);
     }
-    return nearImage;
+    return nearVideo;
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/SearchOperator.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/SearchOperator.java
@@ -20,10 +20,12 @@ public class SearchOperator {
     this.minimumOrTokensMatch = minimumOrTokensMatch;
   }
 
-  void appendTo(WeaviateProtoBaseSearch.SearchOperatorOptions.Builder options) {
+  void appendTo(WeaviateProtoBaseSearch.BM25.Builder req) {
+    var options = WeaviateProtoBaseSearch.SearchOperatorOptions.newBuilder();
     options.setOperator(operator == "And" ? Operator.OPERATOR_AND : Operator.OPERATOR_OR);
     if (minimumOrTokensMatch != null) {
       options.setMinimumOrTokensMatch(minimumOrTokensMatch);
     }
+    req.setSearchOperator(options);
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/Where.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/Where.java
@@ -69,6 +69,12 @@ public class Where implements WhereOperand {
         || operands.stream().allMatch(operator -> operator.isEmpty());
   }
 
+  @Override
+  public String toString() {
+    var operandStrings = operands.stream().map(Object::toString).toList();
+    return "Where(" + String.join(" " + operator.toString() + " ", operandStrings) + ")";
+  }
+
   // Logical operators return a complete operand.
   // --------------------------------------------------------------------------
   public static Where and(WhereOperand... operands) {
@@ -580,6 +586,11 @@ public class Where implements WhereOperand {
       }
       // FIXME: no way to reference objects rn?
     }
+
+    @Override
+    public String toString() {
+      return String.join("::", path);
+    }
   }
 
   private static class TextOperand implements WhereOperand {
@@ -592,6 +603,11 @@ public class Where implements WhereOperand {
     @Override
     public void appendTo(WeaviateProtoBase.Filters.Builder where) {
       where.setValueText(value);
+    }
+
+    @Override
+    public String toString() {
+      return value;
     }
   }
 
@@ -611,6 +627,11 @@ public class Where implements WhereOperand {
     public void appendTo(WeaviateProtoBase.Filters.Builder where) {
       where.setValueTextArray(WeaviateProtoBase.TextArray.newBuilder().addAllValues(values));
     }
+
+    @Override
+    public String toString() {
+      return values.toString();
+    }
   }
 
   private static class BooleanOperand implements WhereOperand {
@@ -623,6 +644,11 @@ public class Where implements WhereOperand {
     @Override
     public void appendTo(WeaviateProtoBase.Filters.Builder where) {
       where.setValueBoolean(value);
+    }
+
+    @Override
+    public String toString() {
+      return value.toString();
     }
   }
 
@@ -642,6 +668,11 @@ public class Where implements WhereOperand {
     public void appendTo(WeaviateProtoBase.Filters.Builder where) {
       where.setValueBooleanArray(WeaviateProtoBase.BooleanArray.newBuilder().addAllValues(values));
     }
+
+    @Override
+    public String toString() {
+      return values.toString();
+    }
   }
 
   private static class IntegerOperand implements WhereOperand {
@@ -654,6 +685,11 @@ public class Where implements WhereOperand {
     @Override
     public void appendTo(WeaviateProtoBase.Filters.Builder where) {
       where.setValueInt(value);
+    }
+
+    @Override
+    public String toString() {
+      return value.toString();
     }
   }
 
@@ -677,6 +713,11 @@ public class Where implements WhereOperand {
     public void appendTo(WeaviateProtoBase.Filters.Builder where) {
       where.setValueIntArray(WeaviateProtoBase.IntArray.newBuilder().addAllValues(toLongs()));
     }
+
+    @Override
+    public String toString() {
+      return values.toString();
+    }
   }
 
   private static class NumberOperand implements WhereOperand {
@@ -689,6 +730,11 @@ public class Where implements WhereOperand {
     @Override
     public void appendTo(WeaviateProtoBase.Filters.Builder where) {
       where.setValueNumber(value.doubleValue());
+    }
+
+    @Override
+    public String toString() {
+      return value.toString();
     }
   }
 
@@ -712,6 +758,11 @@ public class Where implements WhereOperand {
     public void appendTo(WeaviateProtoBase.Filters.Builder where) {
       where.setValueNumberArray(WeaviateProtoBase.NumberArray.newBuilder().addAllValues(toDoubles()));
     }
+
+    @Override
+    public String toString() {
+      return values.toString();
+    }
   }
 
   private static class DateOperand implements WhereOperand {
@@ -729,6 +780,11 @@ public class Where implements WhereOperand {
     public void appendTo(WeaviateProtoBase.Filters.Builder where) {
       where.setValueText(format(value));
     }
+
+    @Override
+    public String toString() {
+      return format(value);
+    }
   }
 
   private static class DateArrayOperand implements WhereOperand {
@@ -745,12 +801,16 @@ public class Where implements WhereOperand {
 
     private List<String> formatted() {
       return values.stream().map(date -> DateOperand.format(date)).toList();
-
     }
 
     @Override
     public void appendTo(WeaviateProtoBase.Filters.Builder where) {
       where.setValueTextArray(WeaviateProtoBase.TextArray.newBuilder().addAllValues(formatted()));
+    }
+
+    @Override
+    public String toString() {
+      return values.toString();
     }
   }
 
@@ -769,6 +829,11 @@ public class Where implements WhereOperand {
     public void appendTo(WeaviateProtoBase.Filters.Builder where) {
       where.setValueGeo(WeaviateProtoBase.GeoCoordinatesFilter.newBuilder()
           .setLatitude(lat).setLongitude(lon).setDistance(distance));
+    }
+
+    @Override
+    public String toString() {
+      return "(lat=%d, lon=%d, distance=%d)".formatted(lat, lon, distance);
     }
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/Where.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/Where.java
@@ -97,7 +97,7 @@ public class Where implements WhereOperand {
   // --------------------------------------------------------------------------
 
   public static WhereBuilder uuid() {
-    return property("_id");
+    return property(ById.ID_PROPERTY);
   }
 
   public static WhereBuilder property(String property) {

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/Where.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/Where.java
@@ -90,6 +90,10 @@ public class Where implements WhereOperand {
   // Comparison operators return fluid builder.
   // --------------------------------------------------------------------------
 
+  public static WhereBuilder uuid() {
+    return property("_id");
+  }
+
   public static WhereBuilder property(String property) {
     return new WhereBuilder(new PathOperand(property));
   }
@@ -564,7 +568,6 @@ public class Where implements WhereOperand {
       this.path = path;
     }
 
-    @SafeVarargs
     private PathOperand(String... path) {
       this(Arrays.asList(path));
     }


### PR DESCRIPTION
This PR adds support for NearObject, Near<Media>, and Hybrid operators in `query` and `aggregate` namespaces.

```java
final var things = client.collections.use("Things");

things.query.hybrid("something like that", q -> q.alpha(0.3f).fusionType(Hybrid.FusionType.RANKED));

// .excludeSelf is a shorthand for `where(Where.uuid().ne("this-thing-id"))`
things.query.nearObject("this-thing-id", q -> q.excludeSelf());
```

There's also some minor improvements to Where-filter builders:
- `Where.uuid()` is a shorthand for `Where.property("_id")`
- `Where::toString` now prints human-readable representation of the filter

```java
Where.reference("hasFriend", "name").eq("Piglet")`
// Outputs:
//   "Where(hasFriend::name Equal Piglet)"
```

- Calls to `.where(...)` can now be chained -- individual conditions will be AND'ed together

```java
query -> query.where(Where.and(
  Where.property("name").eq("pooh"),
  Where.property("age").gte(22)
))

// is equivalent to

query -> query
  .where(Where.property("name").eq("pooh")
  .where(Where.property("age").gte(22)
```