### PR TITLE
v6: add CollectionHandle `.size()` shortcut

### DIFF
--- a/src/it/java/io/weaviate/integration/AggregationITest.java
+++ b/src/it/java/io/weaviate/integration/AggregationITest.java
@@ -165,4 +165,13 @@ public class AggregationITest extends ConcurrentTest {
               .as(desc.apply("median")).returns((double) expectedPrice, IntegerAggregation.Values::median);
         });
   }
+
+  @Test
+  public void testCollestionSizeShortcut() {
+    var things = client.collections.use(COLLECTION);
+    var countAggregate = things.aggregate
+        .overAll(x -> x.includeTotalCount(true)).totalCount();
+    var size = things.size();
+    Assertions.assertThat(size).isEqualTo(countAggregate);
+  }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/CollectionHandle.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/CollectionHandle.java
@@ -1,5 +1,6 @@
 package io.weaviate.client6.v1.api.collections;
 
+import java.util.Collection;
 import java.util.function.Function;
 
 import io.weaviate.client6.v1.api.collections.aggregate.WeaviateAggregateClient;
@@ -35,5 +36,25 @@ public class CollectionHandle<T> {
 
   public Paginator<T> paginate(Function<Paginator.Builder<T>, ObjectBuilder<Paginator<T>>> fn) {
     return Paginator.of(this.query, fn);
+  }
+
+  /**
+   * Get the object count in this collection.
+   *
+   * <p>
+   * While made to resemeble {@link Collection#size}, counting Weaviate collection
+   * objects involves making a network call, making this a blocking operation.
+   * This method also does not define behaviour for cases where the size of the
+   * collection exceeds {@link Long#MAX_VALUE} as this is unlikely to happen.
+   *
+   * <p>
+   * This is a shortcut for:
+   *
+   * <pre>{@code
+   * handle.aggregate.overAll(all -> all.includeTotalCount(true)).totalCount()
+   * }</pre>
+   */
+  public long size() {
+    return this.aggregate.overAll(all -> all.includeTotalCount(true)).totalCount();
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/CollectionHandleAsync.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/CollectionHandleAsync.java
@@ -1,7 +1,10 @@
 package io.weaviate.client6.v1.api.collections;
 
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
+import io.weaviate.client6.v1.api.collections.aggregate.AggregateResponse;
 import io.weaviate.client6.v1.api.collections.aggregate.WeaviateAggregateClientAsync;
 import io.weaviate.client6.v1.api.collections.config.WeaviateConfigClientAsync;
 import io.weaviate.client6.v1.api.collections.data.WeaviateDataClientAsync;
@@ -36,5 +39,29 @@ public class CollectionHandleAsync<PropertiesT> {
   public AsyncPaginator<PropertiesT> paginate(
       Function<AsyncPaginator.Builder<PropertiesT>, ObjectBuilder<AsyncPaginator<PropertiesT>>> fn) {
     return AsyncPaginator.of(this.query, fn);
+  }
+
+  /**
+   * Get the object count in this collection.
+   *
+   * <p>
+   * While made to resemeble {@link Collection#size}, counting Weaviate collection
+   * objects involves making a network call; still, this operation is
+   * non-blocking, as resolving the underlying {@code CompletableFuture} is
+   * deferred to the caller.
+   *
+   * This method also does not define behaviour for cases where the size of the
+   * collection exceeds {@link Long#MAX_VALUE} as this is unlikely to happen.
+   *
+   * <p>
+   * This is a shortcut for:
+   *
+   * <pre>{@code
+   * handle.aggregate.overAll(all -> all.includeTotalCount(true)).totalCount()
+   * }</pre>
+   */
+  public CompletableFuture<Long> size() {
+    return this.aggregate.overAll(all -> all.includeTotalCount(true))
+        .thenApply(AggregateResponse::totalCount);
   }
 }


### PR DESCRIPTION
Similarly to how Python's "collection" object has `__len__` override, CollectionHandle will have `.size()` to retrieve collection size idiomatically.


```java
var things = client.collections.use("Things");
System.out.printf("Collection Things has %d elements", things.size());
```

The -async version of this method is non-blocking.


`resolves` #423 