### PR TITLE
Configure alias permissions per collection

### DIFF
--- a/src/main/java/io/weaviate/client/v1/rbac/model/AliasPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/AliasPermission.java
@@ -8,14 +8,16 @@ import lombok.Getter;
 @EqualsAndHashCode(callSuper = true)
 public class AliasPermission extends Permission<AliasPermission> {
   final String alias;
+  final String collection;
 
-  public AliasPermission(String alias, Action... actions) {
+  public AliasPermission(String alias, String collection, Action... actions) {
     super(actions);
     this.alias = alias;
+    this.collection = collection;
   }
 
-  AliasPermission(String alias, String action) {
-    this(alias, RbacAction.fromString(Action.class, action));
+  AliasPermission(String alias, String collection, String action) {
+    this(alias, collection, RbacAction.fromString(Action.class, action));
   }
 
   @AllArgsConstructor

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
@@ -67,7 +67,8 @@ public abstract class Permission<P extends Permission<P>> {
   public static Permission<?> fromWeaviate(WeaviatePermission perm) {
     String action = perm.getAction();
     if (perm.getAliases() != null) {
-      return new AliasPermission(perm.getAliases().getAlias(), action);
+      AliasPermission aliases = perm.getAliases();
+      return new AliasPermission(aliases.getAlias(), aliases.getCollection(), action);
     } else if (perm.getBackups() != null) {
       return new BackupsPermission(perm.getBackups().getCollection(), action);
     } else if (perm.getCollections() != null) {
@@ -132,11 +133,11 @@ public abstract class Permission<P extends Permission<P>> {
    * Create {@link AliasPermission} for an alias.
    * <p>
    * Example:
-   * {@code Permission.alias("PizzaAlias", AliasPermission.Action.CREATE) }
+   * {@code Permission.alias("PizzaAlias", "Pizza", AliasPermission.Action.CREATE) }
    */
-  public static AliasPermission alias(String alias, AliasPermission.Action... actions) {
+  public static AliasPermission alias(String alias, String collection, AliasPermission.Action... actions) {
     checkDeprecation(actions);
-    return new AliasPermission(alias, actions);
+    return new AliasPermission(alias, collection, actions);
   }
 
   /**

--- a/src/test/java/io/weaviate/client/v1/rbac/api/WeaviatePermissionTest.java
+++ b/src/test/java/io/weaviate/client/v1/rbac/api/WeaviatePermissionTest.java
@@ -28,8 +28,8 @@ public class WeaviatePermissionTest {
   public void testMergedPermissions() {
     WeaviatePermission[] apiPermissions = {
         // Create and delete PizzaAlias alias
-        new WeaviatePermission("create_aliases", new AliasPermission("PizzaAlias")),
-        new WeaviatePermission("delete_aliases", new AliasPermission("PizzaAlias")),
+        new WeaviatePermission("create_aliases", new AliasPermission("PizzaAlias", "Pizza")),
+        new WeaviatePermission("delete_aliases", new AliasPermission("PizzaAlias", "Pizza")),
 
         // Manage Pizza backups
         new WeaviatePermission("manage_backups", new BackupsPermission("Pizza")),
@@ -75,7 +75,7 @@ public class WeaviatePermissionTest {
     };
 
     Permission<?>[] libraryPermissions = {
-        new AliasPermission("PizzaAlias", AliasPermission.Action.CREATE, AliasPermission.Action.DELETE),
+        new AliasPermission("PizzaAlias", "Pizza", AliasPermission.Action.CREATE, AliasPermission.Action.DELETE),
         new BackupsPermission("Pizza", BackupsPermission.Action.MANAGE),
         new DataPermission("Pizza", DataPermission.Action.MANAGE, DataPermission.Action.READ),
         new DataPermission("Songs", DataPermission.Action.UPDATE, DataPermission.Action.DELETE),

--- a/src/test/java/io/weaviate/client/v1/rbac/model/PermissionTest.java
+++ b/src/test/java/io/weaviate/client/v1/rbac/model/PermissionTest.java
@@ -23,7 +23,7 @@ import io.weaviate.client.v1.rbac.api.WeaviatePermission;
 @RunWith(JParamsTestRunner.class)
 public class PermissionTest {
   public static Object[][] serializationTestCases() {
-    AliasPermission alias = new AliasPermission("PizzaAlias", AliasPermission.Action.CREATE);
+    AliasPermission alias = new AliasPermission("PizzaAlias", "Pizza", AliasPermission.Action.CREATE);
     BackupsPermission backups = new BackupsPermission("Pizza", BackupsPermission.Action.MANAGE);
     DataPermission data = new DataPermission("Pizza", DataPermission.Action.MANAGE);
     NodesPermission nodes = new NodesPermission("Pizza", NodesPermission.Action.READ);

--- a/src/test/java/io/weaviate/integration/tests/rbac/ClientRbacTestSuite.java
+++ b/src/test/java/io/weaviate/integration/tests/rbac/ClientRbacTestSuite.java
@@ -137,7 +137,7 @@ public class ClientRbacTestSuite {
     String myCollectionAlias = "PizzaAlias";
 
     Permission<?>[] wantPermissions = new Permission<?>[] {
-        Permission.alias(myCollectionAlias, AliasPermission.Action.CREATE),
+        Permission.alias(myCollectionAlias, myCollection, AliasPermission.Action.CREATE),
         Permission.backups(myCollection, BackupsPermission.Action.MANAGE),
         Permission.cluster(ClusterPermission.Action.READ),
         Permission.nodes(myCollection, NodesPermission.Action.READ),


### PR DESCRIPTION
Follow-up to #409: accept `collection` parameter for AliasPermission ([reference Python PR](https://github.com/weaviate/weaviate-python-client/pull/1734)).