### PR TITLE
v6: include a shaded version of client6 in deployment bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Official Weaviate Java Client.
 
 ## Usage
 
-To start using Weaviate Java Client add this dependency to `pom.xml`:
+To start using Weaviate Java Client add the dependency to `pom.xml`:
 
 ```xml
 
@@ -17,11 +17,17 @@ To start using Weaviate Java Client add this dependency to `pom.xml`:
 </dependency>
 ```
 
-### For applications on Java 9 or above
+### Uber JAR🫙
+
+If you're building a uber-JAR with something like `maven-assembly-plugin`, use a shaded version with classifier `all`.  
+This ensures that all dynamically-loaded dependecies of `io.grpc` are resolved correctly.
+
+
+### Gson and reflective access to internal JDK classes
 
 The client uses Google's [`gson`](https://github.com/google/gson) for JSON de-/serialization which does reflection on internal `java.lang` classes. This is _not allowed by default_ in Java 9 and above.
 
-To work around this, it's necessary to add this JVM commandline argument:
+To work around this, it's necessary to add this JVM command line argument:
 
 ```
 --add-opens=java.base/java.lang=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,6 @@
             <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.58.0:exe:${os.detected.classifier}</pluginArtifact>
             <outputDirectory>src/main/java</outputDirectory>
             <clearOutputDirectory>false</clearOutputDirectory>
-
           </configuration>
           <executions>
             <execution>
@@ -445,6 +444,28 @@
           <artifactId>maven-project-info-reports-plugin</artifactId>
           <version>3.1.1my</version>
         </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>3.6.0</version>
+          <configuration>
+            <createDependencyReducedPom>false</createDependencyReducedPom>
+            <shadedArtifactAttached>true</shadedArtifactAttached>
+            <shadedClassifierName>all</shadedClassifierName>
+            <transformers>
+              <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+            </transformers>
+          </configuration>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                <goal>shade</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -463,6 +484,10 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Resolves #422 

### Problem

Trying to `java -jar` a fat JAR built with something like `maven-assembly-plugin` users will see this error as soon as they try to instantiate WeaviateClient:

```sh
Exception in thread "main" java.lang.IllegalArgumentException: Address types of NameResolver 'unix' for 'grpc-
blahblahblah.gcp.weaviate.cloud:443' not supported by transport
        at io.grpc.internal.ManagedChannelImplBuilder.getNameResolverProvider(ManagedChannelImplBuilder.java:8
50)
        at io.grpc.internal.ManagedChannelImplBuilder.build(ManagedChannelImplBuilder.java:700)
        at io.grpc.ForwardingChannelBuilder2.build(ForwardingChannelBuilder2.java:272)
        at io.weaviate.client6.v1.internal.grpc.DefaultGrpcTransport.buildChannel(DefaultGrpcTransport.java:92
)
        at io.weaviate.client6.v1.internal.grpc.DefaultGrpcTransport.<init>(DefaultGrpcTransport.java:24)
        at io.weaviate.client6.v1.api.WeaviateClient.<init>(WeaviateClient.java:26)
        at io.weaviate.client6.v1.api.WeaviateClient.custom(WeaviateClient.java:54)
``` 

After some investigation (and with invaluable help from @Dabz) the problem is this:

`io.grpc` uses META-INF/services to dynamically load NameResolver providers. When building a fat JAR, plugins like maven-assembly-plugin won't merge overlapping config files without an additional configuration on the end-user's side.

[This comment](https://github.com/grpc/grpc-java/issues/10853#issuecomment-1917363853) is also very insightful.

### Solution

While configuring the plugin is not difficult and we could document this in our README, we will do our users one better:
using `maven-shade-plugin` we can distribute a shaded version of client6 with all its' dependencies' configurations resolved in advance (in addition to the 'slim' version of the lib).

Now, when trying to build a fat JAR all that our users will need to do is include `<classifier>all</classifier>` tag to `client6` <dependency> block.

```xml
<dependency>
  <groupId>io.weaviate</groupId>
  <artifactId>client6</artifactId>
  <version>6.0.0-XXX</artifactId>
  <classifier>all</classifier>
<dependency>
```
