### PR TITLE
v6: Relocate gRPC dependencies in a shaded library version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -472,6 +472,19 @@
             <transformers>
               <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
             </transformers>
+            <!-- Common gRPC dependencies may appear in user's project under different, -->
+            <!-- incompatible versions. Relocating them in a shaded version of the package -->
+            <!-- avoids dependency conflicts. -->
+            <relocations>
+              <relocation>
+                <pattern>com.google.protobuf</pattern>
+                <shadedPattern>io.weaviate.shaded.com.google.protobuf</shadedPattern>
+              </relocation>
+              <relocation>
+                <pattern>io.grpc</pattern>
+                <shadedPattern>io.weaviate.shaded.io.grpc</shadedPattern>
+              </relocation>
+            </relocations>
           </configuration>
           <executions>
             <execution>


### PR DESCRIPTION
Users of `client6` may be relying on incompatible versions of gRPC dependencies for their projects. To avoid conflicts, the shaded version of `client6` introduced in #429 must also relocate these dependencies.

This PR adds configuration to relocate `io.grpc` and `com.google.protobuf` dependencies under `io.weaviate.shaded.io.grpc` and `io.weaviate.shaded.com.google.protobuf` respectively.