### PR TITLE
v6: Per-collection-handle consistency

### DIFF
--- a/src/main/java/io/weaviate/client6/v1/api/collections/CollectionHandle.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/CollectionHandle.java
@@ -7,34 +7,50 @@ import io.weaviate.client6.v1.api.collections.aggregate.WeaviateAggregateClient;
 import io.weaviate.client6.v1.api.collections.config.WeaviateConfigClient;
 import io.weaviate.client6.v1.api.collections.data.WeaviateDataClient;
 import io.weaviate.client6.v1.api.collections.pagination.Paginator;
+import io.weaviate.client6.v1.api.collections.query.ConsistencyLevel;
 import io.weaviate.client6.v1.api.collections.query.WeaviateQueryClient;
 import io.weaviate.client6.v1.internal.ObjectBuilder;
 import io.weaviate.client6.v1.internal.grpc.GrpcTransport;
 import io.weaviate.client6.v1.internal.orm.CollectionDescriptor;
 import io.weaviate.client6.v1.internal.rest.RestTransport;
 
-public class CollectionHandle<T> {
+public class CollectionHandle<PropertiesT> {
   public final WeaviateConfigClient config;
-  public final WeaviateDataClient<T> data;
-  public final WeaviateQueryClient<T> query;
+  public final WeaviateDataClient<PropertiesT> data;
+  public final WeaviateQueryClient<PropertiesT> query;
   public final WeaviateAggregateClient aggregate;
+
+  private final CollectionHandleDefaults defaults;
 
   public CollectionHandle(
       RestTransport restTransport,
       GrpcTransport grpcTransport,
-      CollectionDescriptor<T> collectionDescriptor) {
-
+      CollectionDescriptor<PropertiesT> collectionDescriptor,
+      CollectionHandleDefaults defaults) {
     this.config = new WeaviateConfigClient(collectionDescriptor, restTransport, grpcTransport);
-    this.data = new WeaviateDataClient<>(collectionDescriptor, restTransport, grpcTransport);
-    this.query = new WeaviateQueryClient<>(collectionDescriptor, grpcTransport);
     this.aggregate = new WeaviateAggregateClient(collectionDescriptor, grpcTransport);
+    this.query = new WeaviateQueryClient<>(collectionDescriptor, grpcTransport, defaults);
+    this.data = new WeaviateDataClient<>(collectionDescriptor, restTransport, grpcTransport, query);
+
+    this.defaults = defaults;
   }
 
-  public Paginator<T> paginate() {
+  /** Copy constructor that sets new defaults. */
+  private CollectionHandle(CollectionHandle<PropertiesT> c, CollectionHandleDefaults defaults) {
+    this.config = c.config;
+    this.aggregate = c.aggregate;
+    this.query = new WeaviateQueryClient<>(c.query, defaults);
+    this.data = new WeaviateDataClient<>(c.data, query);
+
+    this.defaults = defaults;
+  }
+
+  public Paginator<PropertiesT> paginate() {
     return Paginator.of(this.query);
   }
 
-  public Paginator<T> paginate(Function<Paginator.Builder<T>, ObjectBuilder<Paginator<T>>> fn) {
+  public Paginator<PropertiesT> paginate(
+      Function<Paginator.Builder<PropertiesT>, ObjectBuilder<Paginator<PropertiesT>>> fn) {
     return Paginator.of(this.query, fn);
   }
 
@@ -56,5 +72,13 @@ public class CollectionHandle<T> {
    */
   public long size() {
     return this.aggregate.overAll(all -> all.includeTotalCount(true)).totalCount();
+  }
+
+  public ConsistencyLevel consistencyLevel() {
+    return defaults.consistencyLevel();
+  }
+
+  public CollectionHandle<PropertiesT> withConsistencyLevel(ConsistencyLevel consistencyLevel) {
+    return new CollectionHandle<>(this, CollectionHandleDefaults.of(def -> def.consistencyLevel(consistencyLevel)));
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/CollectionHandle.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/CollectionHandle.java
@@ -28,7 +28,7 @@ public class CollectionHandle<PropertiesT> {
       CollectionDescriptor<PropertiesT> collectionDescriptor,
       CollectionHandleDefaults defaults) {
     this.config = new WeaviateConfigClient(collectionDescriptor, restTransport, grpcTransport);
-    this.aggregate = new WeaviateAggregateClient(collectionDescriptor, grpcTransport);
+    this.aggregate = new WeaviateAggregateClient(collectionDescriptor, grpcTransport, defaults);
     this.query = new WeaviateQueryClient<>(collectionDescriptor, grpcTransport, defaults);
     this.data = new WeaviateDataClient<>(collectionDescriptor, restTransport, grpcTransport, defaults);
 

--- a/src/main/java/io/weaviate/client6/v1/api/collections/CollectionHandle.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/CollectionHandle.java
@@ -30,7 +30,7 @@ public class CollectionHandle<PropertiesT> {
     this.config = new WeaviateConfigClient(collectionDescriptor, restTransport, grpcTransport);
     this.aggregate = new WeaviateAggregateClient(collectionDescriptor, grpcTransport);
     this.query = new WeaviateQueryClient<>(collectionDescriptor, grpcTransport, defaults);
-    this.data = new WeaviateDataClient<>(collectionDescriptor, restTransport, grpcTransport, query);
+    this.data = new WeaviateDataClient<>(collectionDescriptor, restTransport, grpcTransport, defaults);
 
     this.defaults = defaults;
   }
@@ -40,7 +40,7 @@ public class CollectionHandle<PropertiesT> {
     this.config = c.config;
     this.aggregate = c.aggregate;
     this.query = new WeaviateQueryClient<>(c.query, defaults);
-    this.data = new WeaviateDataClient<>(c.data, query);
+    this.data = new WeaviateDataClient<>(c.data, defaults);
 
     this.defaults = defaults;
   }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/CollectionHandleAsync.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/CollectionHandleAsync.java
@@ -33,7 +33,7 @@ public class CollectionHandleAsync<PropertiesT> {
     this.config = new WeaviateConfigClientAsync(collectionDescriptor, restTransport, grpcTransport);
     this.aggregate = new WeaviateAggregateClientAsync(collectionDescriptor, grpcTransport);
     this.query = new WeaviateQueryClientAsync<>(collectionDescriptor, grpcTransport, defaults);
-    this.data = new WeaviateDataClientAsync<>(collectionDescriptor, restTransport, grpcTransport, query);
+    this.data = new WeaviateDataClientAsync<>(collectionDescriptor, restTransport, grpcTransport, defaults);
 
     this.defaults = defaults;
   }
@@ -43,7 +43,7 @@ public class CollectionHandleAsync<PropertiesT> {
     this.config = c.config;
     this.aggregate = c.aggregate;
     this.query = new WeaviateQueryClientAsync<>(c.query, defaults);
-    this.data = new WeaviateDataClientAsync<>(c.data, query);
+    this.data = new WeaviateDataClientAsync<>(c.data, defaults);
 
     this.defaults = defaults;
   }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/CollectionHandleAsync.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/CollectionHandleAsync.java
@@ -31,7 +31,7 @@ public class CollectionHandleAsync<PropertiesT> {
       CollectionHandleDefaults defaults) {
 
     this.config = new WeaviateConfigClientAsync(collectionDescriptor, restTransport, grpcTransport);
-    this.aggregate = new WeaviateAggregateClientAsync(collectionDescriptor, grpcTransport);
+    this.aggregate = new WeaviateAggregateClientAsync(collectionDescriptor, grpcTransport, defaults);
     this.query = new WeaviateQueryClientAsync<>(collectionDescriptor, grpcTransport, defaults);
     this.data = new WeaviateDataClientAsync<>(collectionDescriptor, restTransport, grpcTransport, defaults);
 

--- a/src/main/java/io/weaviate/client6/v1/api/collections/CollectionHandleDefaults.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/CollectionHandleDefaults.java
@@ -14,6 +14,7 @@ import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateGrpc.WeaviateBlocki
 import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateGrpc.WeaviateFutureStub;
 import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoBatch;
 import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoBatchDelete;
+import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoSearchGet;
 import io.weaviate.client6.v1.internal.rest.Endpoint;
 import io.weaviate.client6.v1.internal.rest.EndpointBase;
 import io.weaviate.client6.v1.internal.rest.JsonEndpoint;
@@ -179,19 +180,26 @@ public record CollectionHandleDefaults(ConsistencyLevel consistencyLevel) {
     @Override
     public RequestM marshal(RequestT request) {
       var message = rpc.marshal(request);
-      if (message instanceof WeaviateProtoBatchDelete.BatchDeleteRequest msg) {
+      if (message instanceof WeaviateProtoBatch.BatchObjectsRequest msg) {
         var b = msg.toBuilder();
         if (!msg.hasConsistencyLevel() && consistencyLevel() != null) {
           consistencyLevel().appendTo(b);
           return (RequestM) b.build();
         }
-      } else if (message instanceof WeaviateProtoBatch.BatchObjectsRequest msg) {
+      } else if (message instanceof WeaviateProtoBatchDelete.BatchDeleteRequest msg) {
+        var b = msg.toBuilder();
+        if (!msg.hasConsistencyLevel() && consistencyLevel() != null) {
+          consistencyLevel().appendTo(b);
+          return (RequestM) b.build();
+        }
+      } else if (message instanceof WeaviateProtoSearchGet.SearchRequest msg) {
         var b = msg.toBuilder();
         if (!msg.hasConsistencyLevel() && consistencyLevel() != null) {
           consistencyLevel().appendTo(b);
           return (RequestM) b.build();
         }
       }
+
       return message;
     }
 

--- a/src/main/java/io/weaviate/client6/v1/api/collections/CollectionHandleDefaults.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/CollectionHandleDefaults.java
@@ -1,0 +1,45 @@
+package io.weaviate.client6.v1.api.collections;
+
+import java.util.function.Function;
+
+import io.weaviate.client6.v1.api.collections.query.ConsistencyLevel;
+import io.weaviate.client6.v1.internal.ObjectBuilder;
+
+public record CollectionHandleDefaults(ConsistencyLevel consistencyLevel) {
+  /**
+   * Set default values for query / aggregation requests.
+   *
+   * @return CollectionHandleDefaults derived from applying {@code fn} to
+   *         {@link Builder}.
+   */
+  public static CollectionHandleDefaults of(Function<Builder, ObjectBuilder<CollectionHandleDefaults>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  /**
+   * Empty collection defaults.
+   *
+   * @return An tucked builder that does not leaves all defaults unset.
+   */
+  public static Function<Builder, ObjectBuilder<CollectionHandleDefaults>> none() {
+    return ObjectBuilder.identity();
+  }
+
+  public CollectionHandleDefaults(Builder builder) {
+    this(builder.consistencyLevel);
+  }
+
+  public static final class Builder implements ObjectBuilder<CollectionHandleDefaults> {
+    private ConsistencyLevel consistencyLevel;
+
+    public Builder consistencyLevel(ConsistencyLevel consistencyLevel) {
+      this.consistencyLevel = consistencyLevel;
+      return this;
+    }
+
+    @Override
+    public CollectionHandleDefaults build() {
+      return new CollectionHandleDefaults(this);
+    }
+  }
+}

--- a/src/main/java/io/weaviate/client6/v1/api/collections/Vectorizer.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/Vectorizer.java
@@ -3,7 +3,6 @@ package io.weaviate.client6.v1.api.collections;
 import java.io.IOException;
 import java.util.EnumMap;
 import java.util.Map;
-import java.util.function.Function;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -20,7 +19,6 @@ import io.weaviate.client6.v1.api.collections.vectorizers.Multi2VecClipVectorize
 import io.weaviate.client6.v1.api.collections.vectorizers.NoneVectorizer;
 import io.weaviate.client6.v1.api.collections.vectorizers.Text2VecContextionaryVectorizer;
 import io.weaviate.client6.v1.api.collections.vectorizers.Text2VecWeaviateVectorizer;
-import io.weaviate.client6.v1.internal.ObjectBuilder;
 import io.weaviate.client6.v1.internal.json.JsonEnum;
 
 public interface Vectorizer {

--- a/src/main/java/io/weaviate/client6/v1/api/collections/WeaviateCollectionsClient.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/WeaviateCollectionsClient.java
@@ -29,7 +29,24 @@ public class WeaviateCollectionsClient {
    *         properties.
    */
   public CollectionHandle<Map<String, Object>> use(String collectionName) {
-    return new CollectionHandle<>(restTransport, grpcTransport, CollectionDescriptor.ofMap(collectionName));
+    return use(collectionName, CollectionHandleDefaults.none());
+  }
+
+  /**
+   * Obtain a handle to send requests to a particular collection.
+   * The returned object is thread-safe.
+   *
+   * @return a handle for a collection with {@code Map<String, Object>}
+   *         properties.
+   */
+  public CollectionHandle<Map<String, Object>> use(
+      String collectionName,
+      Function<CollectionHandleDefaults.Builder, ObjectBuilder<CollectionHandleDefaults>> fn) {
+    return new CollectionHandle<>(
+        restTransport,
+        grpcTransport,
+        CollectionDescriptor.ofMap(collectionName),
+        CollectionHandleDefaults.of(fn));
   }
 
   /**

--- a/src/main/java/io/weaviate/client6/v1/api/collections/WeaviateCollectionsClientAsync.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/WeaviateCollectionsClientAsync.java
@@ -22,8 +22,17 @@ public class WeaviateCollectionsClientAsync {
   }
 
   public CollectionHandleAsync<Map<String, Object>> use(String collectionName) {
-    return new CollectionHandleAsync<>(restTransport, grpcTransport,
-        CollectionDescriptor.ofMap(collectionName));
+    return use(collectionName, CollectionHandleDefaults.none());
+  }
+
+  public CollectionHandleAsync<Map<String, Object>> use(
+      String collectionName,
+      Function<CollectionHandleDefaults.Builder, ObjectBuilder<CollectionHandleDefaults>> fn) {
+    return new CollectionHandleAsync<>(
+        restTransport,
+        grpcTransport,
+        CollectionDescriptor.ofMap(collectionName),
+        CollectionHandleDefaults.of(fn));
   }
 
   public CompletableFuture<CollectionConfig> create(String name) {

--- a/src/main/java/io/weaviate/client6/v1/api/collections/aggregate/AbstractAggregateClient.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/aggregate/AbstractAggregateClient.java
@@ -3,6 +3,7 @@ package io.weaviate.client6.v1.api.collections.aggregate;
 import java.util.List;
 import java.util.function.Function;
 
+import io.weaviate.client6.v1.api.collections.CollectionHandleDefaults;
 import io.weaviate.client6.v1.api.collections.query.Hybrid;
 import io.weaviate.client6.v1.api.collections.query.NearAudio;
 import io.weaviate.client6.v1.api.collections.query.NearDepth;
@@ -20,10 +21,15 @@ import io.weaviate.client6.v1.internal.orm.CollectionDescriptor;
 abstract class AbstractAggregateClient<ResponseT, GroupedResponseT> {
   protected final CollectionDescriptor<?> collection;
   protected final GrpcTransport transport;
+  protected final CollectionHandleDefaults defaults;
 
-  AbstractAggregateClient(CollectionDescriptor<?> collection, GrpcTransport transport) {
+  AbstractAggregateClient(
+      CollectionDescriptor<?> collection,
+      GrpcTransport transport,
+      CollectionHandleDefaults defaults) {
     this.transport = transport;
     this.collection = collection;
+    this.defaults = defaults;
   }
 
   protected abstract ResponseT performRequest(Aggregation aggregation);

--- a/src/main/java/io/weaviate/client6/v1/api/collections/aggregate/WeaviateAggregateClient.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/aggregate/WeaviateAggregateClient.java
@@ -1,12 +1,16 @@
 package io.weaviate.client6.v1.api.collections.aggregate;
 
+import io.weaviate.client6.v1.api.collections.CollectionHandleDefaults;
 import io.weaviate.client6.v1.internal.grpc.GrpcTransport;
 import io.weaviate.client6.v1.internal.orm.CollectionDescriptor;
 
 public class WeaviateAggregateClient extends AbstractAggregateClient<AggregateResponse, AggregateResponseGrouped> {
 
-  public WeaviateAggregateClient(CollectionDescriptor<?> collection, GrpcTransport transport) {
-    super(collection, transport);
+  public WeaviateAggregateClient(
+      CollectionDescriptor<?> collection,
+      GrpcTransport transport,
+      CollectionHandleDefaults defaults) {
+    super(collection, transport, defaults);
   }
 
   protected final AggregateResponse performRequest(Aggregation aggregation) {

--- a/src/main/java/io/weaviate/client6/v1/api/collections/aggregate/WeaviateAggregateClientAsync.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/aggregate/WeaviateAggregateClientAsync.java
@@ -2,14 +2,18 @@ package io.weaviate.client6.v1.api.collections.aggregate;
 
 import java.util.concurrent.CompletableFuture;
 
+import io.weaviate.client6.v1.api.collections.CollectionHandleDefaults;
 import io.weaviate.client6.v1.internal.grpc.GrpcTransport;
 import io.weaviate.client6.v1.internal.orm.CollectionDescriptor;
 
 public class WeaviateAggregateClientAsync
     extends AbstractAggregateClient<CompletableFuture<AggregateResponse>, CompletableFuture<AggregateResponseGrouped>> {
 
-  public WeaviateAggregateClientAsync(CollectionDescriptor<?> collection, GrpcTransport transport) {
-    super(collection, transport);
+  public WeaviateAggregateClientAsync(
+      CollectionDescriptor<?> collection,
+      GrpcTransport transport,
+      CollectionHandleDefaults defaults) {
+    super(collection, transport, defaults);
   }
 
   protected final CompletableFuture<AggregateResponse> performRequest(Aggregation aggregation) {

--- a/src/main/java/io/weaviate/client6/v1/api/collections/data/DeleteManyRequest.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/data/DeleteManyRequest.java
@@ -2,6 +2,7 @@ package io.weaviate.client6.v1.api.collections.data;
 
 import java.util.function.Function;
 
+import io.weaviate.client6.v1.api.collections.CollectionHandleDefaults;
 import io.weaviate.client6.v1.api.collections.query.Where;
 import io.weaviate.client6.v1.internal.ObjectBuilder;
 import io.weaviate.client6.v1.internal.grpc.ByteStringUtil;
@@ -15,7 +16,8 @@ import io.weaviate.client6.v1.internal.orm.CollectionDescriptor;
 public record DeleteManyRequest(Where where, Boolean verbose, Boolean dryRun) {
 
   public static Rpc<DeleteManyRequest, WeaviateProtoBatchDelete.BatchDeleteRequest, DeleteManyResponse, WeaviateProtoBatchDelete.BatchDeleteReply> rpc(
-      CollectionDescriptor<?> collectionDescriptor) {
+      CollectionDescriptor<?> collectionDescriptor,
+      CollectionHandleDefaults defaults) {
     return Rpc
         .of(
             request -> {
@@ -27,6 +29,9 @@ public record DeleteManyRequest(Where where, Boolean verbose, Boolean dryRun) {
               }
               if (request.dryRun != null) {
                 message.setDryRun(request.dryRun);
+              }
+              if (defaults.consistencyLevel() != null) {
+                defaults.consistencyLevel().appendTo(message);
               }
 
               var filters = WeaviateProtoBase.Filters.newBuilder();

--- a/src/main/java/io/weaviate/client6/v1/api/collections/data/DeleteManyRequest.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/data/DeleteManyRequest.java
@@ -16,48 +16,46 @@ import io.weaviate.client6.v1.internal.orm.CollectionDescriptor;
 public record DeleteManyRequest(Where where, Boolean verbose, Boolean dryRun) {
 
   public static Rpc<DeleteManyRequest, WeaviateProtoBatchDelete.BatchDeleteRequest, DeleteManyResponse, WeaviateProtoBatchDelete.BatchDeleteReply> rpc(
-      CollectionDescriptor<?> collectionDescriptor,
+      CollectionDescriptor<?> collection,
       CollectionHandleDefaults defaults) {
-    return Rpc
-        .of(
-            request -> {
-              var message = WeaviateProtoBatchDelete.BatchDeleteRequest.newBuilder();
-              message.setCollection(collectionDescriptor.name());
+    return defaults.rpc(
+        Rpc
+            .of(
+                request -> {
+                  var message = WeaviateProtoBatchDelete.BatchDeleteRequest.newBuilder();
+                  message.setCollection(collection.name());
 
-              if (request.verbose != null) {
-                message.setVerbose(request.verbose);
-              }
-              if (request.dryRun != null) {
-                message.setDryRun(request.dryRun);
-              }
-              if (defaults.consistencyLevel() != null) {
-                defaults.consistencyLevel().appendTo(message);
-              }
+                  if (request.verbose != null) {
+                    message.setVerbose(request.verbose);
+                  }
+                  if (request.dryRun != null) {
+                    message.setDryRun(request.dryRun);
+                  }
 
-              var filters = WeaviateProtoBase.Filters.newBuilder();
-              request.where.appendTo(filters);
-              message.setFilters(filters);
+                  var filters = WeaviateProtoBase.Filters.newBuilder();
+                  request.where.appendTo(filters);
+                  message.setFilters(filters);
 
-              return message.build();
-            },
-            reply -> {
-              var objects = reply.getObjectsList()
-                  .stream()
-                  .map(obj -> new DeleteManyResponse.DeletedObject(
-                      ByteStringUtil.decodeUuid(obj.getUuid()).toString(),
-                      obj.getSuccessful(),
-                      obj.getError()))
-                  .toList();
+                  return message.build();
+                },
+                reply -> {
+                  var objects = reply.getObjectsList()
+                      .stream()
+                      .map(obj -> new DeleteManyResponse.DeletedObject(
+                          ByteStringUtil.decodeUuid(obj.getUuid()).toString(),
+                          obj.getSuccessful(),
+                          obj.getError()))
+                      .toList();
 
-              return new DeleteManyResponse(
-                  reply.getTook(),
-                  reply.getFailed(),
-                  reply.getMatches(),
-                  reply.getSuccessful(),
-                  objects);
-            },
-            () -> WeaviateBlockingStub::batchDelete,
-            () -> WeaviateFutureStub::batchDelete);
+                  return new DeleteManyResponse(
+                      reply.getTook(),
+                      reply.getFailed(),
+                      reply.getMatches(),
+                      reply.getSuccessful(),
+                      objects);
+                },
+                () -> WeaviateBlockingStub::batchDelete,
+                () -> WeaviateFutureStub::batchDelete));
   }
 
   public static DeleteManyRequest of(Where where) {

--- a/src/main/java/io/weaviate/client6/v1/api/collections/data/DeleteObjectRequest.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/data/DeleteObjectRequest.java
@@ -2,13 +2,23 @@ package io.weaviate.client6.v1.api.collections.data;
 
 import java.util.Collections;
 
+import io.weaviate.client6.v1.api.collections.CollectionHandleDefaults;
+import io.weaviate.client6.v1.api.collections.CollectionHandleDefaults.Location;
+import io.weaviate.client6.v1.internal.orm.CollectionDescriptor;
 import io.weaviate.client6.v1.internal.rest.Endpoint;
 import io.weaviate.client6.v1.internal.rest.SimpleEndpoint;
 
-public record DeleteObjectRequest(String collectionName, String uuid) {
+public record DeleteObjectRequest(String uuid) {
 
-  public static final Endpoint<DeleteObjectRequest, Void> _ENDPOINT = SimpleEndpoint.sideEffect(
-      request -> "DELETE",
-      request -> "/objects/" + request.collectionName + "/" + request.uuid,
-      request -> Collections.emptyMap());
+  public static final Endpoint<DeleteObjectRequest, Void> endpoint(
+      CollectionDescriptor<?> collection,
+      CollectionHandleDefaults defaults) {
+    return defaults.endpoint(
+        SimpleEndpoint.sideEffect(
+            request -> "DELETE",
+            request -> "/objects/" + collection.name() + "/" + request.uuid,
+            request -> Collections.emptyMap()),
+        add -> add
+            .consistencyLevel(Location.QUERY));
+  }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/data/ReferenceAddManyRequest.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/data/ReferenceAddManyRequest.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import io.weaviate.client6.v1.api.collections.CollectionHandleDefaults;
+import io.weaviate.client6.v1.api.collections.CollectionHandleDefaults.Location;
 import io.weaviate.client6.v1.internal.json.JSON;
 import io.weaviate.client6.v1.internal.rest.Endpoint;
 import io.weaviate.client6.v1.internal.rest.SimpleEndpoint;
@@ -11,24 +13,28 @@ import io.weaviate.client6.v1.internal.rest.SimpleEndpoint;
 public record ReferenceAddManyRequest(List<BatchReference> references) {
 
   public static final Endpoint<ReferenceAddManyRequest, ReferenceAddManyResponse> endpoint(
-      List<BatchReference> references) {
-    return new SimpleEndpoint<>(
-        request -> "POST",
-        request -> "/batch/references",
-        request -> Collections.emptyMap(),
-        request -> JSON.serialize(request.references),
-        (statusCode, response) -> {
-          var result = JSON.deserialize(response, ReferenceAddManyResponse.class);
-          var errors = new ArrayList<ReferenceAddManyResponse.BatchError>();
+      List<BatchReference> references,
+      CollectionHandleDefaults defaults) {
+    return defaults.endpoint(
+        new SimpleEndpoint<>(
+            request -> "POST",
+            request -> "/batch/references",
+            request -> Collections.emptyMap(),
+            request -> JSON.serialize(request.references),
+            (statusCode, response) -> {
+              var result = JSON.deserialize(response, ReferenceAddManyResponse.class);
+              var errors = new ArrayList<ReferenceAddManyResponse.BatchError>();
 
-          for (var err : result.errors()) {
-            errors.add(new ReferenceAddManyResponse.BatchError(
-                err.message(),
-                references.get(err.referenceIndex()),
-                err.referenceIndex()));
-          }
-          return new ReferenceAddManyResponse(errors);
-        });
+              for (var err : result.errors()) {
+                errors.add(new ReferenceAddManyResponse.BatchError(
+                    err.message(),
+                    references.get(err.referenceIndex()),
+                    err.referenceIndex()));
+              }
+              return new ReferenceAddManyResponse(errors);
+            }),
+        add -> add
+            .consistencyLevel(Location.QUERY));
   }
 
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/data/ReferenceAddRequest.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/data/ReferenceAddRequest.java
@@ -2,6 +2,8 @@ package io.weaviate.client6.v1.api.collections.data;
 
 import java.util.Collections;
 
+import io.weaviate.client6.v1.api.collections.CollectionHandleDefaults;
+import io.weaviate.client6.v1.api.collections.CollectionHandleDefaults.Location;
 import io.weaviate.client6.v1.internal.json.JSON;
 import io.weaviate.client6.v1.internal.orm.CollectionDescriptor;
 import io.weaviate.client6.v1.internal.rest.Endpoint;
@@ -10,11 +12,16 @@ import io.weaviate.client6.v1.internal.rest.SimpleEndpoint;
 public record ReferenceAddRequest(String fromUuid, String fromProperty, Reference reference) {
 
   public static final Endpoint<ReferenceAddRequest, Void> endpoint(
-      CollectionDescriptor<?> descriptor) {
-    return SimpleEndpoint.sideEffect(
-        request -> "POST",
-        request -> "/objects/" + descriptor.name() + "/" + request.fromUuid + "/references/" + request.fromProperty,
-        request -> Collections.emptyMap(),
-        request -> JSON.serialize(request.reference));
+      CollectionDescriptor<?> descriptor,
+      CollectionHandleDefaults defautls) {
+    return defautls.endpoint(
+        SimpleEndpoint.sideEffect(
+            request -> "POST",
+            request -> "/objects/" + descriptor.name() + "/" + request.fromUuid + "/references/" + request.fromProperty,
+            request -> Collections.emptyMap(),
+            request -> JSON.serialize(request.reference)),
+        add -> add
+            .consistencyLevel(Location.QUERY));
+
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/data/ReferenceDeleteRequest.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/data/ReferenceDeleteRequest.java
@@ -2,6 +2,8 @@ package io.weaviate.client6.v1.api.collections.data;
 
 import java.util.Collections;
 
+import io.weaviate.client6.v1.api.collections.CollectionHandleDefaults;
+import io.weaviate.client6.v1.api.collections.CollectionHandleDefaults.Location;
 import io.weaviate.client6.v1.internal.json.JSON;
 import io.weaviate.client6.v1.internal.orm.CollectionDescriptor;
 import io.weaviate.client6.v1.internal.rest.Endpoint;
@@ -10,11 +12,15 @@ import io.weaviate.client6.v1.internal.rest.SimpleEndpoint;
 public record ReferenceDeleteRequest(String fromUuid, String fromProperty, Reference reference) {
 
   public static final Endpoint<ReferenceDeleteRequest, Void> endpoint(
-      CollectionDescriptor<?> descriptor) {
-    return SimpleEndpoint.sideEffect(
-        request -> "DELETE",
-        request -> "/objects/" + descriptor.name() + "/" + request.fromUuid + "/references/" + request.fromProperty,
-        request -> Collections.emptyMap(),
-        request -> JSON.serialize(request.reference));
+      CollectionDescriptor<?> descriptor,
+      CollectionHandleDefaults defaults) {
+    return defaults.endpoint(
+        SimpleEndpoint.sideEffect(
+            request -> "DELETE",
+            request -> "/objects/" + descriptor.name() + "/" + request.fromUuid + "/references/" + request.fromProperty,
+            request -> Collections.emptyMap(),
+            request -> JSON.serialize(request.reference)),
+        add -> add
+            .consistencyLevel(Location.QUERY));
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/data/ReferenceReplaceRequest.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/data/ReferenceReplaceRequest.java
@@ -3,6 +3,8 @@ package io.weaviate.client6.v1.api.collections.data;
 import java.util.Collections;
 import java.util.List;
 
+import io.weaviate.client6.v1.api.collections.CollectionHandleDefaults;
+import io.weaviate.client6.v1.api.collections.CollectionHandleDefaults.Location;
 import io.weaviate.client6.v1.internal.json.JSON;
 import io.weaviate.client6.v1.internal.orm.CollectionDescriptor;
 import io.weaviate.client6.v1.internal.rest.Endpoint;
@@ -11,11 +13,15 @@ import io.weaviate.client6.v1.internal.rest.SimpleEndpoint;
 public record ReferenceReplaceRequest(String fromUuid, String fromProperty, Reference reference) {
 
   public static final Endpoint<ReferenceReplaceRequest, Void> endpoint(
-      CollectionDescriptor<?> descriptor) {
-    return SimpleEndpoint.sideEffect(
-        request -> "PUT",
-        request -> "/objects/" + descriptor.name() + "/" + request.fromUuid + "/references/" + request.fromProperty,
-        request -> Collections.emptyMap(),
-        request -> JSON.serialize(List.of(request.reference)));
+      CollectionDescriptor<?> descriptor,
+      CollectionHandleDefaults defaults) {
+    return defaults.endpoint(
+        SimpleEndpoint.sideEffect(
+            request -> "PUT",
+            request -> "/objects/" + descriptor.name() + "/" + request.fromUuid + "/references/" + request.fromProperty,
+            request -> Collections.emptyMap(),
+            request -> JSON.serialize(List.of(request.reference))),
+        add -> add
+            .consistencyLevel(Location.QUERY));
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/data/ReplaceObjectRequest.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/data/ReplaceObjectRequest.java
@@ -5,6 +5,8 @@ import java.util.function.Function;
 
 import com.google.gson.reflect.TypeToken;
 
+import io.weaviate.client6.v1.api.collections.CollectionHandleDefaults;
+import io.weaviate.client6.v1.api.collections.CollectionHandleDefaults.Location;
 import io.weaviate.client6.v1.api.collections.ObjectMetadata;
 import io.weaviate.client6.v1.api.collections.Vectors;
 import io.weaviate.client6.v1.api.collections.WeaviateObject;
@@ -16,13 +18,17 @@ import io.weaviate.client6.v1.internal.rest.SimpleEndpoint;
 
 public record ReplaceObjectRequest<T>(WeaviateObject<T, Reference, ObjectMetadata> object) {
 
-  static final <T> Endpoint<ReplaceObjectRequest<T>, Void> endpoint(CollectionDescriptor<T> collectionDescriptor) {
-    return SimpleEndpoint.sideEffect(
-        request -> "PUT",
-        request -> "/objects/" + collectionDescriptor.name() + "/" + request.object.metadata().uuid(),
-        request -> Collections.emptyMap(),
-        request -> JSON.serialize(request.object, TypeToken.getParameterized(
-            WeaviateObject.class, collectionDescriptor.typeToken().getType(), Reference.class, ObjectMetadata.class)));
+  static final <T> Endpoint<ReplaceObjectRequest<T>, Void> endpoint(CollectionDescriptor<T> collection,
+      CollectionHandleDefaults defaults) {
+    return defaults.endpoint(
+        SimpleEndpoint.sideEffect(
+            request -> "PUT",
+            request -> "/objects/" + collection.name() + "/" + request.object.metadata().uuid(),
+            request -> Collections.emptyMap(),
+            request -> JSON.serialize(request.object, TypeToken.getParameterized(
+                WeaviateObject.class, collection.typeToken().getType(), Reference.class, ObjectMetadata.class))),
+        add -> add
+            .consistencyLevel(Location.QUERY));
   }
 
   public static <T> ReplaceObjectRequest<T> of(String collectionName, String uuid,

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/AbstractQueryClient.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/AbstractQueryClient.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import io.weaviate.client6.v1.api.collections.CollectionHandleDefaults;
+import io.weaviate.client6.v1.api.collections.WeaviateObject;
 import io.weaviate.client6.v1.internal.ObjectBuilder;
 import io.weaviate.client6.v1.internal.grpc.GrpcTransport;
 import io.weaviate.client6.v1.internal.orm.CollectionDescriptor;
@@ -49,11 +50,14 @@ abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedRespo
   /**
    * Retrieve the first result from query response if any.
    *
-   * @param objects A list of objects, normally {@link QueryResponse#objects}.
+   * @param response Query response.
    * @return An object from the list or empty {@link Optional}.
    */
-  protected final <T> Optional<T> optionalFirst(List<T> objects) {
-    return objects.isEmpty() ? Optional.empty() : Optional.ofNullable(objects.get(0));
+  protected final <T> Optional<WeaviateObject<T, Object, QueryMetadata>> optionalFirst(QueryResponse<T> response) {
+    return response == null || response.objects().isEmpty()
+        ? Optional.empty()
+        : Optional.ofNullable(response.objects().get(0));
+
   }
 
   // Object queries -----------------------------------------------------------

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/AbstractQueryClient.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/AbstractQueryClient.java
@@ -14,7 +14,7 @@ abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedRespo
   protected final CollectionDescriptor<PropertiesT> collection;
   protected final GrpcTransport grpcTransport;
 
-  private final CollectionHandleDefaults defaults;
+  protected final CollectionHandleDefaults defaults;
 
   AbstractQueryClient(CollectionDescriptor<PropertiesT> collection, GrpcTransport grpcTransport,
       CollectionHandleDefaults defaults) {

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/AbstractQueryClient.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/AbstractQueryClient.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
-import io.weaviate.client6.v1.api.collections.CollectionHandle;
 import io.weaviate.client6.v1.api.collections.CollectionHandleDefaults;
 import io.weaviate.client6.v1.internal.ObjectBuilder;
 import io.weaviate.client6.v1.internal.grpc.GrpcTransport;
@@ -34,18 +33,6 @@ abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedRespo
   protected abstract ResponseT performRequest(QueryOperator operator);
 
   protected abstract GroupedResponseT performRequest(QueryOperator operator, GroupBy groupBy);
-
-  /**
-   * Apply default query parameters set on the parent {@link CollectionHandle}.
-   *
-   * @param fn User-provided query options.
-   *
-   * @return Tucket builder with defaults.
-   */
-  private <T, B extends BaseQueryOptions.Builder<B, T>> Function<B, ObjectBuilder<T>> applyDefaults(
-      Function<B, ObjectBuilder<T>> fn) {
-    return ObjectBuilder.partial(fn, b -> b.consistencyLevel(defaults.consistencyLevel()));
-  }
 
   // Fetch by ID --------------------------------------------------------------
 
@@ -95,7 +82,7 @@ abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedRespo
   }
 
   public ResponseT bm25(String query, Function<Bm25.Builder, ObjectBuilder<Bm25>> fn) {
-    return bm25(Bm25.of(query, applyDefaults(fn)));
+    return bm25(Bm25.of(query, fn));
   }
 
   public ResponseT bm25(Bm25 query) {
@@ -107,7 +94,7 @@ abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedRespo
   }
 
   public GroupedResponseT bm25(String query, Function<Bm25.Builder, ObjectBuilder<Bm25>> fn, GroupBy groupBy) {
-    return bm25(Bm25.of(query, applyDefaults(fn)), groupBy);
+    return bm25(Bm25.of(query, fn), groupBy);
   }
 
   public GroupedResponseT bm25(Bm25 query, GroupBy groupBy) {
@@ -121,7 +108,7 @@ abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedRespo
   }
 
   public ResponseT hybrid(String query, Function<Hybrid.Builder, ObjectBuilder<Hybrid>> fn) {
-    return hybrid(Hybrid.of(query, applyDefaults(fn)));
+    return hybrid(Hybrid.of(query, fn));
   }
 
   public ResponseT hybrid(Hybrid query) {
@@ -133,7 +120,7 @@ abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedRespo
   }
 
   public GroupedResponseT hybrid(String query, Function<Hybrid.Builder, ObjectBuilder<Hybrid>> fn, GroupBy groupBy) {
-    return hybrid(Hybrid.of(query, applyDefaults(fn)), groupBy);
+    return hybrid(Hybrid.of(query, fn), groupBy);
   }
 
   public GroupedResponseT hybrid(Hybrid query, GroupBy groupBy) {
@@ -147,7 +134,7 @@ abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedRespo
   }
 
   public ResponseT nearVector(float[] vector, Function<NearVector.Builder, ObjectBuilder<NearVector>> fn) {
-    return nearVector(NearVector.of(vector, applyDefaults(fn)));
+    return nearVector(NearVector.of(vector, fn));
   }
 
   public ResponseT nearVector(NearVector query) {
@@ -160,7 +147,7 @@ abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedRespo
 
   public GroupedResponseT nearVector(float[] vector, Function<NearVector.Builder, ObjectBuilder<NearVector>> fn,
       GroupBy groupBy) {
-    return nearVector(NearVector.of(vector, applyDefaults(fn)), groupBy);
+    return nearVector(NearVector.of(vector, fn), groupBy);
   }
 
   public GroupedResponseT nearVector(NearVector query, GroupBy groupBy) {
@@ -174,7 +161,7 @@ abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedRespo
   }
 
   public ResponseT nearObject(String uuid, Function<NearObject.Builder, ObjectBuilder<NearObject>> fn) {
-    return nearObject(NearObject.of(uuid, applyDefaults(fn)));
+    return nearObject(NearObject.of(uuid, fn));
   }
 
   public ResponseT nearObject(NearObject query) {
@@ -187,7 +174,7 @@ abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedRespo
 
   public GroupedResponseT nearObject(String uuid, Function<NearObject.Builder, ObjectBuilder<NearObject>> fn,
       GroupBy groupBy) {
-    return nearObject(NearObject.of(uuid, applyDefaults(fn)), groupBy);
+    return nearObject(NearObject.of(uuid, fn), groupBy);
   }
 
   public GroupedResponseT nearObject(NearObject query, GroupBy groupBy) {
@@ -201,11 +188,11 @@ abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedRespo
   }
 
   public ResponseT nearText(String text, Function<NearText.Builder, ObjectBuilder<NearText>> fn) {
-    return nearText(NearText.of(text, applyDefaults(fn)));
+    return nearText(NearText.of(text, fn));
   }
 
   public ResponseT nearText(List<String> text, Function<NearText.Builder, ObjectBuilder<NearText>> fn) {
-    return nearText(NearText.of(text, applyDefaults(fn)));
+    return nearText(NearText.of(text, fn));
   }
 
   public ResponseT nearText(NearText query) {
@@ -241,7 +228,7 @@ abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedRespo
   }
 
   public ResponseT nearImage(String image, Function<NearImage.Builder, ObjectBuilder<NearImage>> fn) {
-    return nearImage(NearImage.of(image, applyDefaults(fn)));
+    return nearImage(NearImage.of(image, fn));
   }
 
   public ResponseT nearImage(NearImage query) {
@@ -254,7 +241,7 @@ abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedRespo
 
   public GroupedResponseT nearImage(String image, Function<NearImage.Builder, ObjectBuilder<NearImage>> fn,
       GroupBy groupBy) {
-    return nearImage(NearImage.of(image, applyDefaults(fn)), groupBy);
+    return nearImage(NearImage.of(image, fn), groupBy);
   }
 
   public GroupedResponseT nearImage(NearImage query, GroupBy groupBy) {
@@ -268,7 +255,7 @@ abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedRespo
   }
 
   public ResponseT nearAudio(String audio, Function<NearAudio.Builder, ObjectBuilder<NearAudio>> fn) {
-    return nearAudio(NearAudio.of(audio, applyDefaults(fn)));
+    return nearAudio(NearAudio.of(audio, fn));
   }
 
   public ResponseT nearAudio(NearAudio query) {
@@ -281,7 +268,7 @@ abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedRespo
 
   public GroupedResponseT nearAudio(String audio, Function<NearAudio.Builder, ObjectBuilder<NearAudio>> fn,
       GroupBy groupBy) {
-    return nearAudio(NearAudio.of(audio, applyDefaults(fn)), groupBy);
+    return nearAudio(NearAudio.of(audio, fn), groupBy);
   }
 
   public GroupedResponseT nearAudio(NearAudio query, GroupBy groupBy) {
@@ -295,7 +282,7 @@ abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedRespo
   }
 
   public ResponseT nearVideo(String video, Function<NearVideo.Builder, ObjectBuilder<NearVideo>> fn) {
-    return nearVideo(NearVideo.of(video, applyDefaults(fn)));
+    return nearVideo(NearVideo.of(video, fn));
   }
 
   public ResponseT nearVideo(NearVideo query) {
@@ -308,7 +295,7 @@ abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedRespo
 
   public GroupedResponseT nearVideo(String video, Function<NearVideo.Builder, ObjectBuilder<NearVideo>> fn,
       GroupBy groupBy) {
-    return nearVideo(NearVideo.of(video, applyDefaults(fn)), groupBy);
+    return nearVideo(NearVideo.of(video, fn), groupBy);
   }
 
   public GroupedResponseT nearVideo(NearVideo query, GroupBy groupBy) {
@@ -322,7 +309,7 @@ abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedRespo
   }
 
   public ResponseT nearThermal(String thermal, Function<NearThermal.Builder, ObjectBuilder<NearThermal>> fn) {
-    return nearThermal(NearThermal.of(thermal, applyDefaults(fn)));
+    return nearThermal(NearThermal.of(thermal, fn));
   }
 
   public ResponseT nearThermal(NearThermal query) {
@@ -335,7 +322,7 @@ abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedRespo
 
   public GroupedResponseT nearThermal(String thermal, Function<NearThermal.Builder, ObjectBuilder<NearThermal>> fn,
       GroupBy groupBy) {
-    return nearThermal(NearThermal.of(thermal, applyDefaults(fn)), groupBy);
+    return nearThermal(NearThermal.of(thermal, fn), groupBy);
   }
 
   public GroupedResponseT nearThermal(NearThermal query, GroupBy groupBy) {
@@ -349,7 +336,7 @@ abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedRespo
   }
 
   public ResponseT nearDepth(String depth, Function<NearDepth.Builder, ObjectBuilder<NearDepth>> fn) {
-    return nearDepth(NearDepth.of(depth, applyDefaults(fn)));
+    return nearDepth(NearDepth.of(depth, fn));
   }
 
   public ResponseT nearDepth(NearDepth query) {
@@ -362,7 +349,7 @@ abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedRespo
 
   public GroupedResponseT nearDepth(String depth, Function<NearDepth.Builder, ObjectBuilder<NearDepth>> fn,
       GroupBy groupBy) {
-    return nearDepth(NearDepth.of(depth, applyDefaults(fn)), groupBy);
+    return nearDepth(NearDepth.of(depth, fn), groupBy);
   }
 
   public GroupedResponseT nearDepth(NearDepth query, GroupBy groupBy) {
@@ -376,7 +363,7 @@ abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedRespo
   }
 
   public ResponseT nearImu(String imu, Function<NearImu.Builder, ObjectBuilder<NearImu>> fn) {
-    return nearImu(NearImu.of(imu, applyDefaults(fn)));
+    return nearImu(NearImu.of(imu, fn));
   }
 
   public ResponseT nearImu(NearImu query) {
@@ -389,7 +376,7 @@ abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedRespo
 
   public GroupedResponseT nearImu(String imu, Function<NearImu.Builder, ObjectBuilder<NearImu>> fn,
       GroupBy groupBy) {
-    return nearImu(NearImu.of(imu, applyDefaults(fn)), groupBy);
+    return nearImu(NearImu.of(imu, fn), groupBy);
   }
 
   public GroupedResponseT nearImu(NearImu query, GroupBy groupBy) {

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/AbstractQueryClient.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/AbstractQueryClient.java
@@ -13,7 +13,6 @@ import io.weaviate.client6.v1.internal.orm.CollectionDescriptor;
 abstract class AbstractQueryClient<PropertiesT, SingleT, ResponseT, GroupedResponseT> {
   protected final CollectionDescriptor<PropertiesT> collection;
   protected final GrpcTransport grpcTransport;
-
   protected final CollectionHandleDefaults defaults;
 
   AbstractQueryClient(CollectionDescriptor<PropertiesT> collection, GrpcTransport grpcTransport,

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/ConsistencyLevel.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/ConsistencyLevel.java
@@ -6,14 +6,16 @@ import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoBatchDelete;
 import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoSearchGet;
 
 public enum ConsistencyLevel {
-  ONE(WeaviateProtoBase.ConsistencyLevel.CONSISTENCY_LEVEL_ONE),
-  QUORUM(WeaviateProtoBase.ConsistencyLevel.CONSISTENCY_LEVEL_ONE),
-  ALL(WeaviateProtoBase.ConsistencyLevel.CONSISTENCY_LEVEL_ONE);
+  ONE(WeaviateProtoBase.ConsistencyLevel.CONSISTENCY_LEVEL_ONE, "ONE"),
+  QUORUM(WeaviateProtoBase.ConsistencyLevel.CONSISTENCY_LEVEL_ONE, "QUORUM"),
+  ALL(WeaviateProtoBase.ConsistencyLevel.CONSISTENCY_LEVEL_ONE, "ALL");
 
   private final WeaviateProtoBase.ConsistencyLevel consistencyLevel;
+  private final String queryParameter;
 
-  ConsistencyLevel(WeaviateProtoBase.ConsistencyLevel consistencyLevel) {
+  ConsistencyLevel(WeaviateProtoBase.ConsistencyLevel consistencyLevel, String queryParameter) {
     this.consistencyLevel = consistencyLevel;
+    this.queryParameter = queryParameter;
   }
 
   public final void appendTo(WeaviateProtoSearchGet.SearchRequest.Builder req) {
@@ -26,5 +28,10 @@ public enum ConsistencyLevel {
 
   public final void appendTo(WeaviateProtoBatch.BatchObjectsRequest.Builder req) {
     req.setConsistencyLevel(consistencyLevel);
+  }
+
+  @Override
+  public String toString() {
+    return queryParameter;
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/ConsistencyLevel.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/ConsistencyLevel.java
@@ -1,6 +1,8 @@
 package io.weaviate.client6.v1.api.collections.query;
 
 import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoBase;
+import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoBatch;
+import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoBatchDelete;
 import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoSearchGet;
 
 public enum ConsistencyLevel {
@@ -14,7 +16,15 @@ public enum ConsistencyLevel {
     this.consistencyLevel = consistencyLevel;
   }
 
-  final void appendTo(WeaviateProtoSearchGet.SearchRequest.Builder req) {
+  public final void appendTo(WeaviateProtoSearchGet.SearchRequest.Builder req) {
+    req.setConsistencyLevel(consistencyLevel);
+  }
+
+  public final void appendTo(WeaviateProtoBatchDelete.BatchDeleteRequest.Builder req) {
+    req.setConsistencyLevel(consistencyLevel);
+  }
+
+  public final void appendTo(WeaviateProtoBatch.BatchObjectsRequest.Builder req) {
     req.setConsistencyLevel(consistencyLevel);
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/QueryOperator.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/QueryOperator.java
@@ -1,7 +1,20 @@
 package io.weaviate.client6.v1.api.collections.query;
 
+import io.weaviate.client6.v1.api.collections.CollectionHandleDefaults;
 import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoSearchGet;
 
 interface QueryOperator {
+  /** Append QueryOperator to the request message. */
   void appendTo(WeaviateProtoSearchGet.SearchRequest.Builder req);
+
+  /**
+   * Append QueryOperator to the request message and apply default parameters.
+   * Implementations generally shouldn't override this method.
+   */
+  default void appendTo(WeaviateProtoSearchGet.SearchRequest.Builder req, CollectionHandleDefaults defaults) {
+    appendTo(req);
+    if (!req.hasConsistencyLevel() && defaults.consistencyLevel() != null) {
+      defaults.consistencyLevel().appendTo(req);
+    }
+  }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/QueryOperator.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/QueryOperator.java
@@ -1,20 +1,8 @@
 package io.weaviate.client6.v1.api.collections.query;
 
-import io.weaviate.client6.v1.api.collections.CollectionHandleDefaults;
 import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoSearchGet;
 
 interface QueryOperator {
   /** Append QueryOperator to the request message. */
   void appendTo(WeaviateProtoSearchGet.SearchRequest.Builder req);
-
-  /**
-   * Append QueryOperator to the request message and apply default parameters.
-   * Implementations generally shouldn't override this method.
-   */
-  default void appendTo(WeaviateProtoSearchGet.SearchRequest.Builder req, CollectionHandleDefaults defaults) {
-    appendTo(req);
-    if (!req.hasConsistencyLevel() && defaults.consistencyLevel() != null) {
-      defaults.consistencyLevel().appendTo(req);
-    }
-  }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/QueryRequest.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/QueryRequest.java
@@ -9,6 +9,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.weaviate.client6.v1.api.collections.CollectionHandleDefaults;
 import io.weaviate.client6.v1.api.collections.ObjectMetadata;
 import io.weaviate.client6.v1.api.collections.Vectors;
 import io.weaviate.client6.v1.api.collections.WeaviateObject;
@@ -24,7 +25,8 @@ import io.weaviate.client6.v1.internal.orm.PropertiesBuilder;
 public record QueryRequest(QueryOperator operator, GroupBy groupBy) {
 
   static <T> Rpc<QueryRequest, WeaviateProtoSearchGet.SearchRequest, QueryResponse<T>, WeaviateProtoSearchGet.SearchReply> rpc(
-      CollectionDescriptor<T> collection) {
+      CollectionDescriptor<T> collection,
+      CollectionHandleDefaults defaults) {
     return Rpc.of(
         request -> {
           var message = WeaviateProtoSearchGet.SearchRequest.newBuilder();
@@ -32,7 +34,7 @@ public record QueryRequest(QueryOperator operator, GroupBy groupBy) {
           message.setUses125Api(true);
           message.setUses123Api(true);
           message.setCollection(collection.name());
-          request.operator.appendTo(message);
+          request.operator.appendTo(message, defaults);
           if (request.groupBy != null) {
             request.groupBy.appendTo(message);
           }
@@ -52,8 +54,9 @@ public record QueryRequest(QueryOperator operator, GroupBy groupBy) {
   }
 
   static <T> Rpc<QueryRequest, WeaviateProtoSearchGet.SearchRequest, QueryResponseGrouped<T>, WeaviateProtoSearchGet.SearchReply> grouped(
-      CollectionDescriptor<T> collection) {
-    var rpc = rpc(collection);
+      CollectionDescriptor<T> collection,
+      CollectionHandleDefaults defaults) {
+    var rpc = rpc(collection, defaults);
     return Rpc.of(
         request -> rpc.marshal(request),
         reply -> {

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/QueryRequest.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/QueryRequest.java
@@ -27,14 +27,14 @@ public record QueryRequest(QueryOperator operator, GroupBy groupBy) {
   static <T> Rpc<QueryRequest, WeaviateProtoSearchGet.SearchRequest, QueryResponse<T>, WeaviateProtoSearchGet.SearchReply> rpc(
       CollectionDescriptor<T> collection,
       CollectionHandleDefaults defaults) {
-    return Rpc.of(
+    return defaults.rpc(Rpc.of(
         request -> {
           var message = WeaviateProtoSearchGet.SearchRequest.newBuilder();
           message.setUses127Api(true);
           message.setUses125Api(true);
           message.setUses123Api(true);
           message.setCollection(collection.name());
-          request.operator.appendTo(message, defaults);
+          request.operator.appendTo(message);
           if (request.groupBy != null) {
             request.groupBy.appendTo(message);
           }
@@ -50,7 +50,7 @@ public record QueryRequest(QueryOperator operator, GroupBy groupBy) {
           return new QueryResponse<>(objects);
         },
         () -> WeaviateBlockingStub::search,
-        () -> WeaviateFutureStub::search);
+        () -> WeaviateFutureStub::search));
   }
 
   static <T> Rpc<QueryRequest, WeaviateProtoSearchGet.SearchRequest, QueryResponseGrouped<T>, WeaviateProtoSearchGet.SearchReply> grouped(

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/WeaviateQueryClient.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/WeaviateQueryClient.java
@@ -26,7 +26,7 @@ public class WeaviateQueryClient<T>
   @Override
   protected Optional<WeaviateObject<T, Object, QueryMetadata>> byId(ById byId) {
     var request = new QueryRequest(byId, null);
-    var result = this.grpcTransport.performRequest(request, QueryRequest.rpc(collection));
+    var result = this.grpcTransport.performRequest(request, QueryRequest.rpc(collection, defaults));
     return optionalFirst(result.objects());
 
   }
@@ -34,13 +34,13 @@ public class WeaviateQueryClient<T>
   @Override
   protected final QueryResponse<T> performRequest(QueryOperator operator) {
     var request = new QueryRequest(operator, null);
-    return this.grpcTransport.performRequest(request, QueryRequest.rpc(collection));
+    return this.grpcTransport.performRequest(request, QueryRequest.rpc(collection, defaults));
   }
 
   @Override
   protected final QueryResponseGrouped<T> performRequest(QueryOperator operator, GroupBy groupBy) {
     var request = new QueryRequest(operator, groupBy);
-    return this.grpcTransport.performRequest(request, QueryRequest.grouped(collection));
+    return this.grpcTransport.performRequest(request, QueryRequest.grouped(collection, defaults));
   }
 
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/WeaviateQueryClient.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/WeaviateQueryClient.java
@@ -2,6 +2,7 @@ package io.weaviate.client6.v1.api.collections.query;
 
 import java.util.Optional;
 
+import io.weaviate.client6.v1.api.collections.CollectionHandleDefaults;
 import io.weaviate.client6.v1.api.collections.WeaviateObject;
 import io.weaviate.client6.v1.internal.grpc.GrpcTransport;
 import io.weaviate.client6.v1.internal.orm.CollectionDescriptor;
@@ -10,8 +11,16 @@ public class WeaviateQueryClient<T>
     extends
     AbstractQueryClient<T, Optional<WeaviateObject<T, Object, QueryMetadata>>, QueryResponse<T>, QueryResponseGrouped<T>> {
 
-  public WeaviateQueryClient(CollectionDescriptor<T> collection, GrpcTransport grpcTransport) {
-    super(collection, grpcTransport);
+  public WeaviateQueryClient(
+      CollectionDescriptor<T> collection,
+      GrpcTransport grpcTransport,
+      CollectionHandleDefaults defaults) {
+    super(collection, grpcTransport, defaults);
+  }
+
+  /** Copy constructor that sets new defaults. */
+  public WeaviateQueryClient(WeaviateQueryClient<T> qc, CollectionHandleDefaults defaults) {
+    super(qc, defaults);
   }
 
   @Override

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/WeaviateQueryClient.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/WeaviateQueryClient.java
@@ -27,7 +27,7 @@ public class WeaviateQueryClient<T>
   protected Optional<WeaviateObject<T, Object, QueryMetadata>> byId(ById byId) {
     var request = new QueryRequest(byId, null);
     var result = this.grpcTransport.performRequest(request, QueryRequest.rpc(collection, defaults));
-    return optionalFirst(result.objects());
+    return optionalFirst(result);
 
   }
 

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/WeaviateQueryClientAsync.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/WeaviateQueryClientAsync.java
@@ -29,7 +29,7 @@ public class WeaviateQueryClientAsync<T>
       ById byId) {
     var request = new QueryRequest(byId, null);
     var result = this.grpcTransport.performRequestAsync(request, QueryRequest.rpc(collection, defaults));
-    return result.thenApply(r -> optionalFirst(r.objects()));
+    return result.thenApply(this::optionalFirst);
   }
 
   @Override

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/WeaviateQueryClientAsync.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/WeaviateQueryClientAsync.java
@@ -3,6 +3,7 @@ package io.weaviate.client6.v1.api.collections.query;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+import io.weaviate.client6.v1.api.collections.CollectionHandleDefaults;
 import io.weaviate.client6.v1.api.collections.WeaviateObject;
 import io.weaviate.client6.v1.internal.grpc.GrpcTransport;
 import io.weaviate.client6.v1.internal.orm.CollectionDescriptor;
@@ -11,8 +12,16 @@ public class WeaviateQueryClientAsync<T>
     extends
     AbstractQueryClient<T, CompletableFuture<Optional<WeaviateObject<T, Object, QueryMetadata>>>, CompletableFuture<QueryResponse<T>>, CompletableFuture<QueryResponseGrouped<T>>> {
 
-  public WeaviateQueryClientAsync(CollectionDescriptor<T> collection, GrpcTransport grpcTransport) {
-    super(collection, grpcTransport);
+  public WeaviateQueryClientAsync(
+      CollectionDescriptor<T> collection,
+      GrpcTransport grpcTransport,
+      CollectionHandleDefaults defaults) {
+    super(collection, grpcTransport, defaults);
+  }
+
+  /** Copy constructor that sets new defaults. */
+  public WeaviateQueryClientAsync(WeaviateQueryClientAsync<T> qc, CollectionHandleDefaults defaults) {
+    super(qc, defaults);
   }
 
   @Override

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/WeaviateQueryClientAsync.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/WeaviateQueryClientAsync.java
@@ -28,20 +28,20 @@ public class WeaviateQueryClientAsync<T>
   protected CompletableFuture<Optional<WeaviateObject<T, Object, QueryMetadata>>> byId(
       ById byId) {
     var request = new QueryRequest(byId, null);
-    var result = this.grpcTransport.performRequestAsync(request, QueryRequest.rpc(collection));
+    var result = this.grpcTransport.performRequestAsync(request, QueryRequest.rpc(collection, defaults));
     return result.thenApply(r -> optionalFirst(r.objects()));
   }
 
   @Override
   protected final CompletableFuture<QueryResponse<T>> performRequest(QueryOperator operator) {
     var request = new QueryRequest(operator, null);
-    return this.grpcTransport.performRequestAsync(request, QueryRequest.rpc(collection));
+    return this.grpcTransport.performRequestAsync(request, QueryRequest.rpc(collection, defaults));
   }
 
   @Override
   protected final CompletableFuture<QueryResponseGrouped<T>> performRequest(QueryOperator operator, GroupBy groupBy) {
     var request = new QueryRequest(operator, groupBy);
-    return this.grpcTransport.performRequestAsync(request, QueryRequest.grouped(collection));
+    return this.grpcTransport.performRequestAsync(request, QueryRequest.grouped(collection, defaults));
   }
 
 }

--- a/src/main/java/io/weaviate/client6/v1/internal/rest/BooleanEndpoint.java
+++ b/src/main/java/io/weaviate/client6/v1/internal/rest/BooleanEndpoint.java
@@ -8,7 +8,7 @@ public class BooleanEndpoint<RequestT> extends EndpointBase<RequestT, Boolean> {
   public BooleanEndpoint(
       Function<RequestT, String> method,
       Function<RequestT, String> requestUrl,
-      Function<RequestT, Map<String, String>> queryParameters,
+      Function<RequestT, Map<String, Object>> queryParameters,
       Function<RequestT, String> body) {
     super(method, requestUrl, queryParameters, body);
   }

--- a/src/main/java/io/weaviate/client6/v1/internal/rest/Endpoint.java
+++ b/src/main/java/io/weaviate/client6/v1/internal/rest/Endpoint.java
@@ -10,7 +10,7 @@ public interface Endpoint<RequestT, ResponseT> {
 
   String body(RequestT request);
 
-  Map<String, String> queryParameters(RequestT request);
+  Map<String, Object> queryParameters(RequestT request);
 
   /** Should this status code be considered an error? */
   boolean isError(int statusCode);

--- a/src/main/java/io/weaviate/client6/v1/internal/rest/OptionalEndpoint.java
+++ b/src/main/java/io/weaviate/client6/v1/internal/rest/OptionalEndpoint.java
@@ -10,7 +10,7 @@ public class OptionalEndpoint<RequestT, ResponseT> extends SimpleEndpoint<Reques
   public static <RequestT, ResponseT> OptionalEndpoint<RequestT, ResponseT> noBodyOptional(
       Function<RequestT, String> method,
       Function<RequestT, String> requestUrl,
-      Function<RequestT, Map<String, String>> queryParameters,
+      Function<RequestT, Map<String, Object>> queryParameters,
       BiFunction<Integer, String, ResponseT> deserializeResponse) {
     return new OptionalEndpoint<>(method, requestUrl, queryParameters, nullBody(), deserializeResponse);
   }
@@ -18,7 +18,7 @@ public class OptionalEndpoint<RequestT, ResponseT> extends SimpleEndpoint<Reques
   public OptionalEndpoint(
       Function<RequestT, String> method,
       Function<RequestT, String> requestUrl,
-      Function<RequestT, Map<String, String>> queryParameters,
+      Function<RequestT, Map<String, Object>> queryParameters,
       Function<RequestT, String> body,
       BiFunction<Integer, String, ResponseT> deserializeResponse) {
     super(method, requestUrl, queryParameters, body, optional(deserializeResponse));

--- a/src/main/java/io/weaviate/client6/v1/internal/rest/SimpleEndpoint.java
+++ b/src/main/java/io/weaviate/client6/v1/internal/rest/SimpleEndpoint.java
@@ -17,7 +17,7 @@ public class SimpleEndpoint<RequestT, ResponseT> extends EndpointBase<RequestT, 
   public static <RequestT, ResponseT> SimpleEndpoint<RequestT, ResponseT> noBody(
       Function<RequestT, String> method,
       Function<RequestT, String> requestUrl,
-      Function<RequestT, Map<String, String>> queryParameters,
+      Function<RequestT, Map<String, Object>> queryParameters,
       BiFunction<Integer, String, ResponseT> deserializeResponse) {
     return new SimpleEndpoint<>(method, requestUrl, queryParameters, nullBody(), deserializeResponse);
   }
@@ -25,7 +25,7 @@ public class SimpleEndpoint<RequestT, ResponseT> extends EndpointBase<RequestT, 
   public static <RequestT> SimpleEndpoint<RequestT, Void> sideEffect(
       Function<RequestT, String> method,
       Function<RequestT, String> requestUrl,
-      Function<RequestT, Map<String, String>> queryParameters,
+      Function<RequestT, Map<String, Object>> queryParameters,
       Function<RequestT, String> body) {
     return new SimpleEndpoint<>(method, requestUrl, queryParameters, body, nullResponse());
   }
@@ -33,14 +33,14 @@ public class SimpleEndpoint<RequestT, ResponseT> extends EndpointBase<RequestT, 
   public static <RequestT> SimpleEndpoint<RequestT, Void> sideEffect(
       Function<RequestT, String> method,
       Function<RequestT, String> requestUrl,
-      Function<RequestT, Map<String, String>> queryParameters) {
+      Function<RequestT, Map<String, Object>> queryParameters) {
     return new SimpleEndpoint<>(method, requestUrl, queryParameters, nullBody(), nullResponse());
   }
 
   public SimpleEndpoint(
       Function<RequestT, String> method,
       Function<RequestT, String> requestUrl,
-      Function<RequestT, Map<String, String>> queryParameters,
+      Function<RequestT, Map<String, Object>> queryParameters,
       Function<RequestT, String> body,
       BiFunction<Integer, String, ResponseT> deserializeResponse) {
     super(method, requestUrl, queryParameters, body);

--- a/src/main/java/io/weaviate/client6/v1/internal/rest/UrlEncoder.java
+++ b/src/main/java/io/weaviate/client6/v1/internal/rest/UrlEncoder.java
@@ -1,0 +1,27 @@
+package io.weaviate.client6.v1.internal.rest;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public final class UrlEncoder {
+
+  private static String encodeValue(Object value) {
+    try {
+      return URLEncoder.encode(value.toString(), StandardCharsets.UTF_8.toString());
+    } catch (UnsupportedEncodingException e) {
+      throw new AssertionError(e); // should never happen with a standard encoding
+    }
+  }
+
+  public static String encodeQuery(Map<String, Object> queryParams) {
+    if (queryParams == null || queryParams.isEmpty()) {
+      return "";
+    }
+    return queryParams.entrySet().stream()
+        .map(qp -> qp.getKey() + "=" + encodeValue(qp.getValue()))
+        .collect(Collectors.joining("&", "?", ""));
+  }
+}

--- a/src/test/java/io/weaviate/client6/v1/api/collections/CollectionHandleDefaultsTest.java
+++ b/src/test/java/io/weaviate/client6/v1/api/collections/CollectionHandleDefaultsTest.java
@@ -11,16 +11,15 @@ import io.weaviate.client6.v1.internal.orm.CollectionDescriptor;
 
 public class CollectionHandleDefaultsTest {
   private static final CollectionDescriptor<Map<String, Object>> DESCRIPTOR = CollectionDescriptor.ofMap("Things");
+  private static final CollectionHandleDefaults NONE_DEFAULTS = CollectionHandleDefaults.of(ObjectBuilder.identity());
 
   /** CollectionHandle with no defaults. */
   private static final CollectionHandle<Map<String, Object>> HANDLE_NONE = new CollectionHandle<>(
-      null, null,
-      DESCRIPTOR, CollectionHandleDefaults.of(ObjectBuilder.identity()));
+      null, null, DESCRIPTOR, NONE_DEFAULTS);
 
   /** CollectionHandleAsync with no defaults. */
   private static final CollectionHandleAsync<Map<String, Object>> HANDLE_NONE_ASYNC = new CollectionHandleAsync<>(
-      null, null,
-      DESCRIPTOR, CollectionHandleDefaults.of(ObjectBuilder.identity()));
+      null, null, DESCRIPTOR, NONE_DEFAULTS);
 
   /** All defaults are {@code null} if none were set. */
   @Test

--- a/src/test/java/io/weaviate/client6/v1/api/collections/CollectionHandleDefaultsTest.java
+++ b/src/test/java/io/weaviate/client6/v1/api/collections/CollectionHandleDefaultsTest.java
@@ -1,0 +1,52 @@
+package io.weaviate.client6.v1.api.collections;
+
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import io.weaviate.client6.v1.api.collections.query.ConsistencyLevel;
+import io.weaviate.client6.v1.internal.ObjectBuilder;
+import io.weaviate.client6.v1.internal.orm.CollectionDescriptor;
+
+public class CollectionHandleDefaultsTest {
+  private static final CollectionDescriptor<Map<String, Object>> DESCRIPTOR = CollectionDescriptor.ofMap("Things");
+
+  /** CollectionHandle with no defaults. */
+  private static final CollectionHandle<Map<String, Object>> HANDLE_NONE = new CollectionHandle<>(
+      null, null,
+      DESCRIPTOR, CollectionHandleDefaults.of(ObjectBuilder.identity()));
+
+  /** CollectionHandleAsync with no defaults. */
+  private static final CollectionHandleAsync<Map<String, Object>> HANDLE_NONE_ASYNC = new CollectionHandleAsync<>(
+      null, null,
+      DESCRIPTOR, CollectionHandleDefaults.of(ObjectBuilder.identity()));
+
+  /** All defaults are {@code null} if none were set. */
+  @Test
+  public void test_defaults() {
+    Assertions.assertThat(HANDLE_NONE.consistencyLevel()).isNull();
+  }
+
+  /**
+   * {@link CollectionHandle#withConsistencyLevel} should create a copy with
+   * different defaults but not modify the original.
+   */
+  @Test
+  public void test_withConsistencyLevel() {
+    var handle = HANDLE_NONE.withConsistencyLevel(ConsistencyLevel.QUORUM);
+    Assertions.assertThat(handle.consistencyLevel()).isEqualTo(ConsistencyLevel.QUORUM);
+    Assertions.assertThat(HANDLE_NONE.consistencyLevel()).isNull();
+  }
+
+  /**
+   * {@link CollectionHandleAsync#withConsistencyLevel} should create a copy with
+   * different defaults but not modify the original.
+   */
+  @Test
+  public void test_withConsistencyLevel_async() {
+    var handle = HANDLE_NONE_ASYNC.withConsistencyLevel(ConsistencyLevel.QUORUM);
+    Assertions.assertThat(handle.consistencyLevel()).isEqualTo(ConsistencyLevel.QUORUM);
+    Assertions.assertThat(HANDLE_NONE_ASYNC.consistencyLevel()).isNull();
+  }
+}

--- a/src/test/java/io/weaviate/client6/v1/api/collections/data/WeaviateDataClientTest.java
+++ b/src/test/java/io/weaviate/client6/v1/api/collections/data/WeaviateDataClientTest.java
@@ -128,18 +128,9 @@ public class WeaviateDataClientTest {
 
   public static Object[][] grpcTestCases() {
     return new Object[][] {
-        {
-            "object exists",
-            (Act) client -> client.exists("test-uuid"),
-        },
-        {
-            "insert many",
-            (Act) client -> client.insertMany(),
-        },
-        {
-            "delete many",
-            (Act) client -> client.deleteMany(),
-        },
+        { "object exists", (Act) client -> client.exists("test-uuid") },
+        { "insert many", (Act) client -> client.insertMany() },
+        { "delete many", (Act) client -> client.deleteMany() },
     };
   }
 

--- a/src/test/java/io/weaviate/client6/v1/api/collections/data/WeaviateDataClientTest.java
+++ b/src/test/java/io/weaviate/client6/v1/api/collections/data/WeaviateDataClientTest.java
@@ -1,0 +1,164 @@
+package io.weaviate.client6.v1.api.collections.data;
+
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.google.gson.JsonParser;
+import com.jparams.junit4.JParamsTestRunner;
+import com.jparams.junit4.data.DataMethod;
+import com.jparams.junit4.description.Name;
+
+import io.weaviate.client6.v1.api.collections.CollectionHandleDefaults;
+import io.weaviate.client6.v1.api.collections.CollectionHandleDefaults.Location;
+import io.weaviate.client6.v1.api.collections.query.ConsistencyLevel;
+import io.weaviate.client6.v1.internal.ObjectBuilder;
+import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoBase;
+import io.weaviate.client6.v1.internal.json.JSON;
+import io.weaviate.client6.v1.internal.orm.CollectionDescriptor;
+import io.weaviate.testutil.transport.MockGrpcTransport;
+import io.weaviate.testutil.transport.MockRestTransport;
+
+@RunWith(JParamsTestRunner.class)
+public class WeaviateDataClientTest {
+  private static MockRestTransport rest;
+  private static MockGrpcTransport grpc;
+
+  @BeforeClass
+  public static void setUp() {
+    rest = new MockRestTransport();
+    grpc = new MockGrpcTransport();
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    rest.close();
+    grpc.close();
+  }
+
+  @FunctionalInterface
+  interface Act {
+    void apply(WeaviateDataClient<Map<String, Object>> client) throws Exception;
+  }
+
+  public static Object[][] restTestCases() {
+    return new Object[][] {
+        {
+            "insert single object",
+            ConsistencyLevel.ONE, Location.QUERY,
+            (Act) client -> client.insert(Map.of()),
+        },
+        {
+            "replace single object",
+            ConsistencyLevel.ONE, Location.QUERY,
+            (Act) client -> client.replace("test-uuid", ObjectBuilder.identity()),
+        },
+        {
+            "update single object",
+            ConsistencyLevel.ONE, Location.QUERY,
+            (Act) client -> client.update("test-uuid", ObjectBuilder.identity()),
+        },
+        {
+            "delete by id",
+            ConsistencyLevel.ONE, Location.QUERY,
+            (Act) client -> client.delete("test-uuid"),
+        },
+        {
+            "add reference",
+            ConsistencyLevel.ONE, Location.QUERY,
+            (Act) client -> client.referenceAdd("from-uuid", "from_property", Reference.uuids("to-uuid")),
+        },
+        {
+            "add reference many",
+            ConsistencyLevel.ONE, Location.QUERY,
+            (Act) client -> client.referenceAddMany(),
+        },
+        {
+            "replace reference",
+            ConsistencyLevel.ONE, Location.QUERY,
+            (Act) client -> client.referenceReplace("from-uuid", "from_property", Reference.uuids("to-uuid")),
+        },
+        {
+            "delete reference",
+            ConsistencyLevel.ONE, Location.QUERY,
+            (Act) client -> client.referenceDelete("from-uuid", "from_property", Reference.uuids("to-uuid")),
+        },
+    };
+  }
+
+  @Name("0")
+  @DataMethod(source = WeaviateDataClientTest.class, method = "restTestCases")
+  @Test
+  public void test_collectionHandleDefaults_rest(String __, ConsistencyLevel cl, Location clLoc, Act act)
+      throws Exception {
+    // Arrange
+    var collection = CollectionDescriptor.ofMap("Things");
+    var defaults = new CollectionHandleDefaults(cl);
+    var client = new WeaviateDataClient<Map<String, Object>>(
+        collection, rest, null, defaults);
+
+    // Act
+    act.apply(client);
+
+    // Assert
+    rest.assertNext((method, requestUrl, body, query) -> {
+      switch (clLoc) {
+        case QUERY:
+          Assertions.assertThat(query).containsEntry("consistency_level", defaults.consistencyLevel());
+          break;
+        case BODY:
+          assertJsonHasValue(body, "consistency_level", defaults.consistencyLevel());
+      }
+    });
+  }
+
+  private <T> void assertJsonHasValue(String json, String key, T value) {
+    var gotJson = JsonParser.parseString(json).getAsJsonObject();
+    Assertions.assertThat(gotJson.has(key))
+        .describedAs("missing key \"%s\" in %s", key, json)
+        .isTrue();
+
+    var wantValue = JsonParser.parseString(JSON.serialize(value));
+    Assertions.assertThat(gotJson.get(key)).isEqualTo(wantValue);
+  }
+
+  public static Object[][] grpcTestCases() {
+    return new Object[][] {
+        {
+            "object exists",
+            (Act) client -> client.exists("test-uuid"),
+        },
+        {
+            "insert many",
+            (Act) client -> client.insertMany(),
+        },
+        {
+            "delete many",
+            (Act) client -> client.deleteMany(),
+        },
+    };
+  }
+
+  @Name("0")
+  @DataMethod(source = WeaviateDataClientTest.class, method = "grpcTestCases")
+  @Test
+  public void test_collectionHandleDefaults_grpc(String __, Act act)
+      throws Exception {
+    // Arrange
+    var collection = CollectionDescriptor.ofMap("Things");
+    var defaults = new CollectionHandleDefaults(ConsistencyLevel.ONE);
+    var client = new WeaviateDataClient<Map<String, Object>>(
+        collection, null, grpc, defaults);
+
+    // Act
+    act.apply(client);
+
+    // Assert
+    grpc.assertNext(json -> assertJsonHasValue(json, "consistencyLevel",
+        WeaviateProtoBase.ConsistencyLevel.CONSISTENCY_LEVEL_ONE.toString()));
+  }
+}

--- a/src/test/java/io/weaviate/client6/v1/api/collections/query/WeaviateQueryClientTest.java
+++ b/src/test/java/io/weaviate/client6/v1/api/collections/query/WeaviateQueryClientTest.java
@@ -51,58 +51,19 @@ public class WeaviateQueryClientTest {
 
   public static Object[][] grpcTestCases() {
     return new Object[][] {
-        {
-            "get by id",
-            (Act) client -> client.byId("test-uuid")
-        },
-        {
-            "fetch objects",
-            (Act) client -> client.fetchObjects(ObjectBuilder.identity()),
-        },
-        {
-            "bm25",
-            (Act) client -> client.bm25("red ballon"),
-        },
-        {
-            "hybrid",
-            (Act) client -> client.hybrid("red ballon"),
-        },
-        {
-            "nearVector",
-            (Act) client -> client.nearVector(new float[] {}),
-        },
-        {
-            "nearText",
-            (Act) client -> client.nearText("weather in Arizona"),
-        },
-        {
-            "nearObject",
-            (Act) client -> client.nearObject("test-uuid"),
-        },
-        {
-            "nearImage",
-            (Act) client -> client.nearImage("img.jpeg"),
-        },
-        {
-            "nearAudio",
-            (Act) client -> client.nearAudio("song.mp3"),
-        },
-        {
-            "nearVideo",
-            (Act) client -> client.nearVideo("clip.mp4"),
-        },
-        {
-            "nearDepth",
-            (Act) client -> client.nearDepth("20.000 leagues"),
-        },
-        {
-            "nearThermal",
-            (Act) client -> client.nearThermal("Fahrenheit 451"),
-        },
-        {
-            "nearImu",
-            (Act) client -> client.nearImu("6 m/s"),
-        },
+        { "get by id", (Act) client -> client.byId("test-uuid") },
+        { "fetch objects", (Act) client -> client.fetchObjects(ObjectBuilder.identity()) },
+        { "bm25", (Act) client -> client.bm25("red ballon") },
+        { "hybrid", (Act) client -> client.hybrid("red ballon") },
+        { "nearVector", (Act) client -> client.nearVector(new float[] {}) },
+        { "nearText", (Act) client -> client.nearText("weather in Arizona") },
+        { "nearObject", (Act) client -> client.nearObject("test-uuid") },
+        { "nearImage", (Act) client -> client.nearImage("img.jpeg") },
+        { "nearAudio", (Act) client -> client.nearAudio("song.mp3") },
+        { "nearVideo", (Act) client -> client.nearVideo("clip.mp4") },
+        { "nearDepth", (Act) client -> client.nearDepth("20.000 leagues") },
+        { "nearThermal", (Act) client -> client.nearThermal("Fahrenheit 451") },
+        { "nearImu", (Act) client -> client.nearImu("6 m/s") },
     };
   }
 

--- a/src/test/java/io/weaviate/client6/v1/api/collections/query/WeaviateQueryClientTest.java
+++ b/src/test/java/io/weaviate/client6/v1/api/collections/query/WeaviateQueryClientTest.java
@@ -1,0 +1,126 @@
+package io.weaviate.client6.v1.api.collections.query;
+
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.google.gson.JsonParser;
+import com.jparams.junit4.JParamsTestRunner;
+import com.jparams.junit4.data.DataMethod;
+import com.jparams.junit4.description.Name;
+
+import io.weaviate.client6.v1.api.collections.CollectionHandleDefaults;
+import io.weaviate.client6.v1.internal.ObjectBuilder;
+import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoBase;
+import io.weaviate.client6.v1.internal.json.JSON;
+import io.weaviate.client6.v1.internal.orm.CollectionDescriptor;
+import io.weaviate.testutil.transport.MockGrpcTransport;
+
+@RunWith(JParamsTestRunner.class)
+public class WeaviateQueryClientTest {
+  private static MockGrpcTransport grpc;
+
+  @BeforeClass
+  public static void setUp() {
+    grpc = new MockGrpcTransport();
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    grpc.close();
+  }
+
+  @FunctionalInterface
+  interface Act {
+    void apply(WeaviateQueryClient<Map<String, Object>> client) throws Exception;
+  }
+
+  private <T> void assertJsonHasValue(String json, String key, T value) {
+    var gotJson = JsonParser.parseString(json).getAsJsonObject();
+    Assertions.assertThat(gotJson.has(key))
+        .describedAs("missing key \"%s\" in %s", key, json)
+        .isTrue();
+
+    var wantValue = JsonParser.parseString(JSON.serialize(value));
+    Assertions.assertThat(gotJson.get(key)).isEqualTo(wantValue);
+  }
+
+  public static Object[][] grpcTestCases() {
+    return new Object[][] {
+        {
+            "get by id",
+            (Act) client -> client.byId("test-uuid")
+        },
+        {
+            "fetch objects",
+            (Act) client -> client.fetchObjects(ObjectBuilder.identity()),
+        },
+        {
+            "bm25",
+            (Act) client -> client.bm25("red ballon"),
+        },
+        {
+            "hybrid",
+            (Act) client -> client.hybrid("red ballon"),
+        },
+        {
+            "nearVector",
+            (Act) client -> client.nearVector(new float[] {}),
+        },
+        {
+            "nearText",
+            (Act) client -> client.nearText("weather in Arizona"),
+        },
+        {
+            "nearObject",
+            (Act) client -> client.nearObject("test-uuid"),
+        },
+        {
+            "nearImage",
+            (Act) client -> client.nearImage("img.jpeg"),
+        },
+        {
+            "nearAudio",
+            (Act) client -> client.nearAudio("song.mp3"),
+        },
+        {
+            "nearVideo",
+            (Act) client -> client.nearVideo("clip.mp4"),
+        },
+        {
+            "nearDepth",
+            (Act) client -> client.nearDepth("20.000 leagues"),
+        },
+        {
+            "nearThermal",
+            (Act) client -> client.nearThermal("Fahrenheit 451"),
+        },
+        {
+            "nearImu",
+            (Act) client -> client.nearImu("6 m/s"),
+        },
+    };
+  }
+
+  @Name("0")
+  @DataMethod(source = WeaviateQueryClientTest.class, method = "grpcTestCases")
+  @Test
+  public void test_collectionHandleDefaults_grpc(String __, Act act)
+      throws Exception {
+    // Arrange
+    var collection = CollectionDescriptor.ofMap("Things");
+    var defaults = new CollectionHandleDefaults(ConsistencyLevel.ONE);
+    var client = new WeaviateQueryClient<Map<String, Object>>(collection, grpc, defaults);
+
+    // Act
+    act.apply(client);
+
+    // Assert
+    grpc.assertNext(json -> assertJsonHasValue(json, "consistencyLevel",
+        WeaviateProtoBase.ConsistencyLevel.CONSISTENCY_LEVEL_ONE.toString()));
+  }
+}

--- a/src/test/java/io/weaviate/client6/v1/internal/json/JSONTest.java
+++ b/src/test/java/io/weaviate/client6/v1/internal/json/JSONTest.java
@@ -345,6 +345,7 @@ public class JSONTest {
 
   }
 
+  @FunctionalInterface
   private interface CustomAssert extends BiConsumer<Object, Object> {
   }
 

--- a/src/test/java/io/weaviate/testutil/transport/MockGrpcTransport.java
+++ b/src/test/java/io/weaviate/testutil/transport/MockGrpcTransport.java
@@ -1,0 +1,56 @@
+package io.weaviate.testutil.transport;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.MessageOrBuilder;
+import com.google.protobuf.util.JsonFormat;
+
+import io.weaviate.client6.v1.internal.grpc.GrpcTransport;
+import io.weaviate.client6.v1.internal.grpc.Rpc;
+
+public class MockGrpcTransport implements GrpcTransport {
+
+  @FunctionalInterface
+  public interface AssertFunction {
+    void apply(String json);
+  }
+
+  private List<MessageOrBuilder> requests = new ArrayList<>();
+
+  public void assertNext(AssertFunction... assertions) {
+    var assertN = Math.min(assertions.length, requests.size());
+    for (var i = 0; i < assertN; i++) {
+      var req = requests.get(i);
+      String json;
+      try {
+        json = JsonFormat.printer().print(req);
+      } catch (InvalidProtocolBufferException e) {
+        throw new RuntimeException(e);
+      }
+      assertions[i].apply(json);
+    }
+    requests.clear();
+  }
+
+  @Override
+  public <RequestT, RequestM, ReplyM, ResponseT> ResponseT performRequest(RequestT request,
+      Rpc<RequestT, RequestM, ResponseT, ReplyM> rpc) {
+    requests.add((MessageOrBuilder) rpc.marshal(request));
+    return null;
+  }
+
+  @Override
+  public <RequestT, RequestM, ReplyM, ResponseT> CompletableFuture<ResponseT> performRequestAsync(RequestT request,
+      Rpc<RequestT, RequestM, ResponseT, ReplyM> rpc) {
+    requests.add((MessageOrBuilder) rpc.marshal(request));
+    return null;
+  }
+
+  @Override
+  public void close() throws IOException {
+  }
+}

--- a/src/test/java/io/weaviate/testutil/transport/MockRestTransport.java
+++ b/src/test/java/io/weaviate/testutil/transport/MockRestTransport.java
@@ -1,0 +1,55 @@
+package io.weaviate.testutil.transport;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import io.weaviate.client6.v1.internal.rest.Endpoint;
+import io.weaviate.client6.v1.internal.rest.RestTransport;
+
+public class MockRestTransport implements RestTransport {
+
+  private record Request<RequestT>(String method, String requestUrl, String body,
+      Map<String, Object> queryParameters) {
+
+    Request(RequestT req, Endpoint<RequestT, ?> ep) {
+      this(ep.method(req), ep.requestUrl(req), ep.body(req), ep.queryParameters(req));
+    }
+  }
+
+  @FunctionalInterface
+  public interface AssertFunction {
+    void apply(String method, String requestUrl, String body, Map<String, Object> queryParameters);
+  }
+
+  private List<Request<?>> requests = new ArrayList<>();
+
+  public void assertNext(AssertFunction... assertions) {
+    var assertN = Math.min(assertions.length, requests.size());
+    for (var i = 0; i < assertN; i++) {
+      var req = requests.get(i);
+      assertions[i].apply(req.method, req.requestUrl, req.body, req.queryParameters);
+    }
+    requests.clear();
+  }
+
+  @Override
+  public <RequestT, ResponseT, ExceptionT> ResponseT performRequest(RequestT request,
+      Endpoint<RequestT, ResponseT> endpoint) throws IOException {
+    requests.add(new Request<>(request, endpoint));
+    return null;
+  }
+
+  @Override
+  public <RequestT, ResponseT, ExceptionT> CompletableFuture<ResponseT> performRequestAsync(RequestT request,
+      Endpoint<RequestT, ResponseT> endpoint) {
+    requests.add(new Request<>(request, endpoint));
+    return null;
+  }
+
+  @Override
+  public void close() throws IOException {
+  }
+}


### PR DESCRIPTION
This PR adds an option to set default consistency level on a CollectionHandle/-Async. If set, consistency level will be applied to _all operations in `query` and `data` namespaces_.

The API is simple and similar to that in the Python client:

```java
// Derive a modified collection handle with a different ConsistencyLevel
var things = client.collections.use("Things");
var thingsQuorum = things.withConsistencyLevel(ConsistencyLevel.QUORUM);
var thingsAll = things.withConsistencyLevel(ConsistencyLevel.ALL);

// Or configure it immediately on creation
var thingsOne = client.collections.use("Things",
    with -> with.consistencyLevel(ConsistencyLevel.ONE));
```

CollectionHandle/-Async can be inspected:

```java
things.consistencyLevel() // returns null
thingsAll.consistencyLevel() // returns ConsistencyLevel.ALL
```

Default ConsistencyLevel can be overridden for an individual query. For example, this search is done with `ConsistencyLevel.ONE`.

```java
thingsAll.query.nearObject(
    "test-uuid",
     q -> q.consistencyLevel(ConsistencyLevel.ONE));
```