### PR TITLE
Bump commons version to 3.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <lombok.version>1.18.36</lombok.version>
     <gson.version>2.12.1</gson.version>
     <httpclient.version>5.4.3</httpclient.version>
-    <lang3.version>3.17.0</lang3.version>
+    <lang3.version>3.18.0</lang3.version>
     <junit.version>5.12.0</junit.version>
     <testcontainers.version>1.20.5</testcontainers.version>
     <assertj-core.version>3.27.3</assertj-core.version>


### PR DESCRIPTION
Hi, this PR bumps the version of Apache commons-lang in the Java client to 3.18.0. This resolves an uncontrolled recursion vulnerability via the ClassUtils.getClass function where an attacker can cause the application to terminate unexpectedly by providing excessively long input values.

The CVE is here: https://www.cve.org/CVERecord?id=CVE-2025-48924

The CVSS is an unusually high 8.8 so please merge as a priority. https://www.first.org/cvss/calculator/4-0#CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:L/VA:H/SC:N/SI:N/SA:N