### PR TITLE
fix(v6): add defensive checks to JSON deserialization

### DIFF
--- a/src/main/java/io/weaviate/client6/v1/api/collections/CollectionConfig.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/CollectionConfig.java
@@ -289,7 +289,7 @@ public record CollectionConfig(
 
           // Separate modules into reranker- and generative- modules.
           var rerankerModules = new JsonArray();
-          if (jsonObject.has("moduleConfig")) {
+          if (jsonObject.has("moduleConfig") && jsonObject.get("moduleConfig").isJsonObject()) {
             var moduleConfig = jsonObject.remove("moduleConfig").getAsJsonObject();
 
             moduleConfig.entrySet().stream()

--- a/src/main/java/io/weaviate/client6/v1/api/collections/CollectionConfig.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/CollectionConfig.java
@@ -264,16 +264,19 @@ public record CollectionConfig(
         public CollectionConfig read(JsonReader in) throws IOException {
           var jsonObject = JsonParser.parseReader(in).getAsJsonObject();
 
-          var mixedProperties = jsonObject.get("properties").getAsJsonArray();
           var references = new JsonArray();
           var properties = new JsonArray();
 
-          for (var property : mixedProperties) {
-            var dataTypes = property.getAsJsonObject().get("dataType").getAsJsonArray();
-            if (dataTypes.size() == 1 && DataType.KNOWN_TYPES.contains(dataTypes.get(0).getAsString())) {
-              properties.add(property);
-            } else {
-              references.add(property);
+          if (jsonObject.has("properties") && jsonObject.get("properties").isJsonArray()) {
+            var mixedProperties = jsonObject.get("properties").getAsJsonArray();
+
+            for (var property : mixedProperties) {
+              var dataTypes = property.getAsJsonObject().get("dataType").getAsJsonArray();
+              if (dataTypes.size() == 1 && DataType.KNOWN_TYPES.contains(dataTypes.get(0).getAsString())) {
+                properties.add(property);
+              } else {
+                references.add(property);
+              }
             }
           }
 

--- a/src/test/java/io/weaviate/client6/v1/internal/json/JSONTest.java
+++ b/src/test/java/io/weaviate/client6/v1/internal/json/JSONTest.java
@@ -400,7 +400,7 @@ public class JSONTest {
             "result": { "status": "SUCCESS", "errors": {} }
           },
           {
-            "result": { "status": "FAILED", "errors": jsonObject.has("properties") && {
+            "result": { "status": "FAILED", "errors": {
               "error": [ "oops" ]
             }}
           }

--- a/src/test/java/io/weaviate/client6/v1/internal/json/JSONTest.java
+++ b/src/test/java/io/weaviate/client6/v1/internal/json/JSONTest.java
@@ -400,7 +400,7 @@ public class JSONTest {
             "result": { "status": "SUCCESS", "errors": {} }
           },
           {
-            "result": { "status": "FAILED", "errors": {
+            "result": { "status": "FAILED", "errors": jsonObject.has("properties") && {
               "error": [ "oops" ]
             }}
           }
@@ -412,5 +412,15 @@ public class JSONTest {
     Assertions.assertThat(got.errors())
         .as("response contains 1 error")
         .hasSize(1);
+  }
+
+  @Test
+  public void test_CollectionConfig_read_empty() {
+    var json = """
+        { "class": "BarebonesCollection" }
+        """;
+    Assertions.assertThatCode(() -> JSON.deserialize(json, CollectionConfig.class))
+        .as("deserialize CollectionConfig with no properties")
+        .doesNotThrowAnyException();
   }
 }


### PR DESCRIPTION
If a collection has no properties, trying to read `"properties"` as JSON array will produce a NPE. This PR adds additional checks to that part of the code.