### PR TITLE
v6: Complete collection configuration and missing `config` functionality

### DIFF
--- a/src/it/java/io/weaviate/containers/Weaviate.java
+++ b/src/it/java/io/weaviate/containers/Weaviate.java
@@ -14,7 +14,7 @@ import io.weaviate.client6.v1.api.WeaviateClient;
 public class Weaviate extends WeaviateContainer {
   private WeaviateClient clientInstance;
 
-  public static final String VERSION = "1.29.0";
+  public static final String VERSION = "1.29.1";
   public static final String DOCKER_IMAGE = "semitechnologies/weaviate";
 
   /**

--- a/src/it/java/io/weaviate/integration/CollectionsITest.java
+++ b/src/it/java/io/weaviate/integration/CollectionsITest.java
@@ -29,7 +29,7 @@ public class CollectionsITest extends ConcurrentTest {
     var thingsCollection = client.collections.getConfig(collectionName);
 
     Assertions.assertThat(thingsCollection).get()
-        .hasFieldOrPropertyWithValue("name", collectionName)
+        .hasFieldOrPropertyWithValue("collectionName", collectionName)
         .extracting(WeaviateCollection::vectors, InstanceOfAssertFactories.map(String.class, VectorIndex.class))
         .as("default vector").extractingByKey("default")
         .satisfies(defaultVector -> {

--- a/src/it/java/io/weaviate/integration/CollectionsITest.java
+++ b/src/it/java/io/weaviate/integration/CollectionsITest.java
@@ -117,29 +117,33 @@ public class CollectionsITest extends ConcurrentTest {
 
   @Test
   public void testUpdateCollection() throws IOException {
-    var nsBoxes = ns("Boxes");
-    var nsThings = ns("Things");
+    try {
+      var nsBoxes = ns("Boxes");
+      var nsThings = ns("Things");
 
-    client.collections.create(nsBoxes);
+      client.collections.create(nsBoxes);
 
-    client.collections.create(nsThings,
-        collection -> collection
-            .description("Things stored in boxes")
-            .properties(
-                Property.text("name"),
-                Property.integer("width"))
-            .references(
-                Property.reference("storedIn", nsBoxes)));
+      client.collections.create(nsThings,
+          collection -> collection
+              .description("Things stored in boxes")
+              .properties(
+                  Property.text("name"),
+                  Property.integer("width"))
+              .references(
+                  Property.reference("storedIn", nsBoxes)));
 
-    var things = client.collections.use(nsThings);
+      var things = client.collections.use(nsThings);
 
-    // Act
-    things.config.update(nsThings, collection -> collection
-        .description("Things stored on shelves"));
+      // Act
+      things.config.update(nsThings, collection -> collection
+          .description("Things stored on shelves"));
 
-    // Assert
-    var thingsConfig = things.config.get();
-    Assertions.assertThat(thingsConfig).get()
-        .returns("Things stored on shelves", CollectionConfig::description);
+      // Assert
+      var thingsConfig = things.config.get();
+      Assertions.assertThat(thingsConfig).get()
+          .returns("Things stored on shelves", CollectionConfig::description);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
   }
 }

--- a/src/it/java/io/weaviate/integration/CollectionsITest.java
+++ b/src/it/java/io/weaviate/integration/CollectionsITest.java
@@ -8,9 +8,9 @@ import org.junit.Test;
 
 import io.weaviate.ConcurrentTest;
 import io.weaviate.client6.v1.api.WeaviateClient;
+import io.weaviate.client6.v1.api.collections.CollectionConfig;
 import io.weaviate.client6.v1.api.collections.Property;
 import io.weaviate.client6.v1.api.collections.VectorIndex;
-import io.weaviate.client6.v1.api.collections.WeaviateCollection;
 import io.weaviate.client6.v1.api.collections.vectorindex.Hnsw;
 import io.weaviate.client6.v1.api.collections.vectorizers.NoneVectorizer;
 import io.weaviate.containers.Container;
@@ -30,7 +30,7 @@ public class CollectionsITest extends ConcurrentTest {
 
     Assertions.assertThat(thingsCollection).get()
         .hasFieldOrPropertyWithValue("collectionName", collectionName)
-        .extracting(WeaviateCollection::vectors, InstanceOfAssertFactories.map(String.class, VectorIndex.class))
+        .extracting(CollectionConfig::vectors, InstanceOfAssertFactories.map(String.class, VectorIndex.class))
         .as("default vector").extractingByKey("default")
         .satisfies(defaultVector -> {
           Assertions.assertThat(defaultVector).extracting(VectorIndex::vectorizer)
@@ -105,7 +105,7 @@ public class CollectionsITest extends ConcurrentTest {
     var all = client.collections.list();
     Assertions.assertThat(all)
         .hasSizeGreaterThanOrEqualTo(3)
-        .extracting(WeaviateCollection::collectionName)
+        .extracting(CollectionConfig::collectionName)
         .contains(nsA, nsB, nsC);
 
     client.collections.deleteAll();
@@ -140,6 +140,6 @@ public class CollectionsITest extends ConcurrentTest {
     // Assert
     var thingsConfig = things.config.get();
     Assertions.assertThat(thingsConfig).get()
-        .returns("Things stored on shelves", WeaviateCollection::description);
+        .returns("Things stored on shelves", CollectionConfig::description);
   }
 }

--- a/src/it/java/io/weaviate/integration/ReferencesITest.java
+++ b/src/it/java/io/weaviate/integration/ReferencesITest.java
@@ -61,7 +61,7 @@ public class ReferencesITest extends ConcurrentTest {
         .as("Artists: create collection")
         .extracting(c -> c.references().stream().findFirst())
         .as("has one reference property").extracting(Optional::get)
-        .returns("hasAwards", ReferenceProperty::name)
+        .returns("hasAwards", ReferenceProperty::propertyName)
         .extracting(ReferenceProperty::dataTypes, InstanceOfAssertFactories.list(String.class))
         .containsOnly(nsGrammy, nsOscar);
 
@@ -87,7 +87,7 @@ public class ReferencesITest extends ConcurrentTest {
     Assertions.assertThat(collectionArtists).get()
         .as("Artists: add reference to Movies")
         .extracting(c -> c.references().stream()
-            .filter(property -> property.name().equals("featuredIn")).findFirst())
+            .filter(property -> property.propertyName().equals("featuredIn")).findFirst())
         .as("featuredIn reference property").extracting(Optional::get)
         .extracting(ReferenceProperty::dataTypes, InstanceOfAssertFactories.list(String.class))
         .containsOnly(nsMovies);

--- a/src/main/java/io/weaviate/client6/v1/api/collections/CollectionConfig.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/CollectionConfig.java
@@ -70,8 +70,8 @@ public record CollectionConfig(
     this(
         builder.collectionName,
         builder.description,
-        builder.properties,
-        builder.references,
+        builder.propertyList(),
+        builder.referenceList(),
         builder.vectors,
         builder.multiTenancy,
         builder.sharding,
@@ -86,8 +86,8 @@ public record CollectionConfig(
     private final String collectionName;
 
     private String description;
-    private List<Property> properties = new ArrayList<>();
-    private List<ReferenceProperty> references = new ArrayList<>();
+    private Map<String, Property> properties = new HashMap<>();
+    private Map<String, ReferenceProperty> references = new HashMap<>();
     private Map<String, VectorIndex> vectors = new HashMap<>();
     private MultiTenancy multiTenancy;
     private Sharding sharding;
@@ -110,8 +110,12 @@ public record CollectionConfig(
     }
 
     public Builder properties(List<Property> properties) {
-      this.properties.addAll(properties);
+      properties.forEach(property -> this.properties.put(property.propertyName(), property));
       return this;
+    }
+
+    private List<Property> propertyList() {
+      return this.properties.values().stream().toList();
     }
 
     public Builder references(ReferenceProperty... references) {
@@ -119,8 +123,12 @@ public record CollectionConfig(
     }
 
     public Builder references(List<ReferenceProperty> references) {
-      this.references.addAll(references);
+      references.forEach(reference -> this.references.put(reference.propertyName(), reference));
       return this;
+    }
+
+    private List<ReferenceProperty> referenceList() {
+      return this.references.values().stream().toList();
     }
 
     public Builder vector(VectorIndex vector) {

--- a/src/main/java/io/weaviate/client6/v1/api/collections/CollectionConfig.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/CollectionConfig.java
@@ -27,7 +27,8 @@ public record CollectionConfig(
     @SerializedName("description") String description,
     @SerializedName("properties") List<Property> properties,
     List<ReferenceProperty> references,
-    @SerializedName("vectorConfig") Map<String, VectorIndex> vectors) {
+    @SerializedName("vectorConfig") Map<String, VectorIndex> vectors,
+    @SerializedName("invertedIndexConfig") InvertedIndex invertedIndex) {
 
   public static CollectionConfig of(String collectionName) {
     return of(collectionName, ObjectBuilder.identity());
@@ -60,7 +61,8 @@ public record CollectionConfig(
         builder.description,
         builder.properties,
         builder.references,
-        builder.vectors);
+        builder.vectors,
+        builder.invertedIndex);
   }
 
   public static class Builder implements ObjectBuilder<CollectionConfig> {
@@ -71,6 +73,7 @@ public record CollectionConfig(
     private List<Property> properties = new ArrayList<>();
     private List<ReferenceProperty> references = new ArrayList<>();
     private Map<String, VectorIndex> vectors = new HashMap<>();
+    private InvertedIndex invertedIndex;
 
     public Builder(String collectionName) {
       this.collectionName = collectionName;
@@ -131,6 +134,11 @@ public record CollectionConfig(
       public Map<String, VectorIndex> build() {
         return this.vectors;
       }
+    }
+
+    public Builder invertedIndex(Function<InvertedIndex.Builder, ObjectBuilder<InvertedIndex>> fn) {
+      this.invertedIndex = InvertedIndex.of(fn);
+      return this;
     }
 
     @Override

--- a/src/main/java/io/weaviate/client6/v1/api/collections/CollectionConfig.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/CollectionConfig.java
@@ -22,18 +22,18 @@ import com.google.gson.stream.JsonWriter;
 
 import io.weaviate.client6.v1.internal.ObjectBuilder;
 
-public record WeaviateCollection(
+public record CollectionConfig(
     @SerializedName("class") String collectionName,
     @SerializedName("description") String description,
     @SerializedName("properties") List<Property> properties,
     List<ReferenceProperty> references,
     @SerializedName("vectorConfig") Map<String, VectorIndex> vectors) {
 
-  public static WeaviateCollection of(String collectionName) {
+  public static CollectionConfig of(String collectionName) {
     return of(collectionName, ObjectBuilder.identity());
   }
 
-  public static WeaviateCollection of(String collectionName, Function<Builder, ObjectBuilder<WeaviateCollection>> fn) {
+  public static CollectionConfig of(String collectionName, Function<Builder, ObjectBuilder<CollectionConfig>> fn) {
     return fn.apply(new Builder(collectionName)).build();
   }
 
@@ -50,11 +50,11 @@ public record WeaviateCollection(
   }
 
   /** Create a copy of this {@code WeaviateCollection} and edit parts of it. */
-  public WeaviateCollection edit(Function<Builder, ObjectBuilder<WeaviateCollection>> fn) {
+  public CollectionConfig edit(Function<Builder, ObjectBuilder<CollectionConfig>> fn) {
     return fn.apply(edit()).build();
   }
 
-  public WeaviateCollection(Builder builder) {
+  public CollectionConfig(Builder builder) {
     this(
         builder.collectionName,
         builder.description,
@@ -63,7 +63,7 @@ public record WeaviateCollection(
         builder.vectors);
   }
 
-  public static class Builder implements ObjectBuilder<WeaviateCollection> {
+  public static class Builder implements ObjectBuilder<CollectionConfig> {
     // Required parameters;
     private final String collectionName;
 
@@ -134,8 +134,8 @@ public record WeaviateCollection(
     }
 
     @Override
-    public WeaviateCollection build() {
-      return new WeaviateCollection(this);
+    public CollectionConfig build() {
+      return new CollectionConfig(this);
     }
   }
 
@@ -145,15 +145,15 @@ public record WeaviateCollection(
     @SuppressWarnings("unchecked")
     @Override
     public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
-      if (type.getRawType() != WeaviateCollection.class) {
+      if (type.getRawType() != CollectionConfig.class) {
         return null;
       }
 
-      final var delegate = gson.getDelegateAdapter(this, (TypeToken<WeaviateCollection>) type);
-      return (TypeAdapter<T>) new TypeAdapter<WeaviateCollection>() {
+      final var delegate = gson.getDelegateAdapter(this, (TypeToken<CollectionConfig>) type);
+      return (TypeAdapter<T>) new TypeAdapter<CollectionConfig>() {
 
         @Override
-        public void write(JsonWriter out, WeaviateCollection value) throws IOException {
+        public void write(JsonWriter out, CollectionConfig value) throws IOException {
           var jsonObject = delegate.toJsonTree(value).getAsJsonObject();
 
           var references = jsonObject.remove("references").getAsJsonArray();
@@ -164,7 +164,7 @@ public record WeaviateCollection(
         }
 
         @Override
-        public WeaviateCollection read(JsonReader in) throws IOException {
+        public CollectionConfig read(JsonReader in) throws IOException {
           var jsonObject = JsonParser.parseReader(in).getAsJsonObject();
 
           var mixedProperties = jsonObject.get("properties").getAsJsonArray();

--- a/src/main/java/io/weaviate/client6/v1/api/collections/CreateCollectionRequest.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/CreateCollectionRequest.java
@@ -7,12 +7,12 @@ import org.apache.hc.core5.http.HttpStatus;
 import io.weaviate.client6.v1.internal.json.JSON;
 import io.weaviate.client6.v1.internal.rest.Endpoint;
 
-public record CreateCollectionRequest(WeaviateCollection collection) {
-  public static final Endpoint<CreateCollectionRequest, WeaviateCollection> _ENDPOINT = Endpoint.of(
+public record CreateCollectionRequest(CollectionConfig collection) {
+  public static final Endpoint<CreateCollectionRequest, CollectionConfig> _ENDPOINT = Endpoint.of(
       request -> "POST",
       request -> "/schema/",
       (gson, request) -> JSON.serialize(request.collection),
       request -> Collections.emptyMap(),
       code -> code != HttpStatus.SC_SUCCESS,
-      (gson, response) -> JSON.deserialize(response, WeaviateCollection.class));
+      (gson, response) -> JSON.deserialize(response, CollectionConfig.class));
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/Generative.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/Generative.java
@@ -1,0 +1,110 @@
+package io.weaviate.client6.v1.api.collections;
+
+import java.io.IOException;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import io.weaviate.client6.v1.api.collections.generative.CohereGenerative;
+import io.weaviate.client6.v1.internal.ObjectBuilder;
+import io.weaviate.client6.v1.internal.json.JsonEnum;
+
+public interface Generative {
+  public enum Kind implements JsonEnum<Kind> {
+    COHERE("generative-cohere");
+
+    private static final Map<String, Kind> jsonValueMap = JsonEnum.collectNames(Kind.values());
+    private final String jsonValue;
+
+    private Kind(String jsonValue) {
+      this.jsonValue = jsonValue;
+    }
+
+    @Override
+    public String jsonValue() {
+      return this.jsonValue;
+    }
+
+    public static Kind valueOfJson(String jsonValue) {
+      return JsonEnum.valueOfJson(jsonValue, jsonValueMap, Kind.class);
+    }
+  }
+
+  Kind _kind();
+
+  Object _self();
+
+  public static Generative cohere() {
+    return CohereGenerative.of();
+  }
+
+  public static Generative cohere(Function<CohereGenerative.Builder, ObjectBuilder<CohereGenerative>> fn) {
+    return CohereGenerative.of(fn);
+  }
+
+  public static enum CustomTypeAdapterFactory implements TypeAdapterFactory {
+    INSTANCE;
+
+    private static final EnumMap<Generative.Kind, TypeAdapter<? extends Generative>> readAdapters = new EnumMap<>(
+        Generative.Kind.class);
+
+    private final void addAdapter(Gson gson, Generative.Kind kind, Class<? extends Generative> cls) {
+      readAdapters.put(kind, (TypeAdapter<? extends Generative>) gson.getDelegateAdapter(this, TypeToken.get(cls)));
+    }
+
+    private final void init(Gson gson) {
+      addAdapter(gson, Generative.Kind.COHERE, CohereGenerative.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+      var rawType = type.getRawType();
+      if (!Generative.class.isAssignableFrom(rawType)) {
+        return null;
+      }
+
+      if (readAdapters.isEmpty()) {
+        init(gson);
+      }
+
+      final TypeAdapter<T> writeAdapter = (TypeAdapter<T>) gson.getDelegateAdapter(this, TypeToken.get(rawType));
+      return (TypeAdapter<T>) new TypeAdapter<Generative>() {
+
+        @Override
+        public void write(JsonWriter out, Generative value) throws IOException {
+          out.beginObject();
+          out.name(value._kind().jsonValue());
+          writeAdapter.write(out, (T) value._self());
+          out.endObject();
+        }
+
+        @Override
+        public Generative read(JsonReader in) throws IOException {
+          in.beginObject();
+          var moduleName = in.nextName();
+          try {
+            var kind = Generative.Kind.valueOfJson(moduleName);
+            var adapter = readAdapters.get(kind);
+            return adapter.read(in);
+          } catch (IllegalArgumentException e) {
+            return null;
+          } finally {
+            if (in.peek() == JsonToken.BEGIN_OBJECT) {
+              in.beginObject();
+            }
+            in.endObject();
+          }
+        }
+      }.nullSafe();
+    }
+  }
+}

--- a/src/main/java/io/weaviate/client6/v1/api/collections/GetConfigRequest.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/GetConfigRequest.java
@@ -9,11 +9,11 @@ import io.weaviate.client6.v1.internal.json.JSON;
 import io.weaviate.client6.v1.internal.rest.Endpoint;
 
 public record GetConfigRequest(String collectionName) {
-  public static final Endpoint<GetConfigRequest, Optional<WeaviateCollection>> _ENDPOINT = Endpoint.of(
+  public static final Endpoint<GetConfigRequest, Optional<CollectionConfig>> _ENDPOINT = Endpoint.of(
       request -> "GET",
       request -> "/schema/" + request.collectionName,
       (gson, request) -> null,
       request -> Collections.emptyMap(),
       code -> code != HttpStatus.SC_SUCCESS,
-      (gson, response) -> Optional.ofNullable(JSON.deserialize(response, WeaviateCollection.class)));
+      (gson, response) -> Optional.ofNullable(JSON.deserialize(response, CollectionConfig.class)));
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/InvertedIndex.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/InvertedIndex.java
@@ -1,0 +1,165 @@
+package io.weaviate.client6.v1.api.collections;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+import com.google.gson.annotations.SerializedName;
+
+import io.weaviate.client6.v1.internal.ObjectBuilder;
+
+public record InvertedIndex(
+    @SerializedName("cleanupIntervalSeconds") String cleanupIntervalSeconds,
+    @SerializedName("bm25") Bm25 bm25,
+    @SerializedName("stopwords") Stopwords stopwords,
+    @SerializedName("indexTimestamps") Boolean indexTimestamps,
+    @SerializedName("indexNullState") Boolean indexNulls,
+    @SerializedName("indexPropertyLength") Boolean indexPropertyLength,
+    @SerializedName("usingBlockMaxWAND") Boolean useBlockMaxWAND) {
+
+  public static InvertedIndex of(Function<Builder, ObjectBuilder<InvertedIndex>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  public record Bm25(
+      @SerializedName("b") Integer b,
+      @SerializedName("k1") Integer k1) {
+
+    public static Bm25 of(Function<Builder, ObjectBuilder<Bm25>> fn) {
+      return fn.apply(new Builder()).build();
+    }
+
+    public Bm25(Builder builder) {
+      this(builder.b, builder.k1);
+    }
+
+    public static class Builder implements ObjectBuilder<Bm25> {
+      private Integer b;
+      private Integer k1;
+
+      public Builder b(int b) {
+        this.b = b;
+        return this;
+      }
+
+      public Builder k1(int k1) {
+        this.k1 = k1;
+        return this;
+      }
+
+      @Override
+      public Bm25 build() {
+        return new Bm25(this);
+      }
+    }
+  }
+
+  public record Stopwords(
+      @SerializedName("preset") String preset,
+      @SerializedName("additions") List<String> additions,
+      @SerializedName("removals") List<String> removals) {
+
+    public static Stopwords of(Function<Builder, ObjectBuilder<Stopwords>> fn) {
+      return fn.apply(new Builder()).build();
+    }
+
+    public Stopwords(Builder builder) {
+      this(builder.preset, builder.additions, builder.removals);
+    }
+
+    public static class Builder implements ObjectBuilder<Stopwords> {
+      private String preset;
+      private List<String> additions;
+      private List<String> removals;
+
+      public Builder preset(String preset) {
+        this.preset = preset;
+        return this;
+      }
+
+      public Builder add(String... additions) {
+        return add(Arrays.asList(additions));
+      }
+
+      public Builder add(List<String> additions) {
+        this.additions.addAll(additions);
+        return this;
+      }
+
+      public Builder remove(String... removals) {
+        return remove(Arrays.asList(removals));
+      }
+
+      public Builder remove(List<String> removals) {
+        this.removals.addAll(removals);
+        return this;
+      }
+
+      @Override
+      public Stopwords build() {
+        return new Stopwords(this);
+      }
+    }
+  }
+
+  public InvertedIndex(Builder builder) {
+    this(
+        builder.cleanupIntervalSeconds,
+        builder.bm25,
+        builder.stopwords,
+        builder.indexTimestamps,
+        builder.indexNulls,
+        builder.indexPropertyLength,
+        builder.useBlockMaxWAND);
+  }
+
+  public static class Builder implements ObjectBuilder<InvertedIndex> {
+    private String cleanupIntervalSeconds;
+    private Bm25 bm25;
+    private Stopwords stopwords;
+    private Boolean indexTimestamps;
+    private Boolean indexNulls;
+    private Boolean indexPropertyLength;
+    private Boolean useBlockMaxWAND;
+
+    public Builder cleanupIntervalSeconds(String cleanupIntervalSeconds) {
+      this.cleanupIntervalSeconds = cleanupIntervalSeconds;
+      return this;
+    }
+
+    public Builder bm25(Function<Bm25.Builder, ObjectBuilder<Bm25>> fn) {
+      this.bm25 = Bm25.of(fn);
+      return this;
+    }
+
+    public Builder stopwords(Function<Stopwords.Builder, ObjectBuilder<Stopwords>> fn) {
+      this.stopwords = Stopwords.of(fn);
+      return this;
+    }
+
+    public Builder indexTimestamps(Boolean indexTimestamps) {
+      this.indexTimestamps = indexTimestamps;
+      return this;
+    }
+
+    public Builder indexNulls(Boolean indexNulls) {
+      this.indexNulls = indexNulls;
+      return this;
+    }
+
+    public Builder indexPropertyLength(Boolean indexPropertyLength) {
+      this.indexPropertyLength = indexPropertyLength;
+      return this;
+    }
+
+    public Builder useBlockMaxWAND(Boolean useBlockMaxWAND) {
+      this.useBlockMaxWAND = useBlockMaxWAND;
+      return this;
+    }
+
+    @Override
+    public InvertedIndex build() {
+      return new InvertedIndex(this);
+    }
+  }
+}

--- a/src/main/java/io/weaviate/client6/v1/api/collections/InvertedIndex.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/InvertedIndex.java
@@ -9,7 +9,7 @@ import com.google.gson.annotations.SerializedName;
 import io.weaviate.client6.v1.internal.ObjectBuilder;
 
 public record InvertedIndex(
-    @SerializedName("cleanupIntervalSeconds") String cleanupIntervalSeconds,
+    @SerializedName("cleanupIntervalSeconds") Integer cleanupIntervalSeconds,
     @SerializedName("bm25") Bm25 bm25,
     @SerializedName("stopwords") Stopwords stopwords,
     @SerializedName("indexTimestamps") Boolean indexTimestamps,
@@ -114,7 +114,7 @@ public record InvertedIndex(
   }
 
   public static class Builder implements ObjectBuilder<InvertedIndex> {
-    private String cleanupIntervalSeconds;
+    private Integer cleanupIntervalSeconds;
     private Bm25 bm25;
     private Stopwords stopwords;
     private Boolean indexTimestamps;
@@ -122,7 +122,7 @@ public record InvertedIndex(
     private Boolean indexPropertyLength;
     private Boolean useBlockMaxWAND;
 
-    public Builder cleanupIntervalSeconds(String cleanupIntervalSeconds) {
+    public Builder cleanupIntervalSeconds(int cleanupIntervalSeconds) {
       this.cleanupIntervalSeconds = cleanupIntervalSeconds;
       return this;
     }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/ListCollectionRequest.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/ListCollectionRequest.java
@@ -5,13 +5,11 @@ import java.util.List;
 
 import org.apache.hc.core5.http.HttpStatus;
 
-import com.google.gson.reflect.TypeToken;
-
 import io.weaviate.client6.v1.internal.json.JSON;
 import io.weaviate.client6.v1.internal.rest.Endpoint;
 
 public record ListCollectionRequest() {
-  public static final Endpoint<ListCollectionRequest, List<WeaviateCollection>> _ENDPOINT = Endpoint.of(
+  public static final Endpoint<ListCollectionRequest, List<CollectionConfig>> _ENDPOINT = Endpoint.of(
       request -> "GET",
       request -> "/schema",
       (gson, request) -> null,

--- a/src/main/java/io/weaviate/client6/v1/api/collections/ListCollectionResponse.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/ListCollectionResponse.java
@@ -4,5 +4,5 @@ import java.util.List;
 
 import com.google.gson.annotations.SerializedName;
 
-public record ListCollectionResponse(@SerializedName("classes") List<WeaviateCollection> collections) {
+public record ListCollectionResponse(@SerializedName("classes") List<CollectionConfig> collections) {
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/MultiTenancy.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/MultiTenancy.java
@@ -1,0 +1,42 @@
+package io.weaviate.client6.v1.api.collections;
+
+import java.util.function.Function;
+
+import com.google.gson.annotations.SerializedName;
+
+import io.weaviate.client6.v1.internal.ObjectBuilder;
+
+public record MultiTenancy(
+    @SerializedName("autoTenantCreation") Boolean createAutomatically,
+    @SerializedName("autoTenantActivate") Boolean activateAutomatically) {
+
+  public static MultiTenancy of(Function<Builder, ObjectBuilder<MultiTenancy>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  public MultiTenancy(Builder builder) {
+    this(
+        builder.createAutomatically,
+        builder.activateAutomatically);
+  }
+
+  public static class Builder implements ObjectBuilder<MultiTenancy> {
+    private Boolean createAutomatically;
+    private Boolean activateAutomatically;
+
+    public Builder createAutomatically(boolean createAutomatically) {
+      this.createAutomatically = createAutomatically;
+      return this;
+    }
+
+    public Builder activateAutomatically(boolean activateAutomatically) {
+      this.activateAutomatically = activateAutomatically;
+      return this;
+    }
+
+    @Override
+    public MultiTenancy build() {
+      return new MultiTenancy(this);
+    }
+  }
+}

--- a/src/main/java/io/weaviate/client6/v1/api/collections/Property.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/Property.java
@@ -2,30 +2,45 @@ package io.weaviate.client6.v1.api.collections;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 
 import com.google.gson.annotations.SerializedName;
 
+import io.weaviate.client6.v1.internal.ObjectBuilder;
+
 public record Property(
-    @SerializedName("name") String name,
-    @SerializedName("dataType") List<String> dataTypes) {
+    @SerializedName("name") String propertyName,
+    @SerializedName("dataType") List<String> dataTypes,
+    @SerializedName("description") String description,
+    @SerializedName("indexInverted") Boolean indexInverted,
+    @SerializedName("indexFilterable") Boolean indexFilterable,
+    @SerializedName("indexRangeFilters") Boolean indexRangeFilters,
+    @SerializedName("indexSearchable") Boolean indexSearchable,
+    @SerializedName("skipVectorization") Boolean skipVectorization,
+    @SerializedName("vectorizePropertyName") Boolean vectorizePropertyName) {
 
-  public Property(String name, String dataType) {
-    this(name, List.of(dataType));
-  }
-
-  /** Add text property with default configuration. */
   public static Property text(String name) {
-    return new Property(name, DataType.TEXT);
+    return text(name, ObjectBuilder.identity());
   }
 
-  /** Add integer property with default configuration. */
+  public static Property text(String name, Function<Builder, ObjectBuilder<Property>> fn) {
+    return fn.apply(new Builder(name, DataType.TEXT)).build();
+  }
+
   public static Property integer(String name) {
-    return new Property(name, DataType.INT);
+    return integer(name, ObjectBuilder.identity());
   }
 
-  /** Add blob property with default configuration. */
+  public static Property integer(String name, Function<Builder, ObjectBuilder<Property>> fn) {
+    return fn.apply(new Builder(name, DataType.INT)).build();
+  }
+
   public static Property blob(String name) {
-    return new Property(name, DataType.BLOB);
+    return blob(name, ObjectBuilder.identity());
+  }
+
+  public static Property blob(String name, Function<Builder, ObjectBuilder<Property>> fn) {
+    return fn.apply(new Builder(name, DataType.BLOB)).build();
   }
 
   public static ReferenceProperty reference(String name, String... collections) {
@@ -34,5 +49,52 @@ public record Property(
 
   public static ReferenceProperty reference(String name, List<String> collections) {
     return new ReferenceProperty(name, collections);
+  }
+
+  public Property(Builder builder) {
+    this(
+        builder.propertyName,
+        builder.dataTypes,
+        builder.description,
+        builder.indexInverted,
+        builder.indexFilterable,
+        builder.indexRangeFilters,
+        builder.indexSearchable,
+        builder.skipVectorization,
+        builder.vectorizePropertyName);
+  }
+
+  public static class Builder implements ObjectBuilder<Property> {
+    // Required parameters.
+    private final String propertyName;
+
+    // Optional parameters.
+    private List<String> dataTypes;
+    private String description;
+    private Boolean indexInverted;
+    private Boolean indexFilterable;
+    private Boolean indexRangeFilters;
+    private Boolean indexSearchable;
+    private Boolean skipVectorization;
+    private Boolean vectorizePropertyName;
+
+    public Builder(String propertyName, String dataType) {
+      this.propertyName = propertyName;
+      this.dataTypes = List.of(dataType);
+    }
+
+    public Builder(String propertyName, String... dataTypes) {
+      this(propertyName, Arrays.asList(dataTypes));
+    }
+
+    public Builder(String propertyName, List<String> dataTypes) {
+      this.propertyName = propertyName;
+      this.dataTypes = List.copyOf(dataTypes);
+    }
+
+    @Override
+    public Property build() {
+      return new Property(this);
+    }
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/Property.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/Property.java
@@ -51,6 +51,21 @@ public record Property(
     return new ReferenceProperty(name, collections);
   }
 
+  public Builder edit() {
+    return new Builder(propertyName, dataTypes)
+        .description(description)
+        .indexInverted(indexInverted)
+        .indexFilterable(indexFilterable)
+        .indexRangeFilters(indexRangeFilters)
+        .indexSearchable(indexSearchable)
+        .skipVectorization(skipVectorization)
+        .vectorizePropertyName(vectorizePropertyName);
+  }
+
+  public Property edit(Function<Builder, ObjectBuilder<Property>> fn) {
+    return fn.apply(edit()).build();
+  }
+
   public Property(Builder builder) {
     this(
         builder.propertyName,
@@ -102,32 +117,32 @@ public record Property(
       return this;
     }
 
-    public Builder indexInverted(boolean indexInverted) {
+    public Builder indexInverted(Boolean indexInverted) {
       this.indexInverted = indexInverted;
       return this;
     }
 
-    public Builder indexFilterable(boolean indexFilterable) {
+    public Builder indexFilterable(Boolean indexFilterable) {
       this.indexFilterable = indexFilterable;
       return this;
     }
 
-    public Builder indexRangeFilters(boolean indexRangeFilters) {
+    public Builder indexRangeFilters(Boolean indexRangeFilters) {
       this.indexRangeFilters = indexRangeFilters;
       return this;
     }
 
-    public Builder indexSearchable(boolean indexSearchable) {
+    public Builder indexSearchable(Boolean indexSearchable) {
       this.indexSearchable = indexSearchable;
       return this;
     }
 
-    public Builder skipVectorization(boolean skipVectorization) {
+    public Builder skipVectorization(Boolean skipVectorization) {
       this.skipVectorization = skipVectorization;
       return this;
     }
 
-    public Builder vectorizePropertyName(boolean vectorizePropertyName) {
+    public Builder vectorizePropertyName(Boolean vectorizePropertyName) {
       this.vectorizePropertyName = vectorizePropertyName;
       return this;
     }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/Property.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/Property.java
@@ -92,6 +92,46 @@ public record Property(
       this.dataTypes = List.copyOf(dataTypes);
     }
 
+    public Builder dataTypes(List<String> dataTypes) {
+      this.dataTypes = dataTypes;
+      return this;
+    }
+
+    public Builder description(String description) {
+      this.description = description;
+      return this;
+    }
+
+    public Builder indexInverted(boolean indexInverted) {
+      this.indexInverted = indexInverted;
+      return this;
+    }
+
+    public Builder indexFilterable(boolean indexFilterable) {
+      this.indexFilterable = indexFilterable;
+      return this;
+    }
+
+    public Builder indexRangeFilters(boolean indexRangeFilters) {
+      this.indexRangeFilters = indexRangeFilters;
+      return this;
+    }
+
+    public Builder indexSearchable(boolean indexSearchable) {
+      this.indexSearchable = indexSearchable;
+      return this;
+    }
+
+    public Builder skipVectorization(boolean skipVectorization) {
+      this.skipVectorization = skipVectorization;
+      return this;
+    }
+
+    public Builder vectorizePropertyName(boolean vectorizePropertyName) {
+      this.vectorizePropertyName = vectorizePropertyName;
+      return this;
+    }
+
     @Override
     public Property build() {
       return new Property(this);

--- a/src/main/java/io/weaviate/client6/v1/api/collections/ReferenceProperty.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/ReferenceProperty.java
@@ -5,10 +5,10 @@ import java.util.List;
 import com.google.gson.annotations.SerializedName;
 
 public record ReferenceProperty(
-    @SerializedName("name") String name,
+    @SerializedName("name") String propertyName,
     @SerializedName("dataType") List<String> dataTypes) {
 
   public Property toProperty() {
-    return new Property.Builder(name, dataTypes).build();
+    return new Property.Builder(propertyName, dataTypes).build();
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/ReferenceProperty.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/ReferenceProperty.java
@@ -9,6 +9,6 @@ public record ReferenceProperty(
     @SerializedName("dataType") List<String> dataTypes) {
 
   public Property toProperty() {
-    return new Property(name, dataTypes);
+    return new Property.Builder(name, dataTypes).build();
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/Replication.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/Replication.java
@@ -1,0 +1,59 @@
+package io.weaviate.client6.v1.api.collections;
+
+import java.util.function.Function;
+
+import com.google.gson.annotations.SerializedName;
+
+import io.weaviate.client6.v1.internal.ObjectBuilder;
+
+public record Replication(
+    @SerializedName("factor") Integer replicationFactor,
+    @SerializedName("asyncEnabled") Boolean asyncEnabled,
+    @SerializedName("deletionStrategy") DeletionStrategy deletionStrategy) {
+
+  public static enum DeletionStrategy {
+    @SerializedName("NoAutomatedResolution")
+    NO_AUTOMATED_RESOLUTION,
+    @SerializedName("DeleteOnConflict")
+    DELETE_ON_CONFLICT,
+    @SerializedName("TimeBasedResolution")
+    TIME_BASED_RESOLUTION;
+  }
+
+  public static Replication of(Function<Builder, ObjectBuilder<Replication>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  public Replication(Builder builder) {
+    this(
+        builder.replicationFactor,
+        builder.asyncEnabled,
+        builder.deletionStrategy);
+  }
+
+  public static class Builder implements ObjectBuilder<Replication> {
+    private Integer replicationFactor;
+    private Boolean asyncEnabled;
+    private DeletionStrategy deletionStrategy;
+
+    public Builder replicationFactor(int replicationFactor) {
+      this.replicationFactor = replicationFactor;
+      return this;
+    }
+
+    public Builder asyncEnabled(boolean asyncEnabled) {
+      this.asyncEnabled = asyncEnabled;
+      return this;
+    }
+
+    public Builder deletionStrategy(DeletionStrategy deletionStrategy) {
+      this.deletionStrategy = deletionStrategy;
+      return this;
+    }
+
+    @Override
+    public Replication build() {
+      return new Replication(this);
+    }
+  }
+}

--- a/src/main/java/io/weaviate/client6/v1/api/collections/Reranker.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/Reranker.java
@@ -1,0 +1,110 @@
+package io.weaviate.client6.v1.api.collections;
+
+import java.io.IOException;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import io.weaviate.client6.v1.api.collections.rerankers.CohereReranker;
+import io.weaviate.client6.v1.internal.ObjectBuilder;
+import io.weaviate.client6.v1.internal.json.JsonEnum;
+
+public interface Reranker {
+  public enum Kind implements JsonEnum<Kind> {
+    COHERE("reranker-cohere");
+
+    private static final Map<String, Kind> jsonValueMap = JsonEnum.collectNames(Kind.values());
+    private final String jsonValue;
+
+    private Kind(String jsonValue) {
+      this.jsonValue = jsonValue;
+    }
+
+    @Override
+    public String jsonValue() {
+      return this.jsonValue;
+    }
+
+    public static Kind valueOfJson(String jsonValue) {
+      return JsonEnum.valueOfJson(jsonValue, jsonValueMap, Kind.class);
+    }
+  }
+
+  Kind _kind();
+
+  Object _self();
+
+  public static Reranker cohere() {
+    return CohereReranker.of();
+  }
+
+  public static Reranker cohere(Function<CohereReranker.Builder, ObjectBuilder<CohereReranker>> fn) {
+    return CohereReranker.of(fn);
+  }
+
+  public static enum CustomTypeAdapterFactory implements TypeAdapterFactory {
+    INSTANCE;
+
+    private static final EnumMap<Reranker.Kind, TypeAdapter<? extends Reranker>> readAdapters = new EnumMap<>(
+        Reranker.Kind.class);
+
+    private final void addAdapter(Gson gson, Reranker.Kind kind, Class<? extends Reranker> cls) {
+      readAdapters.put(kind, (TypeAdapter<? extends Reranker>) gson.getDelegateAdapter(this, TypeToken.get(cls)));
+    }
+
+    private final void init(Gson gson) {
+      addAdapter(gson, Reranker.Kind.COHERE, CohereReranker.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+      var rawType = type.getRawType();
+      if (!Reranker.class.isAssignableFrom(rawType)) {
+        return null;
+      }
+
+      if (readAdapters.isEmpty()) {
+        init(gson);
+      }
+
+      final TypeAdapter<T> writeAdapter = (TypeAdapter<T>) gson.getDelegateAdapter(this, TypeToken.get(rawType));
+      return (TypeAdapter<T>) new TypeAdapter<Reranker>() {
+
+        @Override
+        public void write(JsonWriter out, Reranker value) throws IOException {
+          out.beginObject();
+          out.name(value._kind().jsonValue());
+          writeAdapter.write(out, (T) value._self());
+          out.endObject();
+        }
+
+        @Override
+        public Reranker read(JsonReader in) throws IOException {
+          in.beginObject();
+          var rerankerName = in.nextName();
+          try {
+            var kind = Reranker.Kind.valueOfJson(rerankerName);
+            var adapter = readAdapters.get(kind);
+            return adapter.read(in);
+          } catch (IllegalArgumentException e) {
+            return null;
+          } finally {
+            if (in.peek() == JsonToken.BEGIN_OBJECT) {
+              in.beginObject();
+            }
+            in.endObject();
+          }
+        }
+      }.nullSafe();
+    }
+  }
+}

--- a/src/main/java/io/weaviate/client6/v1/api/collections/Sharding.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/Sharding.java
@@ -1,0 +1,50 @@
+package io.weaviate.client6.v1.api.collections;
+
+import java.util.function.Function;
+
+import com.google.gson.annotations.SerializedName;
+
+import io.weaviate.client6.v1.internal.ObjectBuilder;
+
+public record Sharding(
+    @SerializedName("virtualPerPhysical") Integer virtualPerPhysical,
+    @SerializedName("desiredCound") Integer desiredCount,
+    @SerializedName("desiredVirtualCount") Integer desiredVirtualCount) {
+
+  public static Sharding of(Function<Builder, ObjectBuilder<Sharding>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  public Sharding(Builder builder) {
+    this(
+        builder.virtualPerPhysical,
+        builder.desiredCount,
+        builder.desiredVirtualCount);
+  }
+
+  public static class Builder implements ObjectBuilder<Sharding> {
+    private Integer virtualPerPhysical;
+    private Integer desiredCount;
+    private Integer desiredVirtualCount;
+
+    public Builder virtualPerPhysical(int virtualPerPhysical) {
+      this.virtualPerPhysical = virtualPerPhysical;
+      return this;
+    }
+
+    public Builder desiredCount(int desiredCount) {
+      this.desiredCount = desiredCount;
+      return this;
+    }
+
+    public Builder desiredVirtualCount(int desiredVirtualCount) {
+      this.desiredVirtualCount = desiredVirtualCount;
+      return this;
+    }
+
+    @Override
+    public Sharding build() {
+      return new Sharding(this);
+    }
+  }
+}

--- a/src/main/java/io/weaviate/client6/v1/api/collections/WeaviateCollection.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/WeaviateCollection.java
@@ -10,6 +10,7 @@ import java.util.function.Function;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
@@ -22,7 +23,7 @@ import com.google.gson.stream.JsonWriter;
 import io.weaviate.client6.v1.internal.ObjectBuilder;
 
 public record WeaviateCollection(
-    @SerializedName("class") String name,
+    @SerializedName("class") String collectionName,
     @SerializedName("description") String description,
     @SerializedName("properties") List<Property> properties,
     List<ReferenceProperty> references,
@@ -34,6 +35,23 @@ public record WeaviateCollection(
 
   public static WeaviateCollection of(String collectionName, Function<Builder, ObjectBuilder<WeaviateCollection>> fn) {
     return fn.apply(new Builder(collectionName)).build();
+  }
+
+  /**
+   * Returns a {@link Builder} with all current values of
+   * {@code WeaviateCollection} pre-filled.
+   */
+  public Builder edit() {
+    return new Builder(collectionName)
+        .description(description)
+        .properties(properties)
+        .references(references)
+        .vectors(vectors);
+  }
+
+  /** Create a copy of this {@code WeaviateCollection} and edit parts of it. */
+  public WeaviateCollection edit(Function<Builder, ObjectBuilder<WeaviateCollection>> fn) {
+    return fn.apply(edit()).build();
   }
 
   public WeaviateCollection(Builder builder) {
@@ -68,7 +86,7 @@ public record WeaviateCollection(
     }
 
     public Builder properties(List<Property> properties) {
-      this.properties = properties;
+      this.properties.addAll(properties);
       return this;
     }
 
@@ -77,7 +95,7 @@ public record WeaviateCollection(
     }
 
     public Builder references(List<ReferenceProperty> references) {
-      this.references = references;
+      this.references.addAll(references);
       return this;
     }
 
@@ -88,6 +106,11 @@ public record WeaviateCollection(
 
     public Builder vector(String name, VectorIndex vector) {
       this.vectors.put(name, vector);
+      return this;
+    }
+
+    public Builder vectors(Map<String, VectorIndex> vectors) {
+      this.vectors.putAll(vectors);
       return this;
     }
 
@@ -159,6 +182,11 @@ public record WeaviateCollection(
 
           jsonObject.add("properties", properties);
           jsonObject.add("references", references);
+
+          if (!jsonObject.has("vectorConfig")) {
+            jsonObject.add("vectorConfig", new JsonObject());
+          }
+
           return delegate.fromJsonTree(jsonObject);
         }
       }.nullSafe();

--- a/src/main/java/io/weaviate/client6/v1/api/collections/WeaviateCollectionsClient.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/WeaviateCollectionsClient.java
@@ -52,7 +52,7 @@ public class WeaviateCollectionsClient {
 
   public void deleteAll() throws IOException {
     for (var collection : list()) {
-      delete(collection.name());
+      delete(collection.collectionName());
     }
   }
 

--- a/src/main/java/io/weaviate/client6/v1/api/collections/WeaviateCollectionsClient.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/WeaviateCollectionsClient.java
@@ -24,25 +24,25 @@ public class WeaviateCollectionsClient {
     return new CollectionHandle<>(restTransport, grpcTransport, CollectionDescriptor.ofMap(collectionName));
   }
 
-  public WeaviateCollection create(String name) throws IOException {
-    return create(WeaviateCollection.of(name));
+  public CollectionConfig create(String name) throws IOException {
+    return create(CollectionConfig.of(name));
   }
 
-  public WeaviateCollection create(String name,
-      Function<WeaviateCollection.Builder, ObjectBuilder<WeaviateCollection>> fn) throws IOException {
-    return create(WeaviateCollection.of(name, fn));
+  public CollectionConfig create(String name,
+      Function<CollectionConfig.Builder, ObjectBuilder<CollectionConfig>> fn) throws IOException {
+    return create(CollectionConfig.of(name, fn));
   }
 
-  public WeaviateCollection create(WeaviateCollection collection) throws IOException {
+  public CollectionConfig create(CollectionConfig collection) throws IOException {
     return this.restTransport.performRequest(new CreateCollectionRequest(collection),
         CreateCollectionRequest._ENDPOINT);
   }
 
-  public Optional<WeaviateCollection> getConfig(String name) throws IOException {
+  public Optional<CollectionConfig> getConfig(String name) throws IOException {
     return this.restTransport.performRequest(new GetConfigRequest(name), GetConfigRequest._ENDPOINT);
   }
 
-  public List<WeaviateCollection> list() throws IOException {
+  public List<CollectionConfig> list() throws IOException {
     return this.restTransport.performRequest(new ListCollectionRequest(), ListCollectionRequest._ENDPOINT);
   }
 

--- a/src/main/java/io/weaviate/client6/v1/api/collections/WeaviateCollectionsClientAsync.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/WeaviateCollectionsClientAsync.java
@@ -26,25 +26,25 @@ public class WeaviateCollectionsClientAsync {
         CollectionDescriptor.ofMap(collectionName));
   }
 
-  public CompletableFuture<WeaviateCollection> create(String name) {
-    return create(WeaviateCollection.of(name));
+  public CompletableFuture<CollectionConfig> create(String name) {
+    return create(CollectionConfig.of(name));
   }
 
-  public CompletableFuture<WeaviateCollection> create(String name,
-      Function<WeaviateCollection.Builder, ObjectBuilder<WeaviateCollection>> fn) {
-    return create(WeaviateCollection.of(name, fn));
+  public CompletableFuture<CollectionConfig> create(String name,
+      Function<CollectionConfig.Builder, ObjectBuilder<CollectionConfig>> fn) {
+    return create(CollectionConfig.of(name, fn));
   }
 
-  public CompletableFuture<WeaviateCollection> create(WeaviateCollection collection) {
+  public CompletableFuture<CollectionConfig> create(CollectionConfig collection) {
     return this.restTransport.performRequestAsync(new CreateCollectionRequest(collection),
         CreateCollectionRequest._ENDPOINT);
   }
 
-  public CompletableFuture<Optional<WeaviateCollection>> getConfig(String name) {
+  public CompletableFuture<Optional<CollectionConfig>> getConfig(String name) {
     return this.restTransport.performRequestAsync(new GetConfigRequest(name), GetConfigRequest._ENDPOINT);
   }
 
-  public CompletableFuture<List<WeaviateCollection>> list() {
+  public CompletableFuture<List<CollectionConfig>> list() {
     return this.restTransport.performRequestAsync(new ListCollectionRequest(), ListCollectionRequest._ENDPOINT);
   }
 

--- a/src/main/java/io/weaviate/client6/v1/api/collections/WeaviateCollectionsClientAsync.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/WeaviateCollectionsClientAsync.java
@@ -55,7 +55,7 @@ public class WeaviateCollectionsClientAsync {
   public CompletableFuture<Void> deleteAll() throws IOException {
     return list().thenCompose(collections -> {
       var futures = collections.stream()
-          .map(collection -> delete(collection.name()))
+          .map(collection -> delete(collection.collectionName()))
           .toArray(CompletableFuture[]::new);
       return CompletableFuture.allOf(futures);
     });

--- a/src/main/java/io/weaviate/client6/v1/api/collections/config/UpdateCollectionRequest.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/config/UpdateCollectionRequest.java
@@ -6,13 +6,13 @@ import java.util.function.Function;
 
 import org.apache.hc.core5.http.HttpStatus;
 
+import io.weaviate.client6.v1.api.collections.CollectionConfig;
 import io.weaviate.client6.v1.api.collections.VectorIndex;
-import io.weaviate.client6.v1.api.collections.WeaviateCollection;
 import io.weaviate.client6.v1.internal.ObjectBuilder;
 import io.weaviate.client6.v1.internal.json.JSON;
 import io.weaviate.client6.v1.internal.rest.Endpoint;
 
-public record UpdateCollectionRequest(WeaviateCollection collection) {
+public record UpdateCollectionRequest(CollectionConfig collection) {
 
   public static final Endpoint<UpdateCollectionRequest, Void> _ENDPOINT = Endpoint.of(
       request -> "PUT",
@@ -22,7 +22,7 @@ public record UpdateCollectionRequest(WeaviateCollection collection) {
       code -> code != HttpStatus.SC_SUCCESS,
       (gson, response) -> null);
 
-  public static UpdateCollectionRequest of(WeaviateCollection collection,
+  public static UpdateCollectionRequest of(CollectionConfig collection,
       Function<Builder, ObjectBuilder<UpdateCollectionRequest>> fn) {
     return fn.apply(new Builder(collection)).build();
   }
@@ -32,10 +32,10 @@ public record UpdateCollectionRequest(WeaviateCollection collection) {
   }
 
   public static class Builder implements ObjectBuilder<UpdateCollectionRequest> {
-    private final WeaviateCollection currentCollection;
-    private final WeaviateCollection.Builder newCollection;
+    private final CollectionConfig currentCollection;
+    private final CollectionConfig.Builder newCollection;
 
-    public Builder(WeaviateCollection currentCollection) {
+    public Builder(CollectionConfig currentCollection) {
       this.currentCollection = currentCollection;
       this.newCollection = currentCollection.edit();
     }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/config/UpdateCollectionRequest.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/config/UpdateCollectionRequest.java
@@ -16,34 +16,38 @@ public record UpdateCollectionRequest(WeaviateCollection collection) {
 
   public static final Endpoint<UpdateCollectionRequest, Void> _ENDPOINT = Endpoint.of(
       request -> "PUT",
-      request -> "/schema/" + request.collection.name(),
+      request -> "/schema/" + request.collection.collectionName(),
       (gson, request) -> JSON.serialize(request.collection),
       request -> Collections.emptyMap(),
       code -> code != HttpStatus.SC_SUCCESS,
       (gson, response) -> null);
 
-  public static UpdateCollectionRequest of(String collectionName,
+  public static UpdateCollectionRequest of(WeaviateCollection collection,
       Function<Builder, ObjectBuilder<UpdateCollectionRequest>> fn) {
-    return fn.apply(new Builder(collectionName)).build();
+    return fn.apply(new Builder(collection)).build();
   }
 
   public UpdateCollectionRequest(Builder builder) {
-    this(builder.collection.build());
+    this(builder.newCollection.build());
   }
 
   public static class Builder implements ObjectBuilder<UpdateCollectionRequest> {
-    private final WeaviateCollection.Builder collection;
+    private final WeaviateCollection currentCollection;
+    private final WeaviateCollection.Builder newCollection;
 
-    public Builder(String collectionName) {
-      this.collection = new WeaviateCollection.Builder(collectionName);
+    public Builder(WeaviateCollection currentCollection) {
+      this.currentCollection = currentCollection;
+      this.newCollection = currentCollection.edit();
     }
 
     public Builder description(String description) {
-      this.collection.description(description);
+      this.newCollection.description(description);
       return this;
     }
 
-    public Builder vectors(Map.Entry<String, VectorIndex> vector) {
+    @SafeVarargs
+    public final Builder vectors(Map.Entry<String, VectorIndex>... vectors) {
+      this.newCollection.vectors(Map.ofEntries(vectors));
       return this;
     }
 

--- a/src/main/java/io/weaviate/client6/v1/api/collections/config/UpdateCollectionRequest.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/config/UpdateCollectionRequest.java
@@ -1,0 +1,61 @@
+package io.weaviate.client6.v1.api.collections.config;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.apache.hc.core5.http.HttpStatus;
+
+import io.weaviate.client6.v1.api.collections.VectorIndex;
+import io.weaviate.client6.v1.api.collections.WeaviateCollection;
+import io.weaviate.client6.v1.internal.ObjectBuilder;
+import io.weaviate.client6.v1.internal.json.JSON;
+import io.weaviate.client6.v1.internal.rest.Endpoint;
+
+public record UpdateCollectionRequest(WeaviateCollection collection) {
+
+  public static final Endpoint<UpdateCollectionRequest, Void> _ENDPOINT = Endpoint.of(
+      request -> "PUT",
+      request -> "/schema/" + request.collection.name(),
+      (gson, request) -> JSON.serialize(request.collection),
+      request -> Collections.emptyMap(),
+      code -> code != HttpStatus.SC_SUCCESS,
+      (gson, response) -> null);
+
+  public static UpdateCollectionRequest of(String collectionName,
+      Function<Builder, ObjectBuilder<UpdateCollectionRequest>> fn) {
+    return fn.apply(new Builder(collectionName)).build();
+  }
+
+  public UpdateCollectionRequest(Builder builder) {
+    this(builder.collection.build());
+  }
+
+  public static class Builder implements ObjectBuilder<UpdateCollectionRequest> {
+    private final WeaviateCollection.Builder collection;
+
+    public Builder(String collectionName) {
+      this.collection = new WeaviateCollection.Builder(collectionName);
+    }
+
+    public Builder description(String description) {
+      this.collection.description(description);
+      return this;
+    }
+
+    public Builder vectors(Map.Entry<String, VectorIndex> vector) {
+      return this;
+    }
+
+    // TODO: propertyDescriptions
+    // TODO: generative config
+    // TODO: inverted index
+    // TODO: replication
+    // TODO: reranker
+
+    @Override
+    public UpdateCollectionRequest build() {
+      return new UpdateCollectionRequest(this);
+    }
+  }
+}

--- a/src/main/java/io/weaviate/client6/v1/api/collections/config/UpdateCollectionRequest.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/config/UpdateCollectionRequest.java
@@ -93,13 +93,8 @@ public record UpdateCollectionRequest(CollectionConfig collection) {
       return this;
     }
 
-    public Builder generativeModules(Generative... generativeModules) {
-      this.newCollection.generativeModules(generativeModules);
-      return this;
-    }
-
-    public Builder generativeModules(List<Generative> generativeModules) {
-      this.newCollection.generativeModules(generativeModules);
+    public Builder generativeModule(Generative generativeModule) {
+      this.newCollection.generativeModule(generativeModule);
       return this;
     }
 

--- a/src/main/java/io/weaviate/client6/v1/api/collections/config/UpdateCollectionRequest.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/config/UpdateCollectionRequest.java
@@ -1,12 +1,17 @@
 package io.weaviate.client6.v1.api.collections.config;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
 import org.apache.hc.core5.http.HttpStatus;
 
 import io.weaviate.client6.v1.api.collections.CollectionConfig;
+import io.weaviate.client6.v1.api.collections.Generative;
+import io.weaviate.client6.v1.api.collections.InvertedIndex;
+import io.weaviate.client6.v1.api.collections.Replication;
+import io.weaviate.client6.v1.api.collections.Reranker;
 import io.weaviate.client6.v1.api.collections.VectorIndex;
 import io.weaviate.client6.v1.internal.ObjectBuilder;
 import io.weaviate.client6.v1.internal.json.JSON;
@@ -32,7 +37,9 @@ public record UpdateCollectionRequest(CollectionConfig collection) {
   }
 
   public static class Builder implements ObjectBuilder<UpdateCollectionRequest> {
+    // For updating property descriptions
     private final CollectionConfig currentCollection;
+    // Builder for the updated collection config.
     private final CollectionConfig.Builder newCollection;
 
     public Builder(CollectionConfig currentCollection) {
@@ -45,17 +52,62 @@ public record UpdateCollectionRequest(CollectionConfig collection) {
       return this;
     }
 
+    public Builder propertyDescription(String propertyName, String description) {
+      for (var property : currentCollection.properties()) {
+        if (property.propertyName().equals(propertyName)) {
+          var newProperty = property.edit(p -> p.description(description));
+          this.newCollection.properties(newProperty);
+          break;
+        }
+      }
+      return this;
+    }
+
+    public Builder replication(Replication replication) {
+      this.newCollection.replication(replication);
+      return this;
+    }
+
+    public Builder replication(Function<Replication.Builder, ObjectBuilder<Replication>> fn) {
+      this.newCollection.replication(fn);
+      return this;
+    }
+
+    public Builder invertedIndex(InvertedIndex invertedIndex) {
+      this.newCollection.invertedIndex(invertedIndex);
+      return this;
+    }
+
+    public Builder invertedIndex(Function<InvertedIndex.Builder, ObjectBuilder<InvertedIndex>> fn) {
+      this.newCollection.invertedIndex(fn);
+      return this;
+    }
+
+    public Builder rerankerModules(Reranker... rerankerModules) {
+      this.newCollection.rerankerModules(rerankerModules);
+      return this;
+    }
+
+    public Builder rerankerModules(List<Reranker> rerankerModules) {
+      this.newCollection.rerankerModules(rerankerModules);
+      return this;
+    }
+
+    public Builder generativeModules(Generative... generativeModules) {
+      this.newCollection.generativeModules(generativeModules);
+      return this;
+    }
+
+    public Builder generativeModules(List<Generative> generativeModules) {
+      this.newCollection.generativeModules(generativeModules);
+      return this;
+    }
+
     @SafeVarargs
     public final Builder vectors(Map.Entry<String, VectorIndex>... vectors) {
       this.newCollection.vectors(Map.ofEntries(vectors));
       return this;
     }
-
-    // TODO: propertyDescriptions
-    // TODO: generative config
-    // TODO: inverted index
-    // TODO: replication
-    // TODO: reranker
 
     @Override
     public UpdateCollectionRequest build() {

--- a/src/main/java/io/weaviate/client6/v1/api/collections/config/WeaviateConfigClient.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/config/WeaviateConfigClient.java
@@ -41,7 +41,9 @@ public class WeaviateConfigClient {
 
   public void update(String collectionName,
       Function<UpdateCollectionRequest.Builder, ObjectBuilder<UpdateCollectionRequest>> fn) throws IOException {
-    this.restTransport.performRequest(UpdateCollectionRequest.of(collectionName, fn),
+    var thisCollection = get().orElseThrow(); // TODO: use descriptive error
+    System.out.println("got");
+    this.restTransport.performRequest(UpdateCollectionRequest.of(thisCollection, fn),
         UpdateCollectionRequest._ENDPOINT);
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/config/WeaviateConfigClient.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/config/WeaviateConfigClient.java
@@ -4,8 +4,8 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.function.Function;
 
+import io.weaviate.client6.v1.api.collections.CollectionConfig;
 import io.weaviate.client6.v1.api.collections.Property;
-import io.weaviate.client6.v1.api.collections.WeaviateCollection;
 import io.weaviate.client6.v1.api.collections.WeaviateCollectionsClient;
 import io.weaviate.client6.v1.internal.ObjectBuilder;
 import io.weaviate.client6.v1.internal.grpc.GrpcTransport;
@@ -26,7 +26,7 @@ public class WeaviateConfigClient {
     this.collection = collection;
   }
 
-  public Optional<WeaviateCollection> get() throws IOException {
+  public Optional<CollectionConfig> get() throws IOException {
     return collectionsClient.getConfig(collection.name());
   }
 
@@ -42,7 +42,6 @@ public class WeaviateConfigClient {
   public void update(String collectionName,
       Function<UpdateCollectionRequest.Builder, ObjectBuilder<UpdateCollectionRequest>> fn) throws IOException {
     var thisCollection = get().orElseThrow(); // TODO: use descriptive error
-    System.out.println("got");
     this.restTransport.performRequest(UpdateCollectionRequest.of(thisCollection, fn),
         UpdateCollectionRequest._ENDPOINT);
   }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/config/WeaviateConfigClient.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/config/WeaviateConfigClient.java
@@ -2,23 +2,25 @@ package io.weaviate.client6.v1.api.collections.config;
 
 import java.io.IOException;
 import java.util.Optional;
+import java.util.function.Function;
 
 import io.weaviate.client6.v1.api.collections.Property;
 import io.weaviate.client6.v1.api.collections.WeaviateCollection;
 import io.weaviate.client6.v1.api.collections.WeaviateCollectionsClient;
+import io.weaviate.client6.v1.internal.ObjectBuilder;
 import io.weaviate.client6.v1.internal.grpc.GrpcTransport;
 import io.weaviate.client6.v1.internal.orm.CollectionDescriptor;
 import io.weaviate.client6.v1.internal.rest.RestTransport;
 
 public class WeaviateConfigClient {
-  private final RestTransport transport;
+  private final RestTransport restTransport;
   private final WeaviateCollectionsClient collectionsClient;
 
   protected final CollectionDescriptor<?> collection;
 
   public WeaviateConfigClient(CollectionDescriptor<?> collection, RestTransport restTransport,
       GrpcTransport grpcTransport) {
-    this.transport = restTransport;
+    this.restTransport = restTransport;
     this.collectionsClient = new WeaviateCollectionsClient(restTransport, grpcTransport);
 
     this.collection = collection;
@@ -29,10 +31,17 @@ public class WeaviateConfigClient {
   }
 
   public void addProperty(Property property) throws IOException {
-    this.transport.performRequest(new AddPropertyRequest(collection.name(), property), AddPropertyRequest._ENDPOINT);
+    this.restTransport.performRequest(new AddPropertyRequest(collection.name(), property),
+        AddPropertyRequest._ENDPOINT);
   }
 
-  public void addReference(String name, String... dataTypes) throws IOException {
-    this.addProperty(Property.reference(name, dataTypes).toProperty());
+  public void addReference(String propertyName, String... dataTypes) throws IOException {
+    this.addProperty(Property.reference(propertyName, dataTypes).toProperty());
+  }
+
+  public void update(String collectionName,
+      Function<UpdateCollectionRequest.Builder, ObjectBuilder<UpdateCollectionRequest>> fn) throws IOException {
+    this.restTransport.performRequest(UpdateCollectionRequest.of(collectionName, fn),
+        UpdateCollectionRequest._ENDPOINT);
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/config/WeaviateConfigClientAsync.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/config/WeaviateConfigClientAsync.java
@@ -3,23 +3,25 @@ package io.weaviate.client6.v1.api.collections.config;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 
 import io.weaviate.client6.v1.api.collections.Property;
 import io.weaviate.client6.v1.api.collections.WeaviateCollection;
 import io.weaviate.client6.v1.api.collections.WeaviateCollectionsClientAsync;
+import io.weaviate.client6.v1.internal.ObjectBuilder;
 import io.weaviate.client6.v1.internal.grpc.GrpcTransport;
 import io.weaviate.client6.v1.internal.orm.CollectionDescriptor;
 import io.weaviate.client6.v1.internal.rest.RestTransport;
 
 public class WeaviateConfigClientAsync {
-  private final RestTransport transport;
+  private final RestTransport restTransport;
   private final WeaviateCollectionsClientAsync collectionsClient;
 
   protected final CollectionDescriptor<?> collection;
 
   public WeaviateConfigClientAsync(CollectionDescriptor<?> collection, RestTransport restTransport,
       GrpcTransport grpcTransport) {
-    this.transport = restTransport;
+    this.restTransport = restTransport;
     this.collectionsClient = new WeaviateCollectionsClientAsync(restTransport, grpcTransport);
 
     this.collection = collection;
@@ -30,11 +32,17 @@ public class WeaviateConfigClientAsync {
   }
 
   public CompletableFuture<Void> addProperty(Property property) throws IOException {
-    return this.transport.performRequestAsync(new AddPropertyRequest(collection.name(), property),
+    return this.restTransport.performRequestAsync(new AddPropertyRequest(collection.name(), property),
         AddPropertyRequest._ENDPOINT);
   }
 
   public CompletableFuture<Void> addReference(String name, String... dataTypes) throws IOException {
     return this.addProperty(Property.reference(name, dataTypes).toProperty());
+  }
+
+  public CompletableFuture<Void> update(String collectionName,
+      Function<UpdateCollectionRequest.Builder, ObjectBuilder<UpdateCollectionRequest>> fn) throws IOException {
+    return this.restTransport.performRequestAsync(UpdateCollectionRequest.of(collectionName, fn),
+        UpdateCollectionRequest._ENDPOINT);
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/config/WeaviateConfigClientAsync.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/config/WeaviateConfigClientAsync.java
@@ -5,8 +5,8 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
+import io.weaviate.client6.v1.api.collections.CollectionConfig;
 import io.weaviate.client6.v1.api.collections.Property;
-import io.weaviate.client6.v1.api.collections.WeaviateCollection;
 import io.weaviate.client6.v1.api.collections.WeaviateCollectionsClientAsync;
 import io.weaviate.client6.v1.internal.ObjectBuilder;
 import io.weaviate.client6.v1.internal.grpc.GrpcTransport;
@@ -27,7 +27,7 @@ public class WeaviateConfigClientAsync {
     this.collectionDescriptor = collection;
   }
 
-  public CompletableFuture<Optional<WeaviateCollection>> get() throws IOException {
+  public CompletableFuture<Optional<CollectionConfig>> get() throws IOException {
     return collectionsClient.getConfig(collectionDescriptor.name());
   }
 

--- a/src/main/java/io/weaviate/client6/v1/api/collections/generative/CohereGenerative.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/generative/CohereGenerative.java
@@ -1,0 +1,96 @@
+package io.weaviate.client6.v1.api.collections.generative;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+import com.google.gson.annotations.SerializedName;
+
+import io.weaviate.client6.v1.api.collections.Generative;
+import io.weaviate.client6.v1.internal.ObjectBuilder;
+
+public record CohereGenerative(
+    @SerializedName("kProperty") String kProperty,
+    @SerializedName("model") String model,
+    @SerializedName("maxTokensProperty") Integer maxTokensProperty,
+    @SerializedName("returnLikelihoodsProperty") String returnLikelihoodsProperty,
+    @SerializedName("stopSequencesProperty") List<String> stopSequencesProperty,
+    @SerializedName("temperatureProperty") String temperatureProperty) implements Generative {
+
+  @Override
+  public Kind _kind() {
+    return Generative.Kind.COHERE;
+  }
+
+  @Override
+  public Object _self() {
+    return this;
+  }
+
+  public static CohereGenerative of() {
+    return of(ObjectBuilder.identity());
+  }
+
+  public static CohereGenerative of(Function<Builder, ObjectBuilder<CohereGenerative>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  public CohereGenerative(Builder builder) {
+    this(
+        builder.kProperty,
+        builder.model,
+        builder.maxTokensProperty,
+        builder.returnLikelihoodsProperty,
+        builder.stopSequencesProperty,
+        builder.temperatureProperty);
+  }
+
+  public static class Builder implements ObjectBuilder<CohereGenerative> {
+    private String kProperty;
+    private String model;
+    private Integer maxTokensProperty;
+    private String returnLikelihoodsProperty;
+    private List<String> stopSequencesProperty = new ArrayList<>();
+    private String temperatureProperty;
+
+    public Builder kProperty(String kProperty) {
+      this.kProperty = kProperty;
+      return this;
+    }
+
+    public Builder model(String model) {
+      this.model = model;
+      return this;
+    }
+
+    public Builder maxTokensProperty(int maxTokensProperty) {
+      this.maxTokensProperty = maxTokensProperty;
+      return this;
+    }
+
+    public Builder returnLikelihoodsProperty(String returnLikelihoodsProperty) {
+      this.returnLikelihoodsProperty = returnLikelihoodsProperty;
+      return this;
+    }
+
+    public Builder stopSequencesProperty(String... stopSequencesProperty) {
+      return stopSequencesProperty(Arrays.asList(stopSequencesProperty));
+    }
+
+    public Builder stopSequencesProperty(List<String> stopSequencesProperty) {
+      this.stopSequencesProperty = stopSequencesProperty;
+      return this;
+    }
+
+    public Builder temperatureProperty(String temperatureProperty) {
+      this.temperatureProperty = temperatureProperty;
+      return this;
+    }
+
+    @Override
+    public CohereGenerative build() {
+      return new CohereGenerative(this);
+    }
+  }
+}

--- a/src/main/java/io/weaviate/client6/v1/api/collections/rerankers/CohereReranker.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/rerankers/CohereReranker.java
@@ -1,0 +1,51 @@
+package io.weaviate.client6.v1.api.collections.rerankers;
+
+import java.util.function.Function;
+
+import com.google.gson.annotations.SerializedName;
+
+import io.weaviate.client6.v1.api.collections.Reranker;
+import io.weaviate.client6.v1.internal.ObjectBuilder;
+
+public record CohereReranker(
+    @SerializedName("model") String model) implements Reranker {
+
+  public static final String RERANK_ENGLISH_V2 = "rerank-english-v2.0";
+  public static final String RERANK_MULTILINGUAL_V2 = "rerank-mulilingual-v2.0";
+
+  @Override
+  public Kind _kind() {
+    return Reranker.Kind.COHERE;
+  }
+
+  @Override
+  public Object _self() {
+    return this;
+  }
+
+  public static CohereReranker of() {
+    return of(ObjectBuilder.identity());
+  }
+
+  public static CohereReranker of(Function<Builder, ObjectBuilder<CohereReranker>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  public CohereReranker(Builder builder) {
+    this(builder.model);
+  }
+
+  public static class Builder implements ObjectBuilder<CohereReranker> {
+    private String model;
+
+    public Builder model(String model) {
+      this.model = model;
+      return this;
+    }
+
+    @Override
+    public CohereReranker build() {
+      return new CohereReranker(this);
+    }
+  }
+}

--- a/src/main/java/io/weaviate/client6/v1/internal/json/JSON.java
+++ b/src/main/java/io/weaviate/client6/v1/internal/json/JSON.java
@@ -12,7 +12,7 @@ public final class JSON {
     gsonBuilder.registerTypeAdapterFactory(
         io.weaviate.client6.v1.api.collections.WeaviateObject.CustomTypeAdapterFactory.INSTANCE);
     gsonBuilder.registerTypeAdapterFactory(
-        io.weaviate.client6.v1.api.collections.WeaviateCollection.CustomTypeAdapterFactory.INSTANCE);
+        io.weaviate.client6.v1.api.collections.CollectionConfig.CustomTypeAdapterFactory.INSTANCE);
     gsonBuilder.registerTypeAdapterFactory(
         io.weaviate.client6.v1.api.collections.Vectors.CustomTypeAdapterFactory.INSTANCE);
     gsonBuilder.registerTypeAdapterFactory(

--- a/src/main/java/io/weaviate/client6/v1/internal/json/JSON.java
+++ b/src/main/java/io/weaviate/client6/v1/internal/json/JSON.java
@@ -19,6 +19,10 @@ public final class JSON {
         io.weaviate.client6.v1.api.collections.Vectorizer.CustomTypeAdapterFactory.INSTANCE);
     gsonBuilder.registerTypeAdapterFactory(
         io.weaviate.client6.v1.api.collections.VectorIndex.CustomTypeAdapterFactory.INSTANCE);
+    gsonBuilder.registerTypeAdapterFactory(
+        io.weaviate.client6.v1.api.collections.Reranker.CustomTypeAdapterFactory.INSTANCE);
+    gsonBuilder.registerTypeAdapterFactory(
+        io.weaviate.client6.v1.api.collections.Generative.CustomTypeAdapterFactory.INSTANCE);
 
     gsonBuilder.registerTypeAdapter(
         io.weaviate.client6.v1.api.collections.vectorizers.NoneVectorizer.class,

--- a/src/test/java/io/weaviate/client6/v1/internal/json/JSONTest.java
+++ b/src/test/java/io/weaviate/client6/v1/internal/json/JSONTest.java
@@ -15,13 +15,16 @@ import com.jparams.junit4.JParamsTestRunner;
 import com.jparams.junit4.data.DataMethod;
 
 import io.weaviate.client6.v1.api.collections.CollectionConfig;
+import io.weaviate.client6.v1.api.collections.Generative;
 import io.weaviate.client6.v1.api.collections.ObjectMetadata;
 import io.weaviate.client6.v1.api.collections.Property;
+import io.weaviate.client6.v1.api.collections.Reranker;
 import io.weaviate.client6.v1.api.collections.VectorIndex;
 import io.weaviate.client6.v1.api.collections.Vectorizer;
 import io.weaviate.client6.v1.api.collections.Vectors;
 import io.weaviate.client6.v1.api.collections.WeaviateObject;
 import io.weaviate.client6.v1.api.collections.data.Reference;
+import io.weaviate.client6.v1.api.collections.rerankers.CohereReranker;
 import io.weaviate.client6.v1.api.collections.vectorindex.Distance;
 import io.weaviate.client6.v1.api.collections.vectorindex.Flat;
 import io.weaviate.client6.v1.api.collections.vectorindex.Hnsw;
@@ -246,6 +249,43 @@ public class JSONTest {
                     "hasRef": [{"beacon": "weaviate://localhost/ref-1"}]
                   },
                   "id": "thing-1"
+                }
+                  """,
+        },
+
+        // Reranker.CustomTypeAdapterFactory
+        {
+            Reranker.class,
+            Reranker.cohere(rerank -> rerank
+                .model(CohereReranker.RERANK_ENGLISH_V2)),
+            """
+                {
+                  "reranker-cohere": {
+                    "model": "rerank-english-v2.0"
+                  }
+                }
+                  """,
+        },
+
+        {
+            Generative.class,
+            Generative.cohere(generate -> generate
+                .kProperty("k-property")
+                .maxTokensProperty(10)
+                .model("example-model")
+                .returnLikelihoodsProperty("likelihood")
+                .stopSequencesProperty("stop", "halt")
+                .temperatureProperty("celcius")),
+            """
+                {
+                  "generative-cohere": {
+                    "kProperty": "k-property",
+                    "maxTokensProperty": 10,
+                    "model": "example-model",
+                    "returnLikelihoodsProperty": "likelihood",
+                    "stopSequencesProperty": ["stop", "halt"],
+                    "temperatureProperty": "celcius"
+                  }
                 }
                   """,
         },

--- a/src/test/java/io/weaviate/client6/v1/internal/json/JSONTest.java
+++ b/src/test/java/io/weaviate/client6/v1/internal/json/JSONTest.java
@@ -14,12 +14,12 @@ import com.google.gson.reflect.TypeToken;
 import com.jparams.junit4.JParamsTestRunner;
 import com.jparams.junit4.data.DataMethod;
 
+import io.weaviate.client6.v1.api.collections.CollectionConfig;
 import io.weaviate.client6.v1.api.collections.ObjectMetadata;
 import io.weaviate.client6.v1.api.collections.Property;
 import io.weaviate.client6.v1.api.collections.VectorIndex;
 import io.weaviate.client6.v1.api.collections.Vectorizer;
 import io.weaviate.client6.v1.api.collections.Vectors;
-import io.weaviate.client6.v1.api.collections.WeaviateCollection;
 import io.weaviate.client6.v1.api.collections.WeaviateObject;
 import io.weaviate.client6.v1.api.collections.data.Reference;
 import io.weaviate.client6.v1.api.collections.vectorindex.Distance;
@@ -184,8 +184,8 @@ public class JSONTest {
 
         // WeaviateCollection.CustomTypeAdapterFactory
         {
-            WeaviateCollection.class,
-            WeaviateCollection.of("Things", things -> things
+            CollectionConfig.class,
+            CollectionConfig.of("Things", things -> things
                 .description("A collection of things")
                 .properties(
                     Property.text("shape"),


### PR DESCRIPTION
This PR extends collection / property configuration parameters and adds the ability for updating this configuration.

```java
final var things = client.collection.use("Things");

things.config.update(collection -> collection
  .description("felt cute might delete later")
  .invertedIndex(idx -> idx.cleanupIntervalSeconds(30)
  .replication(repl -> repl.asyncEnabled(true))
  .propertyDescription("name", "what the thing is called"));
```

[Implementation detail]: Internally this is enabled by 2 handy methods that both `Property` and `CollectionConfig` have: "edit".

```java
// Create config builder that has existing properties pre-filled.
var newConfigBuilder = oldConfig.edit();
newConfigBuilder.generativeModules(Generative.cohere());

// Creates a copy of the config object with changes applied.
var newConfig = oldConfig.edit(config -> config.rerankerModules(Reranker.cohere()));
```

Miscellaneous changes:
- rename Property::name to Property::propertyName to avoid ambiguity (same for ReferenceProperty::propertyName)
- rename WeaviateCollection to CollectionConfig
- updated target Weaviate version to `1.29.1` (allows updating property descriptions)
-  