### PR TITLE
feat: Support collection aliases

### DIFF
--- a/src/main/java/io/weaviate/client/WeaviateClient.java
+++ b/src/main/java/io/weaviate/client/WeaviateClient.java
@@ -8,6 +8,7 @@ import io.weaviate.client.base.http.impl.CommonsHttpClientImpl;
 import io.weaviate.client.base.util.DbVersionProvider;
 import io.weaviate.client.base.util.DbVersionSupport;
 import io.weaviate.client.base.util.GrpcVersionSupport;
+import io.weaviate.client.v1.aliases.Aliases;
 import io.weaviate.client.v1.async.WeaviateAsyncClient;
 import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 import io.weaviate.client.v1.backup.Backup;
@@ -109,6 +110,10 @@ public class WeaviateClient {
 
   public Users users() {
     return new Users(httpClient, config);
+  }
+
+  public Aliases aliases() {
+    return new Aliases(httpClient, config);
   }
 
   private DbVersionProvider initDbVersionProvider() {

--- a/src/main/java/io/weaviate/client/WeaviateClient.java
+++ b/src/main/java/io/weaviate/client/WeaviateClient.java
@@ -112,7 +112,7 @@ public class WeaviateClient {
     return new Users(httpClient, config);
   }
 
-  public Aliases aliases() {
+  public Aliases alias() {
     return new Aliases(httpClient, config);
   }
 

--- a/src/main/java/io/weaviate/client/base/AsyncBaseClient.java
+++ b/src/main/java/io/weaviate/client/base/AsyncBaseClient.java
@@ -30,39 +30,48 @@ public abstract class AsyncBaseClient<T> {
     return sendRequest(endpoint, null, "GET", classOfT, callback, null);
   }
 
-  protected Future<Result<T>> sendGetRequest(String endpoint, FutureCallback<Result<T>> callback, ResponseParser<T> parser) {
+  protected Future<Result<T>> sendGetRequest(String endpoint, FutureCallback<Result<T>> callback,
+      ResponseParser<T> parser) {
     return sendRequest(endpoint, null, "GET", null, callback, parser);
   }
 
-  protected Future<Result<T>> sendPostRequest(String endpoint, Object payload, Class<T> classOfT, FutureCallback<Result<T>> callback) {
+  protected Future<Result<T>> sendPostRequest(String endpoint, Object payload, Class<T> classOfT,
+      FutureCallback<Result<T>> callback) {
     return sendRequest(endpoint, payload, "POST", classOfT, callback, null);
   }
 
-  protected Future<Result<T>> sendPostRequest(String endpoint, Object payload, FutureCallback<Result<T>> callback, ResponseParser<T> parser) {
+  protected Future<Result<T>> sendPostRequest(String endpoint, Object payload, FutureCallback<Result<T>> callback,
+      ResponseParser<T> parser) {
     return sendRequest(endpoint, payload, "POST", null, callback, parser);
   }
 
-  protected Future<Result<T>> sendPutRequest(String endpoint, Object payload, Class<T> classOfT, FutureCallback<Result<T>> callback) {
+  protected Future<Result<T>> sendPutRequest(String endpoint, Object payload, Class<T> classOfT,
+      FutureCallback<Result<T>> callback) {
     return sendRequest(endpoint, payload, "PUT", classOfT, callback, null);
   }
 
-  protected Future<Result<T>> sendPutRequest(String endpoint, Object payload, FutureCallback<Result<T>> callback, ResponseParser<T> parser) {
+  protected Future<Result<T>> sendPutRequest(String endpoint, Object payload, FutureCallback<Result<T>> callback,
+      ResponseParser<T> parser) {
     return sendRequest(endpoint, payload, "PUT", null, callback, parser);
   }
 
-  protected Future<Result<T>> sendPatchRequest(String endpoint, Object payload, Class<T> classOfT, FutureCallback<Result<T>> callback) {
+  protected Future<Result<T>> sendPatchRequest(String endpoint, Object payload, Class<T> classOfT,
+      FutureCallback<Result<T>> callback) {
     return sendRequest(endpoint, payload, "PATCH", classOfT, callback, null);
   }
 
-  protected Future<Result<T>> sendPatchRequest(String endpoint, Object payload, FutureCallback<Result<T>> callback, ResponseParser<T> parser) {
+  protected Future<Result<T>> sendPatchRequest(String endpoint, Object payload, FutureCallback<Result<T>> callback,
+      ResponseParser<T> parser) {
     return sendRequest(endpoint, payload, "PATCH", null, callback, parser);
   }
 
-  protected Future<Result<T>> sendDeleteRequest(String endpoint, Object payload, Class<T> classOfT, FutureCallback<Result<T>> callback) {
+  protected Future<Result<T>> sendDeleteRequest(String endpoint, Object payload, Class<T> classOfT,
+      FutureCallback<Result<T>> callback) {
     return sendRequest(endpoint, payload, "DELETE", classOfT, callback, null);
   }
 
-  protected Future<Result<T>> sendDeleteRequest(String endpoint, Object payload, FutureCallback<Result<T>> callback, ResponseParser<T> parser) {
+  protected Future<Result<T>> sendDeleteRequest(String endpoint, Object payload, FutureCallback<Result<T>> callback,
+      ResponseParser<T> parser) {
     return sendRequest(endpoint, payload, "DELETE", null, callback, parser);
   }
 
@@ -70,12 +79,15 @@ public abstract class AsyncBaseClient<T> {
     return sendRequest(endpoint, null, "HEAD", classOfT, callback, null);
   }
 
-  protected Future<Result<T>> sendHeadRequest(String endpoint, FutureCallback<Result<T>> callback, ResponseParser<T> parser) {
+  protected Future<Result<T>> sendHeadRequest(String endpoint, FutureCallback<Result<T>> callback,
+      ResponseParser<T> parser) {
     return sendRequest(endpoint, null, "HEAD", null, callback, parser);
   }
 
-  private Future<Result<T>> sendRequest(String endpoint, Object payload, String method, Class<T> classOfT, FutureCallback<Result<T>> callback, ResponseParser<T> parser) {
-    return client.execute(SimpleRequestProducer.create(getRequest(endpoint, payload, method)), new WeaviateResponseConsumer<>(classOfT, parser), callback);
+  private Future<Result<T>> sendRequest(String endpoint, Object payload, String method, Class<T> classOfT,
+      FutureCallback<Result<T>> callback, ResponseParser<T> parser) {
+    return client.execute(SimpleRequestProducer.create(getRequest(endpoint, payload, method)),
+        new WeaviateResponseConsumer<>(classOfT, parser), callback);
   }
 
   protected SimpleHttpRequest getRequest(String endpoint, Object payload, String method) {

--- a/src/main/java/io/weaviate/client/base/AsyncBaseClient.java
+++ b/src/main/java/io/weaviate/client/base/AsyncBaseClient.java
@@ -1,17 +1,19 @@
 package io.weaviate.client.base;
 
-import io.weaviate.client.Config;
-import io.weaviate.client.base.http.async.ResponseParser;
-import io.weaviate.client.base.http.async.WeaviateResponseConsumer;
-import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 import java.util.Map;
 import java.util.concurrent.Future;
+
 import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
 import org.apache.hc.client5.http.async.methods.SimpleRequestProducer;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpHeaders;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.http.async.ResponseParser;
+import io.weaviate.client.base.http.async.WeaviateResponseConsumer;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 
 public abstract class AsyncBaseClient<T> {
   protected final CloseableHttpAsyncClient client;

--- a/src/main/java/io/weaviate/client/v1/aliases/Aliases.java
+++ b/src/main/java/io/weaviate/client/v1/aliases/Aliases.java
@@ -1,0 +1,39 @@
+package io.weaviate.client.v1.aliases;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.aliases.api.AliasAllGetter;
+import io.weaviate.client.v1.aliases.api.AliasCreator;
+import io.weaviate.client.v1.aliases.api.AliasDeleter;
+import io.weaviate.client.v1.aliases.api.AliasGetter;
+import io.weaviate.client.v1.aliases.api.AliasUpdater;
+
+public class Aliases {
+  private final Config config;
+  private final HttpClient httpClient;
+
+  public Aliases(HttpClient httpClient, Config config) {
+    this.config = config;
+    this.httpClient = httpClient;
+  }
+
+  public AliasCreator creator() {
+    return new AliasCreator(httpClient, config);
+  }
+
+  public AliasGetter getter() {
+    return new AliasGetter(httpClient, config);
+  }
+
+  public AliasAllGetter allGetter() {
+    return new AliasAllGetter(httpClient, config);
+  }
+
+  public AliasDeleter deleter() {
+    return new AliasDeleter(httpClient, config);
+  }
+
+  public Object updater() {
+    return new AliasUpdater(httpClient, config);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/aliases/Aliases.java
+++ b/src/main/java/io/weaviate/client/v1/aliases/Aliases.java
@@ -33,7 +33,7 @@ public class Aliases {
     return new AliasDeleter(httpClient, config);
   }
 
-  public Object updater() {
+  public AliasUpdater updater() {
     return new AliasUpdater(httpClient, config);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/aliases/api/AliasAllGetter.java
+++ b/src/main/java/io/weaviate/client/v1/aliases/api/AliasAllGetter.java
@@ -1,0 +1,36 @@
+package io.weaviate.client.v1.aliases.api;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Response;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.aliases.api.AliasAllGetter.ResponseBody;
+import io.weaviate.client.v1.aliases.model.Alias;
+
+public class AliasAllGetter extends BaseClient<ResponseBody> implements ClientResult<Map<String, Alias>> {
+  public AliasAllGetter(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  static class ResponseBody {
+    List<Alias> aliases;
+  }
+
+  @Override
+  public Result<Map<String, Alias>> run() {
+    Response<ResponseBody> resp = sendGetRequest("/aliases", ResponseBody.class);
+    if (resp.getErrors() != null) {
+      return new Result<>(resp, null);
+    }
+    Map<String, Alias> aliases = resp.getBody().aliases.stream()
+        .collect(Collectors.toMap(Alias::getAlias, Function.identity()));
+    return new Result<>(resp, aliases);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/aliases/api/AliasAllGetter.java
+++ b/src/main/java/io/weaviate/client/v1/aliases/api/AliasAllGetter.java
@@ -15,8 +15,16 @@ import io.weaviate.client.v1.aliases.api.AliasAllGetter.ResponseBody;
 import io.weaviate.client.v1.aliases.model.Alias;
 
 public class AliasAllGetter extends BaseClient<ResponseBody> implements ClientResult<Map<String, Alias>> {
+  private String className;
+
   public AliasAllGetter(HttpClient httpClient, Config config) {
     super(httpClient, config);
+  }
+
+  /** List aliases defined for this class. */
+  public AliasAllGetter withClassName(String className) {
+    this.className = className;
+    return this;
   }
 
   static class ResponseBody {
@@ -25,7 +33,8 @@ public class AliasAllGetter extends BaseClient<ResponseBody> implements ClientRe
 
   @Override
   public Result<Map<String, Alias>> run() {
-    Response<ResponseBody> resp = sendGetRequest("/aliases", ResponseBody.class);
+    String path = "/aliases" + (className != null ? "?class=" + className : "");
+    Response<ResponseBody> resp = sendGetRequest(path, ResponseBody.class);
     if (resp.getErrors() != null) {
       return new Result<>(resp, null);
     }

--- a/src/main/java/io/weaviate/client/v1/aliases/api/AliasCreator.java
+++ b/src/main/java/io/weaviate/client/v1/aliases/api/AliasCreator.java
@@ -1,0 +1,34 @@
+package io.weaviate.client.v1.aliases.api;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Response;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.aliases.model.Alias;
+
+public class AliasCreator extends BaseClient<Void> implements ClientResult<Boolean> {
+  private String className;
+  private String alias;
+
+  public AliasCreator(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public AliasCreator withClassName(String className) {
+    this.className = className;
+    return this;
+  }
+
+  public AliasCreator withAlias(String alias) {
+    this.alias = alias;
+    return this;
+  }
+
+  @Override
+  public Result<Boolean> run() {
+    Response<Void> resp = sendPostRequest("/aliases", new Alias(className, alias), Void.class);
+    return Result.voidToBoolean(resp);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/aliases/api/AliasDeleter.java
+++ b/src/main/java/io/weaviate/client/v1/aliases/api/AliasDeleter.java
@@ -1,0 +1,27 @@
+package io.weaviate.client.v1.aliases.api;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Response;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+
+public class AliasDeleter extends BaseClient<Void> implements ClientResult<Boolean> {
+  private String alias;
+
+  public AliasDeleter(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public AliasDeleter withAlias(String alias) {
+    this.alias = alias;
+    return this;
+  }
+
+  @Override
+  public Result<Boolean> run() {
+    Response<Void> resp = sendDeleteRequest("/aliases/" + alias, null, Void.class);
+    return Result.voidToBoolean(resp);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/aliases/api/AliasGetter.java
+++ b/src/main/java/io/weaviate/client/v1/aliases/api/AliasGetter.java
@@ -1,0 +1,26 @@
+package io.weaviate.client.v1.aliases.api;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.aliases.model.Alias;
+
+public class AliasGetter extends BaseClient<Alias> implements ClientResult<Alias> {
+  private String alias;
+
+  public AliasGetter(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public AliasGetter withAlias(String alias) {
+    this.alias = alias;
+    return this;
+  }
+
+  @Override
+  public Result<Alias> run() {
+    return new Result<>(sendGetRequest("/aliases/" + alias, Alias.class));
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/aliases/api/AliasUpdater.java
+++ b/src/main/java/io/weaviate/client/v1/aliases/api/AliasUpdater.java
@@ -1,0 +1,40 @@
+package io.weaviate.client.v1.aliases.api;
+
+import com.google.gson.annotations.SerializedName;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Response;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+
+public class AliasUpdater extends BaseClient<Void> implements ClientResult<Boolean> {
+  private String className;
+  private String alias;
+
+  public AliasUpdater(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public AliasUpdater withAlias(String alias) {
+    this.alias = alias;
+    return this;
+  }
+
+  public AliasUpdater withNewClassName(String className) {
+    this.className = className;
+    return this;
+  }
+
+  class Body {
+    @SerializedName("class")
+    String className = AliasUpdater.this.className;
+  }
+
+  @Override
+  public Result<Boolean> run() {
+    Response<Void> resp = sendPutRequest("/aliases/" + alias, new Body(), Void.class);
+    return Result.voidToBoolean(resp);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/aliases/model/Alias.java
+++ b/src/main/java/io/weaviate/client/v1/aliases/model/Alias.java
@@ -1,0 +1,15 @@
+package io.weaviate.client.v1.aliases.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class Alias {
+  @SerializedName("class")
+  private final String collection;
+  @SerializedName("alias")
+  private final String alias;
+}

--- a/src/main/java/io/weaviate/client/v1/aliases/model/Alias.java
+++ b/src/main/java/io/weaviate/client/v1/aliases/model/Alias.java
@@ -2,14 +2,16 @@ package io.weaviate.client.v1.aliases.model;
 
 import com.google.gson.annotations.SerializedName;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
+@EqualsAndHashCode
 public class Alias {
   @SerializedName("class")
-  private final String collection;
+  private final String className;
   @SerializedName("alias")
   private final String alias;
 }

--- a/src/main/java/io/weaviate/client/v1/async/WeaviateAsyncClient.java
+++ b/src/main/java/io/weaviate/client/v1/async/WeaviateAsyncClient.java
@@ -85,7 +85,7 @@ public class WeaviateAsyncClient implements AutoCloseable {
     return new Users(client, config, tokenProvider);
   }
 
-  public Aliases aliases() {
+  public Aliases alias() {
     return new Aliases(client, config, tokenProvider);
   }
 

--- a/src/main/java/io/weaviate/client/v1/async/WeaviateAsyncClient.java
+++ b/src/main/java/io/weaviate/client/v1/async/WeaviateAsyncClient.java
@@ -12,6 +12,7 @@ import io.weaviate.client.base.http.async.AsyncHttpClient;
 import io.weaviate.client.base.util.DbVersionProvider;
 import io.weaviate.client.base.util.DbVersionSupport;
 import io.weaviate.client.base.util.GrpcVersionSupport;
+import io.weaviate.client.v1.async.aliases.Aliases;
 import io.weaviate.client.v1.async.backup.Backup;
 import io.weaviate.client.v1.async.batch.Batch;
 import io.weaviate.client.v1.async.classifications.Classifications;
@@ -82,6 +83,10 @@ public class WeaviateAsyncClient implements AutoCloseable {
 
   public Users users() {
     return new Users(client, config, tokenProvider);
+  }
+
+  public Aliases aliases() {
+    return new Aliases(client, config, tokenProvider);
   }
 
   private DbVersionProvider initDbVersionProvider() {

--- a/src/main/java/io/weaviate/client/v1/async/aliases/Aliases.java
+++ b/src/main/java/io/weaviate/client/v1/async/aliases/Aliases.java
@@ -1,0 +1,39 @@
+package io.weaviate.client.v1.async.aliases;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.v1.async.aliases.api.AliasAllGetter;
+import io.weaviate.client.v1.async.aliases.api.AliasCreator;
+import io.weaviate.client.v1.async.aliases.api.AliasDeleter;
+import io.weaviate.client.v1.async.aliases.api.AliasGetter;
+import io.weaviate.client.v1.async.aliases.api.AliasUpdater;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class Aliases {
+  private final CloseableHttpAsyncClient client;
+  private final Config config;
+  private final AccessTokenProvider tokenProvider;
+
+  public AliasCreator creator() {
+    return new AliasCreator(client, config, tokenProvider);
+  }
+
+  public AliasGetter getter() {
+    return new AliasGetter(client, config, tokenProvider);
+  }
+
+  public AliasAllGetter allGetter() {
+    return new AliasAllGetter(client, config, tokenProvider);
+  }
+
+  public AliasDeleter deleter() {
+    return new AliasDeleter(client, config, tokenProvider);
+  }
+
+  public Object updater() {
+    return new AliasUpdater(client, config, tokenProvider);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/aliases/Aliases.java
+++ b/src/main/java/io/weaviate/client/v1/async/aliases/Aliases.java
@@ -33,7 +33,7 @@ public class Aliases {
     return new AliasDeleter(client, config, tokenProvider);
   }
 
-  public Object updater() {
+  public AliasUpdater updater() {
     return new AliasUpdater(client, config, tokenProvider);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/async/aliases/api/AliasAllGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/aliases/api/AliasAllGetter.java
@@ -22,14 +22,22 @@ import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
 
 public class AliasAllGetter extends AsyncBaseClient<Map<String, Alias>>
     implements AsyncClientResult<Map<String, Alias>> {
+  private String className;
 
   public AliasAllGetter(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
     super(httpClient, config, tokenProvider);
   }
 
+  /** List aliases defined for this class. */
+  public AliasAllGetter withClassName(String className) {
+    this.className = className;
+    return this;
+  }
+
   @Override
   public Future<Result<Map<String, Alias>>> run(FutureCallback<Result<Map<String, Alias>>> callback) {
-    return sendGetRequest("/aliases", callback, new ResponseParser<Map<String, Alias>>() {
+    String path = "/aliases" + (className != null ? "?class=" + className : "");
+    return sendGetRequest(path, callback, new ResponseParser<Map<String, Alias>>() {
 
       class ResponseBody {
         List<Alias> aliases;

--- a/src/main/java/io/weaviate/client/v1/async/aliases/api/AliasAllGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/aliases/api/AliasAllGetter.java
@@ -1,0 +1,50 @@
+package io.weaviate.client.v1.async.aliases.api;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpResponse;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Response;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.async.ResponseParser;
+import io.weaviate.client.v1.aliases.model.Alias;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+
+public class AliasAllGetter extends AsyncBaseClient<Map<String, Alias>>
+    implements AsyncClientResult<Map<String, Alias>> {
+
+  public AliasAllGetter(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  @Override
+  public Future<Result<Map<String, Alias>>> run(FutureCallback<Result<Map<String, Alias>>> callback) {
+    return sendGetRequest("/aliases", callback, new ResponseParser<Map<String, Alias>>() {
+
+      class ResponseBody {
+        List<Alias> aliases;
+      }
+
+      @Override
+      public Result<Map<String, Alias>> parse(HttpResponse response, String body, ContentType contentType) {
+        Response<ResponseBody> resp = serializer.toResponse(response.getCode(), body, ResponseBody.class);
+        if (resp.getErrors() != null) {
+          return new Result<>(resp, null);
+        }
+        Map<String, Alias> aliases = resp.getBody().aliases.stream()
+            .collect(Collectors.toMap(Alias::getAlias, Function.identity()));
+        return new Result<>(resp, aliases);
+      }
+    });
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/aliases/api/AliasCreator.java
+++ b/src/main/java/io/weaviate/client/v1/async/aliases/api/AliasCreator.java
@@ -1,0 +1,38 @@
+package io.weaviate.client.v1.async.aliases.api;
+
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.aliases.model.Alias;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+
+public class AliasCreator extends AsyncBaseClient<Boolean> implements AsyncClientResult<Boolean> {
+  private String className;
+  private String alias;
+
+  public AliasCreator(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  public AliasCreator withClassName(String className) {
+    this.className = className;
+    return this;
+  }
+
+  public AliasCreator withAlias(String alias) {
+    this.alias = alias;
+    return this;
+  }
+
+  @Override
+  public Future<Result<Boolean>> run(FutureCallback<Result<Boolean>> callback) {
+    return sendPostRequest("/aliases", new Alias(className, alias),
+        callback, Result.voidToBooleanParser());
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/aliases/api/AliasDeleter.java
+++ b/src/main/java/io/weaviate/client/v1/async/aliases/api/AliasDeleter.java
@@ -1,0 +1,31 @@
+package io.weaviate.client.v1.async.aliases.api;
+
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+
+public class AliasDeleter extends AsyncBaseClient<Boolean> implements AsyncClientResult<Boolean> {
+  private String alias;
+
+  public AliasDeleter(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  public AliasDeleter withAlias(String alias) {
+    this.alias = alias;
+    return this;
+  }
+
+  @Override
+  public Future<Result<Boolean>> run(FutureCallback<Result<Boolean>> callback) {
+    return sendDeleteRequest("/aliases/" + alias, null,
+        callback, Result.voidToBooleanParser());
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/aliases/api/AliasGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/aliases/api/AliasGetter.java
@@ -1,0 +1,31 @@
+package io.weaviate.client.v1.async.aliases.api;
+
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.aliases.model.Alias;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+
+public class AliasGetter extends AsyncBaseClient<Alias> implements AsyncClientResult<Alias> {
+  private String alias;
+
+  public AliasGetter(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  public AliasGetter withAlias(String alias) {
+    this.alias = alias;
+    return this;
+  }
+
+  @Override
+  public Future<Result<Alias>> run(FutureCallback<Result<Alias>> callback) {
+    return sendGetRequest("/aliases/" + alias, Alias.class, callback);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/aliases/api/AliasUpdater.java
+++ b/src/main/java/io/weaviate/client/v1/async/aliases/api/AliasUpdater.java
@@ -1,0 +1,44 @@
+package io.weaviate.client.v1.async.aliases.api;
+
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+
+import com.google.gson.annotations.SerializedName;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+
+public class AliasUpdater extends AsyncBaseClient<Boolean> implements AsyncClientResult<Boolean> {
+  private String className;
+  private String alias;
+
+  public AliasUpdater(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  public AliasUpdater withAlias(String alias) {
+    this.alias = alias;
+    return this;
+  }
+
+  public AliasUpdater withNewClassName(String className) {
+    this.className = className;
+    return this;
+  }
+
+  class Body {
+    @SerializedName("class")
+    String className = AliasUpdater.this.className;
+  }
+
+  @Override
+  public Future<Result<Boolean>> run(FutureCallback<Result<Boolean>> callback) {
+    return sendPutRequest("/aliases/" + alias, new Body(),
+        callback, Result.voidToBooleanParser());
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/WeaviatePermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/WeaviatePermission.java
@@ -3,7 +3,7 @@ package io.weaviate.client.v1.rbac.api;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.weaviate.client.v1.rbac.model.AliasesPermission;
+import io.weaviate.client.v1.rbac.model.AliasPermission;
 import io.weaviate.client.v1.rbac.model.BackupsPermission;
 import io.weaviate.client.v1.rbac.model.CollectionsPermission;
 import io.weaviate.client.v1.rbac.model.DataPermission;
@@ -26,7 +26,7 @@ import lombok.ToString;
 @ToString
 public class WeaviatePermission {
   String action;
-  AliasesPermission aliases;
+  AliasPermission aliases;
   BackupsPermission backups;
   CollectionsPermission collections;
   DataPermission data;
@@ -41,8 +41,8 @@ public class WeaviatePermission {
 
   public <P extends Permission<P>> WeaviatePermission(String action, Permission<P> perm) {
     this.action = action;
-    if (perm instanceof AliasesPermission) {
-      this.aliases = (AliasesPermission) perm;
+    if (perm instanceof AliasPermission) {
+      this.aliases = (AliasPermission) perm;
     } else if (perm instanceof BackupsPermission) {
       this.backups = (BackupsPermission) perm;
     } else if (perm instanceof CollectionsPermission) {

--- a/src/main/java/io/weaviate/client/v1/rbac/api/WeaviatePermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/WeaviatePermission.java
@@ -3,6 +3,7 @@ package io.weaviate.client.v1.rbac.api;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.weaviate.client.v1.rbac.model.AliasesPermission;
 import io.weaviate.client.v1.rbac.model.BackupsPermission;
 import io.weaviate.client.v1.rbac.model.CollectionsPermission;
 import io.weaviate.client.v1.rbac.model.DataPermission;
@@ -25,6 +26,7 @@ import lombok.ToString;
 @ToString
 public class WeaviatePermission {
   String action;
+  AliasesPermission aliases;
   BackupsPermission backups;
   CollectionsPermission collections;
   DataPermission data;
@@ -39,7 +41,9 @@ public class WeaviatePermission {
 
   public <P extends Permission<P>> WeaviatePermission(String action, Permission<P> perm) {
     this.action = action;
-    if (perm instanceof BackupsPermission) {
+    if (perm instanceof AliasesPermission) {
+      this.aliases = (AliasesPermission) perm;
+    } else if (perm instanceof BackupsPermission) {
       this.backups = (BackupsPermission) perm;
     } else if (perm instanceof CollectionsPermission) {
       this.collections = (CollectionsPermission) perm;

--- a/src/main/java/io/weaviate/client/v1/rbac/model/AliasPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/AliasPermission.java
@@ -6,15 +6,15 @@ import lombok.Getter;
 
 @Getter
 @EqualsAndHashCode(callSuper = true)
-public class AliasesPermission extends Permission<AliasesPermission> {
+public class AliasPermission extends Permission<AliasPermission> {
   final String alias;
 
-  public AliasesPermission(String alias, Action... actions) {
+  public AliasPermission(String alias, Action... actions) {
     super(actions);
     this.alias = alias;
   }
 
-  AliasesPermission(String alias, String action) {
+  AliasPermission(String alias, String action) {
     this(alias, RbacAction.fromString(Action.class, action));
   }
 

--- a/src/main/java/io/weaviate/client/v1/rbac/model/AliasesPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/AliasesPermission.java
@@ -1,0 +1,31 @@
+package io.weaviate.client.v1.rbac.model;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode(callSuper = true)
+public class AliasesPermission extends Permission<AliasesPermission> {
+  final String alias;
+
+  public AliasesPermission(String alias, Action... actions) {
+    super(actions);
+    this.alias = alias;
+  }
+
+  AliasesPermission(String alias, String action) {
+    this(alias, RbacAction.fromString(Action.class, action));
+  }
+
+  @AllArgsConstructor
+  public enum Action implements RbacAction {
+    CREATE("create_aliases"),
+    READ("read_aliases"),
+    UPDATE("update_aliases"),
+    DELETE("delete_aliases");
+
+    @Getter
+    private final String value;
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
@@ -132,9 +132,9 @@ public abstract class Permission<P extends Permission<P>> {
    * Create {@link AliasesPermission} for a alias.
    * <p>
    * Example:
-   * {@code Permission.backups("Pizza", AliasPermission.Action.MANAGE) }
+   * {@code Permission.aliases("PizzaAlias", AliasPermission.Action.CREATE) }
    */
-  public static AliasesPermission alias(String alias, AliasesPermission.Action... actions) {
+  public static AliasesPermission aliases(String alias, AliasesPermission.Action... actions) {
     checkDeprecation(actions);
     return new AliasesPermission(alias, actions);
   }

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
@@ -66,7 +66,9 @@ public abstract class Permission<P extends Permission<P>> {
    */
   public static Permission<?> fromWeaviate(WeaviatePermission perm) {
     String action = perm.getAction();
-    if (perm.getBackups() != null) {
+    if (perm.getAliases() != null) {
+      return new AliasesPermission(perm.getAliases().getAlias(), action);
+    } else if (perm.getBackups() != null) {
       return new BackupsPermission(perm.getBackups().getCollection(), action);
     } else if (perm.getCollections() != null) {
       return new CollectionsPermission(perm.getCollections().getCollection(), action);
@@ -127,10 +129,21 @@ public abstract class Permission<P extends Permission<P>> {
   }
 
   /**
+   * Create {@link AliasesPermission} for a alias.
+   * <p>
+   * Example:
+   * {@code Permission.backups("Pizza", AliasPermission.Action.MANAGE) }
+   */
+  public static AliasesPermission alias(String alias, AliasesPermission.Action... actions) {
+    checkDeprecation(actions);
+    return new AliasesPermission(alias, actions);
+  }
+
+  /**
    * Create {@link BackupsPermission} for a collection.
    * <p>
    * Example:
-   * {@code Permission.backups(BackupsPermission.Action.MANAGE, "Pizza") }
+   * {@code Permission.backups("Pizza", BackupsPermission.Action.MANAGE) }
    */
   public static BackupsPermission backups(String collection, BackupsPermission.Action... actions) {
     checkDeprecation(actions);
@@ -140,7 +153,7 @@ public abstract class Permission<P extends Permission<P>> {
   /**
    * Create {@link ClusterPermission} permission.
    * <p>
-   * Example: {@code Permission.cluster(ClusterPermission.Action.READ, "Pizza") }
+   * Example: {@code Permission.cluster(ClusterPermission.Action.READ) }
    */
   public static ClusterPermission cluster(ClusterPermission.Action... actions) {
     checkDeprecation(actions);

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
@@ -67,7 +67,7 @@ public abstract class Permission<P extends Permission<P>> {
   public static Permission<?> fromWeaviate(WeaviatePermission perm) {
     String action = perm.getAction();
     if (perm.getAliases() != null) {
-      return new AliasesPermission(perm.getAliases().getAlias(), action);
+      return new AliasPermission(perm.getAliases().getAlias(), action);
     } else if (perm.getBackups() != null) {
       return new BackupsPermission(perm.getBackups().getCollection(), action);
     } else if (perm.getCollections() != null) {
@@ -129,14 +129,14 @@ public abstract class Permission<P extends Permission<P>> {
   }
 
   /**
-   * Create {@link AliasesPermission} for a alias.
+   * Create {@link AliasPermission} for an alias.
    * <p>
    * Example:
-   * {@code Permission.aliases("PizzaAlias", AliasPermission.Action.CREATE) }
+   * {@code Permission.alias("PizzaAlias", AliasPermission.Action.CREATE) }
    */
-  public static AliasesPermission aliases(String alias, AliasesPermission.Action... actions) {
+  public static AliasPermission alias(String alias, AliasPermission.Action... actions) {
     checkDeprecation(actions);
-    return new AliasesPermission(alias, actions);
+    return new AliasPermission(alias, actions);
   }
 
   /**

--- a/src/test/java/io/weaviate/client/v1/rbac/api/WeaviatePermissionTest.java
+++ b/src/test/java/io/weaviate/client/v1/rbac/api/WeaviatePermissionTest.java
@@ -28,8 +28,8 @@ public class WeaviatePermissionTest {
   public void testMergedPermissions() {
     WeaviatePermission[] apiPermissions = {
         // Create and delete PizzaAlias alias
-        new WeaviatePermission("create_alias", new AliasesPermission("PizzaAlias")),
-        new WeaviatePermission("delete_alias", new AliasesPermission("PizzaAlias")),
+        new WeaviatePermission("create_aliases", new AliasesPermission("PizzaAlias")),
+        new WeaviatePermission("delete_aliases", new AliasesPermission("PizzaAlias")),
 
         // Manage Pizza backups
         new WeaviatePermission("manage_backups", new BackupsPermission("Pizza")),

--- a/src/test/java/io/weaviate/client/v1/rbac/api/WeaviatePermissionTest.java
+++ b/src/test/java/io/weaviate/client/v1/rbac/api/WeaviatePermissionTest.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
+import io.weaviate.client.v1.rbac.model.AliasesPermission;
 import io.weaviate.client.v1.rbac.model.BackupsPermission;
 import io.weaviate.client.v1.rbac.model.ClusterPermission;
 import io.weaviate.client.v1.rbac.model.CollectionsPermission;
@@ -26,6 +27,10 @@ public class WeaviatePermissionTest {
   @Test
   public void testMergedPermissions() {
     WeaviatePermission[] apiPermissions = {
+        // Create and delete PizzaAlias alias
+        new WeaviatePermission("create_alias", new AliasesPermission("PizzaAlias")),
+        new WeaviatePermission("delete_alias", new AliasesPermission("PizzaAlias")),
+
         // Manage Pizza backups
         new WeaviatePermission("manage_backups", new BackupsPermission("Pizza")),
 
@@ -70,6 +75,7 @@ public class WeaviatePermissionTest {
     };
 
     Permission<?>[] libraryPermissions = {
+        new AliasesPermission("PizzaAlias", AliasesPermission.Action.CREATE, AliasesPermission.Action.DELETE),
         new BackupsPermission("Pizza", BackupsPermission.Action.MANAGE),
         new DataPermission("Pizza", DataPermission.Action.MANAGE, DataPermission.Action.READ),
         new DataPermission("Songs", DataPermission.Action.UPDATE, DataPermission.Action.DELETE),

--- a/src/test/java/io/weaviate/client/v1/rbac/api/WeaviatePermissionTest.java
+++ b/src/test/java/io/weaviate/client/v1/rbac/api/WeaviatePermissionTest.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
-import io.weaviate.client.v1.rbac.model.AliasesPermission;
+import io.weaviate.client.v1.rbac.model.AliasPermission;
 import io.weaviate.client.v1.rbac.model.BackupsPermission;
 import io.weaviate.client.v1.rbac.model.ClusterPermission;
 import io.weaviate.client.v1.rbac.model.CollectionsPermission;
@@ -28,8 +28,8 @@ public class WeaviatePermissionTest {
   public void testMergedPermissions() {
     WeaviatePermission[] apiPermissions = {
         // Create and delete PizzaAlias alias
-        new WeaviatePermission("create_aliases", new AliasesPermission("PizzaAlias")),
-        new WeaviatePermission("delete_aliases", new AliasesPermission("PizzaAlias")),
+        new WeaviatePermission("create_aliases", new AliasPermission("PizzaAlias")),
+        new WeaviatePermission("delete_aliases", new AliasPermission("PizzaAlias")),
 
         // Manage Pizza backups
         new WeaviatePermission("manage_backups", new BackupsPermission("Pizza")),
@@ -75,7 +75,7 @@ public class WeaviatePermissionTest {
     };
 
     Permission<?>[] libraryPermissions = {
-        new AliasesPermission("PizzaAlias", AliasesPermission.Action.CREATE, AliasesPermission.Action.DELETE),
+        new AliasPermission("PizzaAlias", AliasPermission.Action.CREATE, AliasPermission.Action.DELETE),
         new BackupsPermission("Pizza", BackupsPermission.Action.MANAGE),
         new DataPermission("Pizza", DataPermission.Action.MANAGE, DataPermission.Action.READ),
         new DataPermission("Songs", DataPermission.Action.UPDATE, DataPermission.Action.DELETE),

--- a/src/test/java/io/weaviate/client/v1/rbac/model/PermissionTest.java
+++ b/src/test/java/io/weaviate/client/v1/rbac/model/PermissionTest.java
@@ -37,7 +37,7 @@ public class PermissionTest {
         {
             "alias permission",
             (Supplier<Permission<?>>) () -> alias,
-            new WeaviatePermission("create_backups", alias),
+            new WeaviatePermission("create_aliases", alias),
         },
         {
             "backup permission",

--- a/src/test/java/io/weaviate/client/v1/rbac/model/PermissionTest.java
+++ b/src/test/java/io/weaviate/client/v1/rbac/model/PermissionTest.java
@@ -23,6 +23,7 @@ import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 @RunWith(JParamsTestRunner.class)
 public class PermissionTest {
   public static Object[][] serializationTestCases() {
+    AliasesPermission alias = new AliasesPermission("PizzaAlias", AliasesPermission.Action.CREATE);
     BackupsPermission backups = new BackupsPermission("Pizza", BackupsPermission.Action.MANAGE);
     DataPermission data = new DataPermission("Pizza", DataPermission.Action.MANAGE);
     NodesPermission nodes = new NodesPermission("Pizza", NodesPermission.Action.READ);
@@ -33,6 +34,11 @@ public class PermissionTest {
     UsersPermission users = new UsersPermission(UsersPermission.Action.READ);
 
     return new Object[][] {
+        {
+            "alias permission",
+            (Supplier<Permission<?>>) () -> alias,
+            new WeaviatePermission("create_backups", alias),
+        },
         {
             "backup permission",
             (Supplier<Permission<?>>) () -> backups,

--- a/src/test/java/io/weaviate/client/v1/rbac/model/PermissionTest.java
+++ b/src/test/java/io/weaviate/client/v1/rbac/model/PermissionTest.java
@@ -23,7 +23,7 @@ import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 @RunWith(JParamsTestRunner.class)
 public class PermissionTest {
   public static Object[][] serializationTestCases() {
-    AliasesPermission alias = new AliasesPermission("PizzaAlias", AliasesPermission.Action.CREATE);
+    AliasPermission alias = new AliasPermission("PizzaAlias", AliasPermission.Action.CREATE);
     BackupsPermission backups = new BackupsPermission("Pizza", BackupsPermission.Action.MANAGE);
     DataPermission data = new DataPermission("Pizza", DataPermission.Action.MANAGE);
     NodesPermission nodes = new NodesPermission("Pizza", NodesPermission.Action.READ);

--- a/src/test/java/io/weaviate/integration/client/aliases/ClientAliasesTest.java
+++ b/src/test/java/io/weaviate/integration/client/aliases/ClientAliasesTest.java
@@ -1,0 +1,85 @@
+package io.weaviate.integration.client.aliases;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.WeaviateClient;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.aliases.model.Alias;
+import io.weaviate.client.v1.schema.model.WeaviateClass;
+import io.weaviate.integration.client.WeaviateDockerCompose;
+
+public class ClientAliasesTest {
+  private WeaviateClient client;
+
+  @ClassRule
+  public static WeaviateDockerCompose compose = new WeaviateDockerCompose();
+
+  @Before
+  public void before() {
+    Config config = new Config("http", compose.getHttpHostAddress());
+    client = new WeaviateClient(config);
+  }
+
+  @Test
+  public void shouldManageAliases() {
+    // Arrange
+    Result<Boolean> createdPaul = client.schema().classCreator().withClass(WeaviateClass.builder()
+        .className("PaulHewson").build()).run();
+    assumeTrue(createdPaul.getResult(), "created PaulHewson collection");
+
+    Result<Boolean> createdGeorge = client.schema().classCreator().withClass(WeaviateClass.builder()
+        .className("GeorgeBarnes").build()).run();
+    assumeTrue(createdGeorge.getResult(), "created GeorgeBarnes collection");
+
+    // Act: create alias
+    client.aliases().creator().withClassName("PaulHewson").withAlias("Bono").run();
+    client.aliases().creator().withClassName("GeorgeBarnes").withAlias("MachineGunKelly").run();
+
+    // Assert: get all
+    Result<Map<String, Alias>> all = client.aliases().allGetter().run();
+
+    Assertions.assertThat(all.getError()).isNull();
+    Assertions.assertThat(all.getResult())
+        .as("fetched all aliases")
+        .containsAllEntriesOf(new HashMap<String, Alias>() {
+          {
+            put("Bono", new Alias("PaulHewson", "Bono"));
+            put("MachineGunKelly", new Alias("GeorgeBarnes", "MachineGunKelly"));
+          }
+        });
+
+    // Act: update
+    Result<Boolean> createdMGK = client.schema().classCreator().withClass(WeaviateClass.builder()
+        .className("ColsonBaker").build()).run();
+    assumeTrue(createdMGK.getResult(), "created ColsonBaker collection");
+
+    client.aliases().updater().withAlias("MachineGunKelly").withNewClassName("ColsonBaker").run();
+
+    // Assert: get one
+    Result<Alias> mgk = client.aliases().getter().withAlias("MachineGunKelly").run();
+
+    Assertions.assertThat(mgk.getResult())
+        .as("MachineGunKelly alias points to ColsonBaker")
+        .returns("MachineGunKelly", Alias::getAlias)
+        .returns("ColsonBaker", Alias::getClassName);
+
+    // Act: delete
+    client.aliases().deleter().withAlias("Bono").run();
+
+    // Assert
+    Result<Alias> bono = client.aliases().getter().withAlias("Bono").run();
+    Assertions.assertThat(bono)
+        .as("Bono alias deleted")
+        .returns(null, Result::getResult)
+        .extracting(Result::getError).isNull();
+  }
+}

--- a/src/test/java/io/weaviate/integration/client/aliases/ClientAliasesTest.java
+++ b/src/test/java/io/weaviate/integration/client/aliases/ClientAliasesTest.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -41,11 +42,11 @@ public class ClientAliasesTest {
     assumeTrue(createdGeorge.getResult(), "created GeorgeBarnes collection");
 
     // Act: create alias
-    client.aliases().creator().withClassName("PaulHewson").withAlias("Bono").run();
-    client.aliases().creator().withClassName("GeorgeBarnes").withAlias("MachineGunKelly").run();
+    client.alias().creator().withClassName("PaulHewson").withAlias("Bono").run();
+    client.alias().creator().withClassName("GeorgeBarnes").withAlias("MachineGunKelly").run();
 
     // Assert: get all
-    Result<Map<String, Alias>> all = client.aliases().allGetter().run();
+    Result<Map<String, Alias>> all = client.alias().allGetter().run();
 
     Assertions.assertThat(all.getError()).isNull();
     Assertions.assertThat(all.getResult())
@@ -62,21 +63,27 @@ public class ClientAliasesTest {
         .className("ColsonBaker").build()).run();
     assumeTrue(createdMGK.getResult(), "created ColsonBaker collection");
 
-    client.aliases().updater().withAlias("MachineGunKelly").withNewClassName("ColsonBaker").run();
+    client.alias().updater().withAlias("MachineGunKelly").withNewClassName("ColsonBaker").run();
 
     // Assert: get one
-    Result<Alias> mgk = client.aliases().getter().withAlias("MachineGunKelly").run();
+    Result<Alias> mgk = client.alias().getter().withAlias("MachineGunKelly").run();
 
     Assertions.assertThat(mgk.getResult())
         .as("MachineGunKelly alias points to ColsonBaker")
         .returns("MachineGunKelly", Alias::getAlias)
         .returns("ColsonBaker", Alias::getClassName);
 
+    Result<Map<String, Alias>> colsonAliases = client.alias().allGetter().withClassName("ColsonBaker").run();
+    Assertions.assertThat(colsonAliases.getResult())
+        .containsOnlyKeys("MachineGunKelly")
+        .extracting(Map::values, InstanceOfAssertFactories.collection(Alias.class))
+        .extracting(Alias::getClassName).containsOnly("ColsonBaker");
+
     // Act: delete
-    client.aliases().deleter().withAlias("Bono").run();
+    client.alias().deleter().withAlias("Bono").run();
 
     // Assert
-    Result<Alias> bono = client.aliases().getter().withAlias("Bono").run();
+    Result<Alias> bono = client.alias().getter().withAlias("Bono").run();
     Assertions.assertThat(bono)
         .as("Bono alias deleted")
         .returns(null, Result::getResult)

--- a/src/test/java/io/weaviate/integration/client/async/aliases/ClientAliasesTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/aliases/ClientAliasesTest.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -49,11 +50,11 @@ public class ClientAliasesTest {
     assumeTrue(createdGeorge.getResult(), "created GeorgeBarnes collection");
 
     // Act: create alias
-    client.aliases().creator().withClassName("PaulHewson").withAlias("Bono").run().get();
-    client.aliases().creator().withClassName("GeorgeBarnes").withAlias("MachineGunKelly").run().get();
+    client.alias().creator().withClassName("PaulHewson").withAlias("Bono").run().get();
+    client.alias().creator().withClassName("GeorgeBarnes").withAlias("MachineGunKelly").run().get();
 
     // Assert: get all
-    Result<Map<String, Alias>> all = client.aliases().allGetter().run().get();
+    Result<Map<String, Alias>> all = client.alias().allGetter().run().get();
 
     Assertions.assertThat(all.getError()).isNull();
     Assertions.assertThat(all.getResult())
@@ -70,21 +71,27 @@ public class ClientAliasesTest {
         .className("ColsonBaker").build()).run().get();
     assumeTrue(createdMGK.getResult(), "created ColsonBaker collection");
 
-    client.aliases().updater().withAlias("MachineGunKelly").withNewClassName("ColsonBaker").run().get();
+    client.alias().updater().withAlias("MachineGunKelly").withNewClassName("ColsonBaker").run().get();
 
     // Assert: get one
-    Result<Alias> mgk = client.aliases().getter().withAlias("MachineGunKelly").run().get();
+    Result<Alias> mgk = client.alias().getter().withAlias("MachineGunKelly").run().get();
 
     Assertions.assertThat(mgk.getResult())
         .as("MachineGunKelly alias points to ColsonBaker")
         .returns("MachineGunKelly", Alias::getAlias)
         .returns("ColsonBaker", Alias::getClassName);
 
+    Result<Map<String, Alias>> colsonAliases = client.alias().allGetter().withClassName("ColsonBaker").run().get();
+    Assertions.assertThat(colsonAliases.getResult())
+        .containsOnlyKeys("MachineGunKelly")
+        .extracting(Map::values, InstanceOfAssertFactories.collection(Alias.class))
+        .extracting(Alias::getClassName).containsOnly("ColsonBaker");
+
     // Act: delete
-    client.aliases().deleter().withAlias("Bono").run().get();
+    client.alias().deleter().withAlias("Bono").run().get();
 
     // Assert
-    Result<Alias> bono = client.aliases().getter().withAlias("Bono").run().get();
+    Result<Alias> bono = client.alias().getter().withAlias("Bono").run().get();
     Assertions.assertThat(bono)
         .as("Bono alias deleted")
         .returns(null, Result::getResult)

--- a/src/test/java/io/weaviate/integration/client/async/aliases/ClientAliasesTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/aliases/ClientAliasesTest.java
@@ -1,0 +1,93 @@
+package io.weaviate.integration.client.async.aliases;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import org.assertj.core.api.Assertions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.WeaviateClient;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.aliases.model.Alias;
+import io.weaviate.client.v1.async.WeaviateAsyncClient;
+import io.weaviate.client.v1.schema.model.WeaviateClass;
+import io.weaviate.integration.client.WeaviateDockerCompose;
+
+public class ClientAliasesTest {
+  private WeaviateAsyncClient client;
+
+  @ClassRule
+  public static WeaviateDockerCompose compose = new WeaviateDockerCompose();
+
+  @Before
+  public void before() {
+    Config config = new Config("http", compose.getHttpHostAddress());
+    client = new WeaviateClient(config).async();
+  }
+
+  @After
+  public void after() {
+    client.close();
+  }
+
+  @Test
+  public void shouldManageAliases() throws InterruptedException, ExecutionException {
+    // Arrange
+    Result<Boolean> createdPaul = client.schema().classCreator().withClass(WeaviateClass.builder()
+        .className("PaulHewson").build()).run().get();
+    assumeTrue(createdPaul.getResult(), "created PaulHewson collection");
+
+    Result<Boolean> createdGeorge = client.schema().classCreator().withClass(WeaviateClass.builder()
+        .className("GeorgeBarnes").build()).run().get();
+    assumeTrue(createdGeorge.getResult(), "created GeorgeBarnes collection");
+
+    // Act: create alias
+    client.aliases().creator().withClassName("PaulHewson").withAlias("Bono").run().get();
+    client.aliases().creator().withClassName("GeorgeBarnes").withAlias("MachineGunKelly").run().get();
+
+    // Assert: get all
+    Result<Map<String, Alias>> all = client.aliases().allGetter().run().get();
+
+    Assertions.assertThat(all.getError()).isNull();
+    Assertions.assertThat(all.getResult())
+        .as("fetched all aliases")
+        .containsAllEntriesOf(new HashMap<String, Alias>() {
+          {
+            put("Bono", new Alias("PaulHewson", "Bono"));
+            put("MachineGunKelly", new Alias("GeorgeBarnes", "MachineGunKelly"));
+          }
+        });
+
+    // Act: update
+    Result<Boolean> createdMGK = client.schema().classCreator().withClass(WeaviateClass.builder()
+        .className("ColsonBaker").build()).run().get();
+    assumeTrue(createdMGK.getResult(), "created ColsonBaker collection");
+
+    client.aliases().updater().withAlias("MachineGunKelly").withNewClassName("ColsonBaker").run().get();
+
+    // Assert: get one
+    Result<Alias> mgk = client.aliases().getter().withAlias("MachineGunKelly").run().get();
+
+    Assertions.assertThat(mgk.getResult())
+        .as("MachineGunKelly alias points to ColsonBaker")
+        .returns("MachineGunKelly", Alias::getAlias)
+        .returns("ColsonBaker", Alias::getClassName);
+
+    // Act: delete
+    client.aliases().deleter().withAlias("Bono").run().get();
+
+    // Assert
+    Result<Alias> bono = client.aliases().getter().withAlias("Bono").run().get();
+    Assertions.assertThat(bono)
+        .as("Bono alias deleted")
+        .returns(null, Result::getResult)
+        .extracting(Result::getError).isNull();
+  }
+}

--- a/src/test/java/io/weaviate/integration/tests/rbac/ClientRbacTestSuite.java
+++ b/src/test/java/io/weaviate/integration/tests/rbac/ClientRbacTestSuite.java
@@ -24,7 +24,7 @@ import com.jparams.junit4.description.Name;
 
 import io.weaviate.client.Config;
 import io.weaviate.client.base.Result;
-import io.weaviate.client.v1.rbac.model.AliasesPermission;
+import io.weaviate.client.v1.rbac.model.AliasPermission;
 import io.weaviate.client.v1.rbac.model.BackupsPermission;
 import io.weaviate.client.v1.rbac.model.ClusterPermission;
 import io.weaviate.client.v1.rbac.model.CollectionsPermission;
@@ -137,7 +137,7 @@ public class ClientRbacTestSuite {
     String myCollectionAlias = "PizzaAlias";
 
     Permission<?>[] wantPermissions = new Permission<?>[] {
-        Permission.aliases(myCollectionAlias, AliasesPermission.Action.CREATE),
+        Permission.alias(myCollectionAlias, AliasPermission.Action.CREATE),
         Permission.backups(myCollection, BackupsPermission.Action.MANAGE),
         Permission.cluster(ClusterPermission.Action.READ),
         Permission.nodes(myCollection, NodesPermission.Action.READ),

--- a/src/test/java/io/weaviate/integration/tests/rbac/ClientRbacTestSuite.java
+++ b/src/test/java/io/weaviate/integration/tests/rbac/ClientRbacTestSuite.java
@@ -137,7 +137,7 @@ public class ClientRbacTestSuite {
     String myCollectionAlias = "PizzaAlias";
 
     Permission<?>[] wantPermissions = new Permission<?>[] {
-        Permission.alias(myCollectionAlias, AliasesPermission.Action.CREATE),
+        Permission.aliases(myCollectionAlias, AliasesPermission.Action.CREATE),
         Permission.backups(myCollection, BackupsPermission.Action.MANAGE),
         Permission.cluster(ClusterPermission.Action.READ),
         Permission.nodes(myCollection, NodesPermission.Action.READ),

--- a/src/test/java/io/weaviate/integration/tests/rbac/ClientRbacTestSuite.java
+++ b/src/test/java/io/weaviate/integration/tests/rbac/ClientRbacTestSuite.java
@@ -24,6 +24,7 @@ import com.jparams.junit4.description.Name;
 
 import io.weaviate.client.Config;
 import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.rbac.model.AliasesPermission;
 import io.weaviate.client.v1.rbac.model.BackupsPermission;
 import io.weaviate.client.v1.rbac.model.ClusterPermission;
 import io.weaviate.client.v1.rbac.model.CollectionsPermission;
@@ -133,8 +134,10 @@ public class ClientRbacTestSuite {
     Rbac roles = rbac.get();
     String myRole = roleName("VectorOwner");
     String myCollection = "Pizza";
+    String myCollectionAlias = "PizzaAlias";
 
     Permission<?>[] wantPermissions = new Permission<?>[] {
+        Permission.alias(myCollectionAlias, AliasesPermission.Action.CREATE),
         Permission.backups(myCollection, BackupsPermission.Action.MANAGE),
         Permission.cluster(ClusterPermission.Action.READ),
         Permission.nodes(myCollection, NodesPermission.Action.READ),


### PR DESCRIPTION
This PR adds API for managing collection aliases and extends the set of permissions with `AliasesPermissions`.


### Manage aliases

```java
client.aliases().creator().withClassName("Pizza").withAlias("PizzaPie").run();
client.aliases().allGetter().run();
client.aliases().getter().withAlias("PizzaPie").run();
client.aliases().updater().withAlias("PizzaPie").withNewClassName("Langos").run();
client.aliases().deleter().withAlias("PizzaPie").run();
```

### Manage alias permissions

```java
.withPermissions(
    Permission.aliases("PizzaPie", AliasesPermission.Action.CREATE, AliasesPermission.Action.DELETE)
); 
```
