### PR TITLE
v6: Improved configuration options for WeaviateClient(-Async)

### DIFF
--- a/src/main/java/io/weaviate/client6/v1/api/WeaviateClient.java
+++ b/src/main/java/io/weaviate/client6/v1/api/WeaviateClient.java
@@ -37,18 +37,21 @@ public class WeaviateClient implements Closeable {
   }
 
   public static WeaviateClient local(Function<Config.Local, ObjectBuilder<Config>> fn) {
-    var config = new Config.Local();
-    return new WeaviateClient(fn.apply(config).build());
+    return new WeaviateClient(fn.apply(new Config.Local()).build());
   }
 
-  public static WeaviateClient wcd(String clusterUrl, String apiKey) {
-    return wcd(clusterUrl, apiKey, ObjectBuilder.identity());
+  public static WeaviateClient wcd(String httpHost, String apiKey) {
+    return wcd(httpHost, apiKey, ObjectBuilder.identity());
   }
 
-  public static WeaviateClient wcd(String clusterUrl, String apiKey,
+  public static WeaviateClient wcd(String httpHost, String apiKey,
       Function<Config.WeaviateCloud, ObjectBuilder<Config>> fn) {
-    var config = new Config.WeaviateCloud(clusterUrl, Authorization.apiKey(apiKey));
+    var config = new Config.WeaviateCloud(httpHost, Authorization.apiKey(apiKey));
     return new WeaviateClient(fn.apply(config).build());
+  }
+
+  public static WeaviateClient custom(Function<Config.Custom, ObjectBuilder<Config>> fn) {
+    return new WeaviateClient(fn.apply(new Config.Custom()).build());
   }
 
   @Override

--- a/src/main/java/io/weaviate/client6/v1/api/WeaviateClientAsync.java
+++ b/src/main/java/io/weaviate/client6/v1/api/WeaviateClientAsync.java
@@ -29,18 +29,21 @@ public class WeaviateClientAsync implements Closeable {
   }
 
   public static WeaviateClientAsync local(Function<Config.Local, ObjectBuilder<Config>> fn) {
-    var config = new Config.Local();
-    return new WeaviateClientAsync(fn.apply(config).build());
+    return new WeaviateClientAsync(fn.apply(new Config.Local()).build());
   }
 
-  public static WeaviateClientAsync wcd(String clusterUrl, String apiKey) {
-    return wcd(clusterUrl, apiKey, ObjectBuilder.identity());
+  public static WeaviateClientAsync wcd(String httpHost, String apiKey) {
+    return wcd(httpHost, apiKey, ObjectBuilder.identity());
   }
 
-  public static WeaviateClientAsync wcd(String clusterUrl, String apiKey,
+  public static WeaviateClientAsync wcd(String httpHost, String apiKey,
       Function<Config.WeaviateCloud, ObjectBuilder<Config>> fn) {
-    var config = new Config.WeaviateCloud(clusterUrl, Authorization.apiKey(apiKey));
+    var config = new Config.WeaviateCloud(httpHost, Authorization.apiKey(apiKey));
     return new WeaviateClientAsync(fn.apply(config).build());
+  }
+
+  public static WeaviateClientAsync custom(Function<Config.Custom, ObjectBuilder<Config>> fn) {
+    return new WeaviateClientAsync(Config.of(fn));
   }
 
   @Override


### PR DESCRIPTION
This PR implements some feedback we gathered from reviewing `beta1` with @g-despot:

- "scheme" is passed same as other parameters, via a Builder method
- added `.custom` factory to WeaviateClient and WeaviateClientAsync namespaces 
- "httpHost" and "grpcHost" can tolerate optional `https://` prefix
- [fixed a bug](https://github.com/weaviate/java-client/pull/407/files#diff-87c3c5dbc8a78d6b1690276be05ac1d6876bc0d61de005c1c42aaa1ed0192e2cL128-R148) for WCD configuration