### PR TITLE
🔒 chore(security): upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <lombok.version>1.18.36</lombok.version>
     <gson.version>2.12.1</gson.version>
     <httpclient.version>5.4.3</httpclient.version>
-    <lang3.version>3.17.0</lang3.version>
+    <lang3.version>3.18.0</lang3.version>
     <junit.version>5.12.0</junit.version>
     <testcontainers.version>1.20.5</testcontainers.version>
     <assertj-core.version>3.27.3</assertj-core.version>
@@ -72,11 +72,11 @@
     <jackson.version>2.18.3</jackson.version>
     <oauth2-oidc-sdk.version>11.23.1</oauth2-oidc-sdk.version>
     <mock-server.version>5.15.0</mock-server.version>
-    <protobuf.java.version>4.29.3</protobuf.java.version>
-    <protobuf.java-util.version>4.29.3</protobuf.java-util.version>
-    <grpc-netty-shaded.version>1.68.2</grpc-netty-shaded.version>
-    <grpc-protobuf.version>1.70.0</grpc-protobuf.version>
-    <grpc-stub.version>1.68.2</grpc-stub.version>
+    <protobuf.java.version>4.30.0</protobuf.java.version>
+    <protobuf.java-util.version>4.30.0</protobuf.java-util.version>
+    <grpc-protobuf.version>1.71.0</grpc-protobuf.version>
+    <grpc-stub.version>1.70.0</grpc-stub.version>
+    <grpc-netty-shaded.version>1.70.0</grpc-netty-shaded.version>
     <annotations-api.version>6.0.53</annotations-api.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <grpc-protobuf.version>1.73.0</grpc-protobuf.version>
     <grpc-stub.version>1.73.0</grpc-stub.version>
     <grpc-netty-shaded.version>1.73.0</grpc-netty-shaded.version>
-    <annotations-api.version>11.0.9</annotations-api.version>
+    <annotations-api.version>6.0.53</annotations-api.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -57,26 +57,26 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.release>8</maven.compiler.release>
-    <lombok.version>1.18.36</lombok.version>
-    <gson.version>2.12.1</gson.version>
-    <httpclient.version>5.4.3</httpclient.version>
+    <lombok.version>1.18.38</lombok.version>
+    <gson.version>2.13.1</gson.version>
+    <httpclient.version>5.5</httpclient.version>
     <lang3.version>3.18.0</lang3.version>
-    <junit.version>5.12.0</junit.version>
-    <testcontainers.version>1.20.5</testcontainers.version>
+    <junit.version>5.13.3</junit.version>
+    <testcontainers.version>1.21.3</testcontainers.version>
     <assertj-core.version>3.27.3</assertj-core.version>
     <jparams.version>1.0.4</jparams.version>
-    <mockito.version>5.15.2</mockito.version>
+    <mockito.version>5.18.0</mockito.version>
     <slf4j.version>2.0.17</slf4j.version>
-    <logback.version>1.5.17</logback.version>
+    <logback.version>1.5.18</logback.version>
     <mock-server.version>5.14.0</mock-server.version>
-    <jackson.version>2.18.3</jackson.version>
-    <oauth2-oidc-sdk.version>11.23.1</oauth2-oidc-sdk.version>
+    <jackson.version>2.19.1</jackson.version>
+    <oauth2-oidc-sdk.version>11.26</oauth2-oidc-sdk.version>
     <mock-server.version>5.15.0</mock-server.version>
-    <protobuf.java.version>4.30.0</protobuf.java.version>
-    <protobuf.java-util.version>4.30.0</protobuf.java-util.version>
-    <grpc-protobuf.version>1.71.0</grpc-protobuf.version>
-    <grpc-stub.version>1.70.0</grpc-stub.version>
-    <grpc-netty-shaded.version>1.70.0</grpc-netty-shaded.version>
+    <protobuf.java.version>4.31.1</protobuf.java.version>
+    <protobuf.java-util.version>4.31.1</protobuf.java-util.version>
+    <grpc-protobuf.version>1.73.0</grpc-protobuf.version>
+    <grpc-stub.version>1.73.0</grpc-stub.version>
+    <grpc-netty-shaded.version>1.73.0</grpc-netty-shaded.version>
     <annotations-api.version>6.0.53</annotations-api.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <grpc-protobuf.version>1.73.0</grpc-protobuf.version>
     <grpc-stub.version>1.73.0</grpc-stub.version>
     <grpc-netty-shaded.version>1.73.0</grpc-netty-shaded.version>
-    <annotations-api.version>6.0.53</annotations-api.version>
+    <annotations-api.version>11.0.9</annotations-api.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
‼️ org.apache.commons::commons-lang3 3.17.0 -> 3.18.0 prevents severe vulnerability: https://www.cve.org/CVERecord?id=CVE-2025-48924

Minor upgrades:
- io.grpc:grpc-protobuf 1.70.0 -> 1.71.0
- io.grpc:grpc-stub 1.68.2 -> 1.70.0
- io.grpc:grpc-netty-shaded 1.68.2 -> 1.70.0
- com.google.protobuf:protobuf-java(-util) 4.29.3 -> 4.30.0
- and more: https://github.com/weaviate/java-client/pull/413/commits/4e1823893aeddc774f4ecedeaa0f4fd049d6c02a, https://github.com/weaviate/java-client/pull/413/commits/2f08434a6d21198295ed124195f78c6bd61816ce

Supersedes these PRs: #359, #360, #365, #366, #367, #411, #412 