### PR TITLE
feat: add `overwriteAlias` to backup restore

### DIFF
--- a/src/main/java/io/weaviate/client/v1/async/backup/api/BackupRestorer.java
+++ b/src/main/java/io/weaviate/client/v1/async/backup/api/BackupRestorer.java
@@ -40,6 +40,7 @@ public class BackupRestorer extends AsyncBaseClient<BackupRestoreResponse>
   private String[] excludeClassNames;
   private String backend;
   private String backupId;
+  private Boolean overwriteAlias;
   private BackupRestoreConfig config;
   private boolean waitForCompletion;
   private final Executor executor;
@@ -81,6 +82,11 @@ public class BackupRestorer extends AsyncBaseClient<BackupRestoreResponse>
     return this;
   }
 
+  public BackupRestorer withOverwriteAlias(boolean overwriteAlias) {
+    this.overwriteAlias = overwriteAlias;
+    return this;
+  }
+
   @Override
   public Future<Result<BackupRestoreResponse>> run(FutureCallback<Result<BackupRestoreResponse>> callback) {
     if (waitForCompletion) {
@@ -94,6 +100,7 @@ public class BackupRestorer extends AsyncBaseClient<BackupRestoreResponse>
         .config(BackupRestoreConfig.builder().build())
         .include(includeClassNames)
         .exclude(excludeClassNames)
+        .overwriteAlias(overwriteAlias)
         .config(config)
         .build();
     String path = String.format("/backups/%s/%s/restore", UrlEncoder.encodePathParam(backend),
@@ -236,6 +243,8 @@ public class BackupRestorer extends AsyncBaseClient<BackupRestoreResponse>
     String[] include;
     @SerializedName("exclude")
     String[] exclude;
+    @SerializedName("overwriteAlias")
+    Boolean overwriteAlias;
   }
 
   @Getter

--- a/src/main/java/io/weaviate/client/v1/backup/api/BackupRestorer.java
+++ b/src/main/java/io/weaviate/client/v1/backup/api/BackupRestorer.java
@@ -24,6 +24,7 @@ public class BackupRestorer extends BaseClient<BackupRestoreResponse> implements
   private String[] excludeClassNames;
   private String backend;
   private String backupId;
+  private Boolean overwriteAlias;
   private BackupRestoreConfig config;
   private boolean waitForCompletion;
 
@@ -44,6 +45,11 @@ public class BackupRestorer extends BaseClient<BackupRestoreResponse> implements
 
   public BackupRestorer withBackend(String backend) {
     this.backend = backend;
+    return this;
+  }
+
+  public BackupRestorer withOverwriteAlias(Boolean overwriteAlias) {
+    this.overwriteAlias = overwriteAlias;
     return this;
   }
 
@@ -72,6 +78,7 @@ public class BackupRestorer extends BaseClient<BackupRestoreResponse> implements
     BackupRestore payload = BackupRestore.builder()
         .include(includeClassNames)
         .exclude(excludeClassNames)
+        .overwriteAlias(overwriteAlias)
         .config(config)
         .build();
 
@@ -146,6 +153,8 @@ public class BackupRestorer extends BaseClient<BackupRestoreResponse> implements
     String[] include;
     @SerializedName("exclude")
     String[] exclude;
+    @SerializedName("overwriteAlias")
+    Boolean overwriteAlias;
   }
 
   @Getter

--- a/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
@@ -3,7 +3,7 @@ package io.weaviate.integration.client;
 public class WeaviateVersion {
 
   // docker image version
-  public static final String WEAVIATE_IMAGE = "1.32.0";
+  public static final String WEAVIATE_IMAGE = "1.33.0-rc.0";
 
   // to be set according to weaviate docker image
   public static final String EXPECTED_WEAVIATE_VERSION = "1.32.0";

--- a/src/test/java/io/weaviate/integration/tests/backup/BackupTestSuite.java
+++ b/src/test/java/io/weaviate/integration/tests/backup/BackupTestSuite.java
@@ -19,6 +19,7 @@ import org.apache.http.HttpStatus;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.base.WeaviateError;
 import io.weaviate.client.base.WeaviateErrorMessage;
+import io.weaviate.client.v1.aliases.model.Alias;
 import io.weaviate.client.v1.backup.model.Backend;
 import io.weaviate.client.v1.backup.model.BackupCreateResponse;
 import io.weaviate.client.v1.backup.model.BackupCreateStatusResponse;
@@ -637,6 +638,16 @@ public class BackupTestSuite {
     assertThat(supplierUser.get().getResult()).as("get restored user").isNotNull();
     assertThat(supplierRole.get().getResult()).as("get restored role").isNotNull();
 
+  }
+
+  public static void testOverwriteAlias_true(
+      Runnable arrange,
+      Callable<Result<?>> act,
+      Supplier<Alias> supplierAlias, String wantClassName) throws Exception {
+    arrange.run();
+    Result<?> result = act.call();
+    assertThat(result.getError()).isNull();
+    assertThat(supplierAlias.get().getClassName()).isEqualTo(wantClassName);
   }
 
   private static void assertThatAllPizzasExist(Function<String, Result<GraphQLResponse>> supplierGQLOfClass) {


### PR DESCRIPTION
Updated target Weaviate version to `1.33.0-rc.0`. With that version it is now possible to let Weaviate overwrite conflicting aliases during backup restore.

```java
client.backup().restorer()
  .withBackupId(backupId)
  .withBackend(BackupTestSuite.BACKEND)
  .withIncludeClassNames(originalClass)
  .withWaitForCompletion(true)
  .withOverwriteAlias(true)
  .run();
```