### PR TITLE
feat: add 'groups' namespace

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,6 +239,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.22.2</version>
           <configuration>
+            <trimStackTrace>false</trimStackTrace>
             <argLine>
               <!--
                 Gson (used for JSON serialization) utilizes reflection and needs to be able to access private fields of

--- a/src/main/java/io/weaviate/client/WeaviateClient.java
+++ b/src/main/java/io/weaviate/client/WeaviateClient.java
@@ -18,6 +18,7 @@ import io.weaviate.client.v1.cluster.Cluster;
 import io.weaviate.client.v1.contextionary.Contextionary;
 import io.weaviate.client.v1.data.Data;
 import io.weaviate.client.v1.graphql.GraphQL;
+import io.weaviate.client.v1.groups.Groups;
 import io.weaviate.client.v1.grpc.GRPC;
 import io.weaviate.client.v1.misc.Misc;
 import io.weaviate.client.v1.misc.api.MetaGetter;
@@ -110,6 +111,10 @@ public class WeaviateClient {
 
   public Users users() {
     return new Users(httpClient, config);
+  }
+
+  public Groups groups() {
+    return new Groups(httpClient, config);
   }
 
   public Aliases alias() {

--- a/src/main/java/io/weaviate/client/v1/async/WeaviateAsyncClient.java
+++ b/src/main/java/io/weaviate/client/v1/async/WeaviateAsyncClient.java
@@ -19,6 +19,7 @@ import io.weaviate.client.v1.async.classifications.Classifications;
 import io.weaviate.client.v1.async.cluster.Cluster;
 import io.weaviate.client.v1.async.data.Data;
 import io.weaviate.client.v1.async.graphql.GraphQL;
+import io.weaviate.client.v1.async.groups.Groups;
 import io.weaviate.client.v1.async.misc.Misc;
 import io.weaviate.client.v1.async.rbac.Roles;
 import io.weaviate.client.v1.async.schema.Schema;
@@ -83,6 +84,10 @@ public class WeaviateAsyncClient implements AutoCloseable {
 
   public Users users() {
     return new Users(client, config, tokenProvider);
+  }
+
+  public Groups groups() {
+    return new Groups(client, config, tokenProvider);
   }
 
   public Aliases alias() {

--- a/src/main/java/io/weaviate/client/v1/async/groups/Groups.java
+++ b/src/main/java/io/weaviate/client/v1/async/groups/Groups.java
@@ -1,0 +1,18 @@
+package io.weaviate.client.v1.async.groups;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class Groups {
+  private final CloseableHttpAsyncClient client;
+  private final Config config;
+  private final AccessTokenProvider tokenProvider;
+
+  public OidcGroups oidc() {
+    return new OidcGroups(client, config, tokenProvider);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/groups/OidcGroups.java
+++ b/src/main/java/io/weaviate/client/v1/async/groups/OidcGroups.java
@@ -1,0 +1,34 @@
+package io.weaviate.client.v1.async.groups;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.v1.async.groups.api.oidc.AssignedRolesGetter;
+import io.weaviate.client.v1.async.groups.api.oidc.KnownGroupNamesGetter;
+import io.weaviate.client.v1.async.groups.api.oidc.RoleAssigner;
+import io.weaviate.client.v1.async.groups.api.oidc.RoleRevoker;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class OidcGroups {
+  private final CloseableHttpAsyncClient client;
+  private final Config config;
+  private final AccessTokenProvider tokenProvider;
+
+  public RoleAssigner roleAssigner() {
+    return new RoleAssigner(client, config, tokenProvider);
+  }
+
+  public RoleRevoker roleRevoker() {
+    return new RoleRevoker(client, config, tokenProvider);
+  }
+
+  public AssignedRolesGetter assignedRolesGetter() {
+    return new AssignedRolesGetter(client, config, tokenProvider);
+  }
+
+  public KnownGroupNamesGetter knownGroupNamesGetter() {
+    return new KnownGroupNamesGetter(client, config, tokenProvider);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/groups/api/oidc/AssignedRolesGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/groups/api/oidc/AssignedRolesGetter.java
@@ -1,0 +1,48 @@
+package io.weaviate.client.v1.async.groups.api.oidc;
+
+import java.util.List;
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.util.UrlEncoder;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import io.weaviate.client.v1.rbac.api.WeaviateRole;
+import io.weaviate.client.v1.rbac.model.Role;
+
+public class AssignedRolesGetter extends AsyncBaseClient<List<Role>> implements AsyncClientResult<List<Role>> {
+  private String groupId;
+  private boolean includePermissions = false;
+
+  public AssignedRolesGetter(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  public AssignedRolesGetter withGroupId(String id) {
+    this.groupId = id;
+    return this;
+  }
+
+  public AssignedRolesGetter includePermissions(boolean include) {
+    this.includePermissions = include;
+    return this;
+  }
+
+  private String _groupId() {
+    return UrlEncoder.encode(this.groupId);
+  }
+
+  @Override
+  public Future<Result<List<Role>>> run(FutureCallback<Result<List<Role>>> callback) {
+    return sendGetRequest(path(), callback, Result.arrayToListParser(WeaviateRole[].class, WeaviateRole::toRole));
+  }
+
+  private String path() {
+    return String.format("/authz/groups/%s/roles/oidc?includeFullRoles=%s", _groupId(), includePermissions);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/groups/api/oidc/AssignedRolesGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/groups/api/oidc/AssignedRolesGetter.java
@@ -33,7 +33,7 @@ public class AssignedRolesGetter extends AsyncBaseClient<List<Role>> implements 
     return this;
   }
 
-  private String _groupId() {
+  private String encodeGroupId() {
     return UrlEncoder.encode(this.groupId);
   }
 
@@ -43,6 +43,6 @@ public class AssignedRolesGetter extends AsyncBaseClient<List<Role>> implements 
   }
 
   private String path() {
-    return String.format("/authz/groups/%s/roles/oidc?includeFullRoles=%s", _groupId(), includePermissions);
+    return String.format("/authz/groups/%s/roles/oidc?includeFullRoles=%s", encodeGroupId(), includePermissions);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/async/groups/api/oidc/KnownGroupNamesGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/groups/api/oidc/KnownGroupNamesGetter.java
@@ -1,0 +1,30 @@
+package io.weaviate.client.v1.async.groups.api.oidc;
+
+import java.util.List;
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.aliases.model.Alias;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+
+public class KnownGroupNamesGetter extends AsyncBaseClient<List<String>> implements AsyncClientResult<List<String>> {
+
+  public KnownGroupNamesGetter(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  static class ResponseBody {
+    List<Alias> aliases;
+  }
+
+  @Override
+  public Future<Result<List<String>>> run(FutureCallback<Result<List<String>>> callback) {
+    return sendGetRequest("/authz/groups/oidc", callback, Result.arrayToListParser(String[].class));
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/groups/api/oidc/RoleAssigner.java
+++ b/src/main/java/io/weaviate/client/v1/async/groups/api/oidc/RoleAssigner.java
@@ -36,7 +36,7 @@ public class RoleAssigner extends AsyncBaseClient<Boolean> implements AsyncClien
     return this;
   }
 
-  private String _groupId() {
+  private String encodeGroupId() {
     return UrlEncoder.encode(this.groupId);
   }
 
@@ -56,6 +56,6 @@ public class RoleAssigner extends AsyncBaseClient<Boolean> implements AsyncClien
   }
 
   private String path() {
-    return String.format("/authz/groups/%s/assign", _groupId());
+    return String.format("/authz/groups/%s/assign", encodeGroupId());
   }
 }

--- a/src/main/java/io/weaviate/client/v1/async/groups/api/oidc/RoleAssigner.java
+++ b/src/main/java/io/weaviate/client/v1/async/groups/api/oidc/RoleAssigner.java
@@ -1,0 +1,61 @@
+package io.weaviate.client.v1.async.groups.api.oidc;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+
+import com.google.gson.annotations.SerializedName;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.util.UrlEncoder;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import lombok.AllArgsConstructor;
+
+public class RoleAssigner extends AsyncBaseClient<Boolean> implements AsyncClientResult<Boolean> {
+  private String groupId;
+  private List<String> roles = new ArrayList<>();
+
+  public RoleAssigner(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  public RoleAssigner withGroupId(String id) {
+    this.groupId = id;
+    return this;
+  }
+
+  public RoleAssigner witRoles(String... roles) {
+    this.roles = Arrays.asList(roles);
+    return this;
+  }
+
+  private String _groupId() {
+    return UrlEncoder.encode(this.groupId);
+  }
+
+  /** The API signature for this method is { "roles": [...] } */
+  @AllArgsConstructor
+  private class Body {
+    @SerializedName("roles")
+    final List<String> roles;
+    @SerializedName("groupType")
+    final String groupType = "oidc";
+  }
+
+  @Override
+  public Future<Result<Boolean>> run(FutureCallback<Result<Boolean>> callback) {
+    return sendPostRequest(path(), new Body(this.roles), callback,
+        Result.voidToBooleanParser());
+  }
+
+  private String path() {
+    return String.format("/authz/groups/%s/assign", _groupId());
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/groups/api/oidc/RoleRevoker.java
+++ b/src/main/java/io/weaviate/client/v1/async/groups/api/oidc/RoleRevoker.java
@@ -36,7 +36,7 @@ public class RoleRevoker extends AsyncBaseClient<Boolean> implements AsyncClient
     return this;
   }
 
-  private String _groupId() {
+  private String encodeGroupId() {
     return UrlEncoder.encode(this.groupId);
   }
 
@@ -56,6 +56,6 @@ public class RoleRevoker extends AsyncBaseClient<Boolean> implements AsyncClient
   }
 
   private String path() {
-    return String.format("/authz/groups/%s/revoke", _groupId());
+    return String.format("/authz/groups/%s/revoke", encodeGroupId());
   }
 }

--- a/src/main/java/io/weaviate/client/v1/async/groups/api/oidc/RoleRevoker.java
+++ b/src/main/java/io/weaviate/client/v1/async/groups/api/oidc/RoleRevoker.java
@@ -1,0 +1,61 @@
+package io.weaviate.client.v1.async.groups.api.oidc;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+
+import com.google.gson.annotations.SerializedName;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.util.UrlEncoder;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import lombok.AllArgsConstructor;
+
+public class RoleRevoker extends AsyncBaseClient<Boolean> implements AsyncClientResult<Boolean> {
+  private String groupId;
+  private List<String> roles = new ArrayList<>();
+
+  public RoleRevoker(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  public RoleRevoker withGroupId(String id) {
+    this.groupId = id;
+    return this;
+  }
+
+  public RoleRevoker witRoles(String... roles) {
+    this.roles = Arrays.asList(roles);
+    return this;
+  }
+
+  private String _groupId() {
+    return UrlEncoder.encode(this.groupId);
+  }
+
+  /** The API signature for this method is { "roles": [...] } */
+  @AllArgsConstructor
+  private class Body {
+    @SerializedName("roles")
+    final List<String> roles;
+    @SerializedName("groupType")
+    final String groupType = "oidc";
+  }
+
+  @Override
+  public Future<Result<Boolean>> run(FutureCallback<Result<Boolean>> callback) {
+    return sendPostRequest(path(), new Body(this.roles), callback,
+        Result.voidToBooleanParser());
+  }
+
+  private String path() {
+    return String.format("/authz/groups/%s/revoke", _groupId());
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/async/rbac/Roles.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/Roles.java
@@ -4,6 +4,7 @@ import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 
 import io.weaviate.client.Config;
 import io.weaviate.client.v1.async.rbac.api.AssignedUsersGetter;
+import io.weaviate.client.v1.async.rbac.api.GroupAssignmentsGetter;
 import io.weaviate.client.v1.async.rbac.api.PermissionAdder;
 import io.weaviate.client.v1.async.rbac.api.PermissionChecker;
 import io.weaviate.client.v1.async.rbac.api.PermissionRemover;
@@ -64,7 +65,7 @@ public class Roles {
   /** Get role and its assiciated permissions. */
   public RoleGetter getter() {
     return new RoleGetter(client, config, tokenProvider);
-  };
+  }
 
   /**
    * Get users assigned to a role.
@@ -74,7 +75,7 @@ public class Roles {
   @Deprecated
   public AssignedUsersGetter assignedUsersGetter() {
     return new AssignedUsersGetter(client, config, tokenProvider);
-  };
+  }
 
   /**
    * Get role assignments.
@@ -89,7 +90,11 @@ public class Roles {
    */
   public UserAssignmentsGetter userAssignmentsGetter() {
     return new UserAssignmentsGetter(client, config, tokenProvider);
-  };
+  }
+
+  public GroupAssignmentsGetter groupAssignmentsGetter() {
+    return new GroupAssignmentsGetter(client, config, tokenProvider);
+  }
 
   /** Check if a role exists. */
   public RoleExists exists() {

--- a/src/main/java/io/weaviate/client/v1/async/rbac/api/GroupAssignmentsGetter.java
+++ b/src/main/java/io/weaviate/client/v1/async/rbac/api/GroupAssignmentsGetter.java
@@ -1,0 +1,37 @@
+package io.weaviate.client.v1.async.rbac.api;
+
+import java.util.List;
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.AsyncBaseClient;
+import io.weaviate.client.base.AsyncClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.auth.provider.AccessTokenProvider;
+import io.weaviate.client.v1.rbac.model.GroupAssignment;
+
+public class GroupAssignmentsGetter extends AsyncBaseClient<List<GroupAssignment>>
+    implements AsyncClientResult<List<GroupAssignment>> {
+  private String role;
+
+  public GroupAssignmentsGetter(CloseableHttpAsyncClient httpClient, Config config, AccessTokenProvider tokenProvider) {
+    super(httpClient, config, tokenProvider);
+  }
+
+  public GroupAssignmentsGetter withRole(String role) {
+    this.role = role;
+    return this;
+  }
+
+  @Override
+  public Future<Result<List<GroupAssignment>>> run(FutureCallback<Result<List<GroupAssignment>>> callback) {
+    return sendGetRequest(path(), callback, Result.arrayToListParser(GroupAssignment[].class));
+  }
+
+  private String path() {
+    return String.format("/authz/roles/%s/group-assignments", this.role);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/groups/Groups.java
+++ b/src/main/java/io/weaviate/client/v1/groups/Groups.java
@@ -1,0 +1,18 @@
+package io.weaviate.client.v1.groups;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.http.HttpClient;
+
+public class Groups {
+  private final Config config;
+  private final HttpClient httpClient;
+
+  public Groups(HttpClient httpClient, Config config) {
+    this.config = config;
+    this.httpClient = httpClient;
+  }
+
+  public OidcGroups oidc() {
+    return new OidcGroups(httpClient, config);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/groups/OidcGroups.java
+++ b/src/main/java/io/weaviate/client/v1/groups/OidcGroups.java
@@ -1,0 +1,34 @@
+package io.weaviate.client.v1.groups;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.groups.api.oidc.AssignedRolesGetter;
+import io.weaviate.client.v1.groups.api.oidc.KnownGroupNamesGetter;
+import io.weaviate.client.v1.groups.api.oidc.RoleAssigner;
+import io.weaviate.client.v1.groups.api.oidc.RoleRevoker;
+
+public class OidcGroups {
+  private final Config config;
+  private final HttpClient httpClient;
+
+  public OidcGroups(HttpClient httpClient, Config config) {
+    this.config = config;
+    this.httpClient = httpClient;
+  }
+
+  public RoleAssigner roleAssigner() {
+    return new RoleAssigner(httpClient, config);
+  }
+
+  public RoleRevoker roleRevoker() {
+    return new RoleRevoker(httpClient, config);
+  }
+
+  public AssignedRolesGetter assignedRolesGetter() {
+    return new AssignedRolesGetter(httpClient, config);
+  }
+
+  public KnownGroupNamesGetter knownGroupNamesGetter() {
+    return new KnownGroupNamesGetter(httpClient, config);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/groups/api/oidc/AssignedRolesGetter.java
+++ b/src/main/java/io/weaviate/client/v1/groups/api/oidc/AssignedRolesGetter.java
@@ -29,7 +29,7 @@ public class AssignedRolesGetter extends BaseClient<WeaviateRole[]> implements C
     return this;
   }
 
-  private String _groupId() {
+  private String encodeGroupId() {
     return UrlEncoder.encode(this.groupId);
   }
 
@@ -39,6 +39,6 @@ public class AssignedRolesGetter extends BaseClient<WeaviateRole[]> implements C
   }
 
   private String path() {
-    return String.format("/authz/groups/%s/roles/oidc?includeFullRoles=%s", _groupId(), includePermissions);
+    return String.format("/authz/groups/%s/roles/oidc?includeFullRoles=%s", encodeGroupId(), includePermissions);
   }
 }

--- a/src/main/java/io/weaviate/client/v1/groups/api/oidc/AssignedRolesGetter.java
+++ b/src/main/java/io/weaviate/client/v1/groups/api/oidc/AssignedRolesGetter.java
@@ -1,0 +1,44 @@
+package io.weaviate.client.v1.groups.api.oidc;
+
+import java.util.List;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.base.util.UrlEncoder;
+import io.weaviate.client.v1.rbac.api.WeaviateRole;
+import io.weaviate.client.v1.rbac.model.Role;
+
+public class AssignedRolesGetter extends BaseClient<WeaviateRole[]> implements ClientResult<List<Role>> {
+  private String groupId;
+  private boolean includePermissions = false;
+
+  public AssignedRolesGetter(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public AssignedRolesGetter withGroupId(String id) {
+    this.groupId = id;
+    return this;
+  }
+
+  public AssignedRolesGetter includePermissions(boolean include) {
+    this.includePermissions = include;
+    return this;
+  }
+
+  private String _groupId() {
+    return UrlEncoder.encode(this.groupId);
+  }
+
+  @Override
+  public Result<List<Role>> run() {
+    return Result.toList(sendGetRequest(path(), WeaviateRole[].class), WeaviateRole::toRole);
+  }
+
+  private String path() {
+    return String.format("/authz/groups/%s/roles/oidc?includeFullRoles=%s", _groupId(), includePermissions);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/groups/api/oidc/KnownGroupNamesGetter.java
+++ b/src/main/java/io/weaviate/client/v1/groups/api/oidc/KnownGroupNamesGetter.java
@@ -1,0 +1,26 @@
+package io.weaviate.client.v1.groups.api.oidc;
+
+import java.util.List;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.aliases.model.Alias;
+
+public class KnownGroupNamesGetter extends BaseClient<String[]> implements ClientResult<List<String>> {
+
+  public KnownGroupNamesGetter(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  static class ResponseBody {
+    List<Alias> aliases;
+  }
+
+  @Override
+  public Result<List<String>> run() {
+    return Result.toList(sendGetRequest("/authz/groups/oidc", String[].class));
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/groups/api/oidc/RoleAssigner.java
+++ b/src/main/java/io/weaviate/client/v1/groups/api/oidc/RoleAssigner.java
@@ -1,0 +1,56 @@
+package io.weaviate.client.v1.groups.api.oidc;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import com.google.gson.annotations.SerializedName;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.base.util.UrlEncoder;
+import lombok.AllArgsConstructor;
+
+public class RoleAssigner extends BaseClient<Void> implements ClientResult<Boolean> {
+  private String groupId;
+  private List<String> roles = new ArrayList<>();
+
+  public RoleAssigner(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public RoleAssigner withGroupId(String id) {
+    this.groupId = id;
+    return this;
+  }
+
+  public RoleAssigner witRoles(String... roles) {
+    this.roles = Arrays.asList(roles);
+    return this;
+  }
+
+  private String _groupId() {
+    return UrlEncoder.encode(this.groupId);
+  }
+
+  /** The API signature for this method is { "roles": [...] } */
+  @AllArgsConstructor
+  private class Body {
+    @SerializedName("roles")
+    final List<String> roles;
+    @SerializedName("groupType")
+    final String groupType = "oidc";
+  }
+
+  @Override
+  public Result<Boolean> run() {
+    return Result.voidToBoolean(sendPostRequest(path(), new Body(this.roles), Void.class));
+  }
+
+  private String path() {
+    return String.format("/authz/groups/%s/assign", _groupId());
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/groups/api/oidc/RoleAssigner.java
+++ b/src/main/java/io/weaviate/client/v1/groups/api/oidc/RoleAssigner.java
@@ -32,7 +32,7 @@ public class RoleAssigner extends BaseClient<Void> implements ClientResult<Boole
     return this;
   }
 
-  private String _groupId() {
+  private String encodeGroupId() {
     return UrlEncoder.encode(this.groupId);
   }
 
@@ -51,6 +51,6 @@ public class RoleAssigner extends BaseClient<Void> implements ClientResult<Boole
   }
 
   private String path() {
-    return String.format("/authz/groups/%s/assign", _groupId());
+    return String.format("/authz/groups/%s/assign", encodeGroupId());
   }
 }

--- a/src/main/java/io/weaviate/client/v1/groups/api/oidc/RoleRevoker.java
+++ b/src/main/java/io/weaviate/client/v1/groups/api/oidc/RoleRevoker.java
@@ -1,0 +1,56 @@
+package io.weaviate.client.v1.groups.api.oidc;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import com.google.gson.annotations.SerializedName;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.base.util.UrlEncoder;
+import lombok.AllArgsConstructor;
+
+public class RoleRevoker extends BaseClient<Void> implements ClientResult<Boolean> {
+  private String groupId;
+  private List<String> roles = new ArrayList<>();
+
+  public RoleRevoker(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public RoleRevoker withGroupId(String id) {
+    this.groupId = id;
+    return this;
+  }
+
+  public RoleRevoker witRoles(String... roles) {
+    this.roles = Arrays.asList(roles);
+    return this;
+  }
+
+  private String _groupId() {
+    return UrlEncoder.encode(this.groupId);
+  }
+
+  /** The API signature for this method is { "roles": [...] } */
+  @AllArgsConstructor
+  private class Body {
+    @SerializedName("roles")
+    final List<String> roles;
+    @SerializedName("groupType")
+    final String groupType = "oidc";
+  }
+
+  @Override
+  public Result<Boolean> run() {
+    return Result.voidToBoolean(sendPostRequest(path(), new Body(this.roles), Void.class));
+  }
+
+  private String path() {
+    return String.format("/authz/groups/%s/revoke", _groupId());
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/groups/api/oidc/RoleRevoker.java
+++ b/src/main/java/io/weaviate/client/v1/groups/api/oidc/RoleRevoker.java
@@ -32,7 +32,7 @@ public class RoleRevoker extends BaseClient<Void> implements ClientResult<Boolea
     return this;
   }
 
-  private String _groupId() {
+  private String encodeGroupId() {
     return UrlEncoder.encode(this.groupId);
   }
 
@@ -51,6 +51,6 @@ public class RoleRevoker extends BaseClient<Void> implements ClientResult<Boolea
   }
 
   private String path() {
-    return String.format("/authz/groups/%s/revoke", _groupId());
+    return String.format("/authz/groups/%s/revoke", encodeGroupId());
   }
 }

--- a/src/main/java/io/weaviate/client/v1/rbac/Roles.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/Roles.java
@@ -3,6 +3,7 @@ package io.weaviate.client.v1.rbac;
 import io.weaviate.client.Config;
 import io.weaviate.client.base.http.HttpClient;
 import io.weaviate.client.v1.rbac.api.AssignedUsersGetter;
+import io.weaviate.client.v1.rbac.api.GroupAssignmentsGetter;
 import io.weaviate.client.v1.rbac.api.PermissionAdder;
 import io.weaviate.client.v1.rbac.api.PermissionChecker;
 import io.weaviate.client.v1.rbac.api.PermissionRemover;
@@ -57,12 +58,12 @@ public class Roles {
   /** Get all existing roles. */
   public RoleAllGetter allGetter() {
     return new RoleAllGetter(httpClient, config);
-  };
+  }
 
   /** Get role and its associated permissions. */
   public RoleGetter getter() {
     return new RoleGetter(httpClient, config);
-  };
+  }
 
   /**
    * Get users assigned to a role.
@@ -72,7 +73,7 @@ public class Roles {
   @Deprecated
   public AssignedUsersGetter assignedUsersGetter() {
     return new AssignedUsersGetter(httpClient, config);
-  };
+  }
 
   /**
    * Get role assignments.
@@ -87,7 +88,11 @@ public class Roles {
    */
   public UserAssignmentsGetter userAssignmentsGetter() {
     return new UserAssignmentsGetter(httpClient, config);
-  };
+  }
+
+  public GroupAssignmentsGetter groupAssignmentsGetter() {
+    return new GroupAssignmentsGetter(httpClient, config);
+  }
 
   /** Check if a role exists. */
   public RoleExists exists() {

--- a/src/main/java/io/weaviate/client/v1/rbac/api/GroupAssignmentsGetter.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/GroupAssignmentsGetter.java
@@ -1,0 +1,33 @@
+package io.weaviate.client.v1.rbac.api;
+
+import java.util.List;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.BaseClient;
+import io.weaviate.client.base.ClientResult;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.base.http.HttpClient;
+import io.weaviate.client.v1.rbac.model.GroupAssignment;
+
+public class GroupAssignmentsGetter extends BaseClient<GroupAssignment[]>
+    implements ClientResult<List<GroupAssignment>> {
+  private String role;
+
+  public GroupAssignmentsGetter(HttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  public GroupAssignmentsGetter withRole(String role) {
+    this.role = role;
+    return this;
+  }
+
+  @Override
+  public Result<List<GroupAssignment>> run() {
+    return Result.toList(sendGetRequest(path(), GroupAssignment[].class));
+  }
+
+  private String path() {
+    return String.format("/authz/roles/%s/group-assignments", this.role);
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/api/WeaviatePermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/WeaviatePermission.java
@@ -7,6 +7,7 @@ import io.weaviate.client.v1.rbac.model.AliasPermission;
 import io.weaviate.client.v1.rbac.model.BackupsPermission;
 import io.weaviate.client.v1.rbac.model.CollectionsPermission;
 import io.weaviate.client.v1.rbac.model.DataPermission;
+import io.weaviate.client.v1.rbac.model.GroupsPermission;
 import io.weaviate.client.v1.rbac.model.NodesPermission;
 import io.weaviate.client.v1.rbac.model.Permission;
 import io.weaviate.client.v1.rbac.model.ReplicatePermission;
@@ -31,6 +32,7 @@ public class WeaviatePermission {
   BackupsPermission backups;
   CollectionsPermission collections;
   DataPermission data;
+  GroupsPermission groups;
   NodesPermission nodes;
   RolesPermission roles;
   TenantsPermission tenants;
@@ -51,6 +53,8 @@ public class WeaviatePermission {
       this.collections = (CollectionsPermission) perm;
     } else if (perm instanceof DataPermission) {
       this.data = (DataPermission) perm;
+    } else if (perm instanceof GroupsPermission) {
+      this.groups = (GroupsPermission) perm;
     } else if (perm instanceof NodesPermission) {
       this.nodes = (NodesPermission) perm;
     } else if (perm instanceof RolesPermission) {

--- a/src/main/java/io/weaviate/client/v1/rbac/api/WeaviateRole.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/api/WeaviateRole.java
@@ -1,8 +1,10 @@
 package io.weaviate.client.v1.rbac.api;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import io.weaviate.client.v1.rbac.model.Permission;
@@ -28,7 +30,8 @@ public class WeaviateRole {
 
   /** Create {@link Role} from the API response object. */
   public Role toRole() {
-    List<Permission<?>> permissions = this.permissions.stream()
+    List<Permission<?>> permissions = Optional.ofNullable(this.permissions)
+        .orElse(new ArrayList<>()).stream()
         .<Permission<?>>map(perm -> Permission.fromWeaviate(perm))
         .filter(Objects::nonNull).collect(Collectors.toList());
     return new Role(this.name, Permission.merge(permissions));

--- a/src/main/java/io/weaviate/client/v1/rbac/model/GroupAssignment.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/GroupAssignment.java
@@ -1,0 +1,18 @@
+package io.weaviate.client.v1.rbac.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor
+public class GroupAssignment {
+  @SerializedName("groupId")
+  String groupId;
+
+  @SerializedName("groupType")
+  String groupType;
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/model/GroupsPermission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/GroupsPermission.java
@@ -1,0 +1,31 @@
+package io.weaviate.client.v1.rbac.model;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode(callSuper = true)
+public class GroupsPermission extends Permission<GroupsPermission> {
+  final String groupId;
+  final String groupType;
+
+  public GroupsPermission(String groupId, String groupType, Action... actions) {
+    super(actions);
+    this.groupId = groupId;
+    this.groupType = groupType;
+  }
+
+  GroupsPermission(String groupId, String groupType, String action) {
+    this(groupId, groupType, RbacAction.fromString(Action.class, action));
+  }
+
+  @AllArgsConstructor
+  public enum Action implements RbacAction {
+    READ("read_groups"),
+    ASSIGN_AND_REVOKE("assign_and_revoke_groups");
+
+    @Getter
+    private final String value;
+  }
+}

--- a/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
+++ b/src/main/java/io/weaviate/client/v1/rbac/model/Permission.java
@@ -75,6 +75,9 @@ public abstract class Permission<P extends Permission<P>> {
       return new CollectionsPermission(perm.getCollections().getCollection(), action);
     } else if (perm.getData() != null) {
       return new DataPermission(perm.getData().getCollection(), action);
+    } else if (perm.getGroups() != null) {
+      GroupsPermission groups = perm.getGroups();
+      return new GroupsPermission(groups.getGroupId(), groups.getGroupType(), action);
     } else if (perm.getNodes() != null) {
       NodesPermission nodes = perm.getNodes();
       if (nodes.getCollection() != null) {
@@ -179,8 +182,7 @@ public abstract class Permission<P extends Permission<P>> {
   }
 
   /**
-   * Create permissions for multiple actions for managing collection's
-   * data.
+   * Create permissions for multiple actions for managing collection's data.
    * <p>
    * Example:
    * {@code Permission.data("Pizza", DataPermission.Action.READ, DataPermission.Action.UPDATE) }
@@ -188,6 +190,17 @@ public abstract class Permission<P extends Permission<P>> {
   public static DataPermission data(String collection, DataPermission.Action... actions) {
     checkDeprecation(actions);
     return new DataPermission(collection, actions);
+  }
+
+  /**
+   * Create permissions for multiple actions for managing RBAC groups.
+   * <p>
+   * Example:
+   * {@code Permission.groups("admin-group", "oidc", GroupsPermission.Action.READ, GroupsPermission.Action.ASSIGN_AND_REVOKE) }
+   */
+  public static GroupsPermission groups(String groupId, String groupType, GroupsPermission.Action... actions) {
+    checkDeprecation(actions);
+    return new GroupsPermission(groupId, groupType, actions);
   }
 
   /**

--- a/src/test/java/io/weaviate/client/v1/rbac/api/WeaviatePermissionTest.java
+++ b/src/test/java/io/weaviate/client/v1/rbac/api/WeaviatePermissionTest.java
@@ -11,6 +11,7 @@ import io.weaviate.client.v1.rbac.model.BackupsPermission;
 import io.weaviate.client.v1.rbac.model.ClusterPermission;
 import io.weaviate.client.v1.rbac.model.CollectionsPermission;
 import io.weaviate.client.v1.rbac.model.DataPermission;
+import io.weaviate.client.v1.rbac.model.GroupsPermission;
 import io.weaviate.client.v1.rbac.model.NodesPermission;
 import io.weaviate.client.v1.rbac.model.Permission;
 import io.weaviate.client.v1.rbac.model.ReplicatePermission;
@@ -77,6 +78,10 @@ public class WeaviatePermissionTest {
         // Create and update replications
         new WeaviatePermission("create_replicate", new ReplicatePermission("Pizza", "shard-123")),
         new WeaviatePermission("update_replicate", new ReplicatePermission("Pizza", "shard-123")),
+
+        // Create and update replications
+        new WeaviatePermission("read_groups", new GroupsPermission("pizza-lovers", "oidc")),
+        new WeaviatePermission("assigne_and_revoke_groups", new GroupsPermission("pizza-lovers", "oidc")),
     };
 
     Permission<?>[] libraryPermissions = {
@@ -96,6 +101,8 @@ public class WeaviatePermissionTest {
         new UsersPermission(UsersPermission.Action.READ, UsersPermission.Action.ASSIGN_AND_REVOKE),
         new ReplicatePermission("Pizza", "shard-123", ReplicatePermission.Action.CREATE,
             ReplicatePermission.Action.UPDATE),
+        new GroupsPermission("pizza-lovers", "oidc", GroupsPermission.Action.READ,
+            GroupsPermission.Action.ASSIGN_AND_REVOKE),
     };
 
     {

--- a/src/test/java/io/weaviate/client/v1/rbac/api/WeaviatePermissionTest.java
+++ b/src/test/java/io/weaviate/client/v1/rbac/api/WeaviatePermissionTest.java
@@ -81,7 +81,7 @@ public class WeaviatePermissionTest {
 
         // Create and update replications
         new WeaviatePermission("read_groups", new GroupsPermission("pizza-lovers", "oidc")),
-        new WeaviatePermission("assigne_and_revoke_groups", new GroupsPermission("pizza-lovers", "oidc")),
+        new WeaviatePermission("assign_and_revoke_groups", new GroupsPermission("pizza-lovers", "oidc")),
     };
 
     Permission<?>[] libraryPermissions = {

--- a/src/test/java/io/weaviate/client/v1/rbac/model/PermissionTest.java
+++ b/src/test/java/io/weaviate/client/v1/rbac/model/PermissionTest.java
@@ -33,6 +33,7 @@ public class PermissionTest {
     TenantsPermission tenants = new TenantsPermission(TenantsPermission.Action.READ);
     UsersPermission users = new UsersPermission(UsersPermission.Action.READ);
     ReplicatePermission replicate = new ReplicatePermission("Pizza", "shard-123", ReplicatePermission.Action.READ);
+    GroupsPermission groups = new GroupsPermission("pizza-lovers", "oidc", GroupsPermission.Action.READ);
 
     return new Object[][] {
         {
@@ -84,6 +85,11 @@ public class PermissionTest {
             "replicate permission",
             (Supplier<Permission<?>>) () -> replicate,
             new WeaviatePermission("read_replicate", replicate),
+        },
+        {
+            "groups permission",
+            (Supplier<Permission<?>>) () -> groups,
+            new WeaviatePermission("read_groups", groups),
         },
     };
   }
@@ -197,6 +203,15 @@ public class PermissionTest {
                 "read_replicate",
                 "update_replicate",
                 "delete_replicate",
+            },
+        },
+        {
+            Permission.groups("group-id", "oidc",
+                GroupsPermission.Action.READ,
+                GroupsPermission.Action.ASSIGN_AND_REVOKE),
+            new String[] {
+                "read_groups",
+                "assign_and_revoke_groups",
             },
         },
     };

--- a/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
+++ b/src/test/java/io/weaviate/integration/client/WeaviateVersion.java
@@ -3,12 +3,12 @@ package io.weaviate.integration.client;
 public class WeaviateVersion {
 
   // docker image version
-  public static final String WEAVIATE_IMAGE = "1.32.0";
+  public static final String WEAVIATE_IMAGE = "1.33.0-rc.0";
 
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_VERSION = "1.32.0";
+  public static final String EXPECTED_WEAVIATE_VERSION = "1.33.0-rc.0";
   // to be set according to weaviate docker image
-  public static final String EXPECTED_WEAVIATE_GIT_HASH = "7cebee0";
+  public static final String EXPECTED_WEAVIATE_GIT_HASH = "15c08c7";
 
   private WeaviateVersion() {
   }

--- a/src/test/java/io/weaviate/integration/client/async/graphql/ClientGraphQLTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/graphql/ClientGraphQLTest.java
@@ -1,5 +1,28 @@
 package io.weaviate.integration.client.async.graphql;
 
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
+
+import org.assertj.core.api.Assertions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Test;
+
 import io.weaviate.client.Config;
 import io.weaviate.client.WeaviateClient;
 import io.weaviate.client.base.Result;
@@ -12,29 +35,26 @@ import io.weaviate.client.v1.async.graphql.api.Raw;
 import io.weaviate.client.v1.batch.model.ObjectGetResponse;
 import io.weaviate.client.v1.data.model.WeaviateObject;
 import io.weaviate.client.v1.filters.Operator;
-import io.weaviate.client.v1.filters.WhereFilter;
 import io.weaviate.client.v1.graphql.model.ExploreFields;
 import io.weaviate.client.v1.graphql.model.GraphQLResponse;
-import io.weaviate.client.v1.graphql.query.argument.*;
+import io.weaviate.client.v1.graphql.query.argument.Bm25Argument;
+import io.weaviate.client.v1.graphql.query.argument.GroupArgument;
+import io.weaviate.client.v1.graphql.query.argument.GroupByArgument;
+import io.weaviate.client.v1.graphql.query.argument.GroupType;
+import io.weaviate.client.v1.graphql.query.argument.HybridArgument;
+import io.weaviate.client.v1.graphql.query.argument.NearObjectArgument;
+import io.weaviate.client.v1.graphql.query.argument.NearTextArgument;
+import io.weaviate.client.v1.graphql.query.argument.NearTextMoveParameters;
+import io.weaviate.client.v1.graphql.query.argument.NearVectorArgument;
+import io.weaviate.client.v1.graphql.query.argument.SortArgument;
+import io.weaviate.client.v1.graphql.query.argument.SortOrder;
+import io.weaviate.client.v1.graphql.query.argument.WhereArgument;
 import io.weaviate.client.v1.graphql.query.fields.Field;
 import io.weaviate.client.v1.schema.model.DataType;
 import io.weaviate.client.v1.schema.model.Property;
 import io.weaviate.client.v1.schema.model.WeaviateClass;
 import io.weaviate.integration.client.WeaviateDockerCompose;
 import io.weaviate.integration.client.WeaviateTestGenerics;
-import org.assertj.core.api.Assertions;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-
-import java.util.*;
-import java.util.concurrent.ExecutionException;
-import java.util.function.Consumer;
-
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
-import static org.junit.jupiter.api.Assertions.*;
 
 public class ClientGraphQLTest extends AbstractAsyncClientTest {
   private final WeaviateTestGenerics testGenerics = new WeaviateTestGenerics();
@@ -68,7 +88,7 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
   @Test
   public void testGraphQLGet() {
     Result<GraphQLResponse> result = doGet(get -> get.withClassName("Pizza")
-      .withFields(field("name")));
+        .withFields(field("name")));
 
     List<?> pizzas = extractClass(result, "Get", "Pizza");
     assertEquals(4, pizzas.size(), "wrong number of pizzas returned");
@@ -88,32 +108,32 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
   public void testGraphQLGetWithNearObjectAndCertainty() {
     String newObjID = "6baed48e-2afe-4be4-a09d-b00a955d962b";
     NearObjectArgument nearObjectArgument = gql.arguments()
-      .nearObjectArgBuilder()
-      .id(newObjID)
-      .certainty(0.99f)
-      .build();
+        .nearObjectArgBuilder()
+        .id(newObjID)
+        .certainty(0.99f)
+        .build();
 
     WeaviateObject soupWithID = WeaviateObject.builder()
-      .className("Soup")
-      .id(newObjID)
-      .properties(new HashMap<String, java.lang.Object>() {
-        {
-          put("name", "JustSoup");
-          put("description", "soup with id");
-        }
-      })
-      .build();
+        .className("Soup")
+        .id(newObjID)
+        .properties(new HashMap<String, java.lang.Object>() {
+          {
+            put("name", "JustSoup");
+            put("description", "soup with id");
+          }
+        })
+        .build();
 
     // Insert additional test data
     Result<ObjectGetResponse[]> insert = syncClient.batch()
-      .objectsBatcher()
-      .withObjects(soupWithID)
-      .run();
+        .objectsBatcher()
+        .withObjects(soupWithID)
+        .run();
     assumeTrue("all test objects inserted successfully", insert.getResult().length == 1);
 
     Result<GraphQLResponse> result = doGet(get -> get.withClassName("Soup")
-      .withNearObject(nearObjectArgument)
-      .withFields(field("name"), _additional("certainty")));
+        .withNearObject(nearObjectArgument)
+        .withFields(field("name"), _additional("certainty")));
 
     List<?> soups = extractClass(result, "Get", "Soup");
     assertEquals(1, soups.size(), "wrong number of soups");
@@ -123,31 +143,31 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
   public void testGraphQLGetWithNearObjectAndDistance() {
     String newObjID = "6baed48e-2afe-4be4-a09d-b00a955d962b";
     NearObjectArgument nearObjectArgument = gql.arguments()
-      .nearObjectArgBuilder()
-      .id(newObjID)
-      .distance(0.1f)
-      .build();
+        .nearObjectArgBuilder()
+        .id(newObjID)
+        .distance(0.1f)
+        .build();
 
     WeaviateObject soupWithID = WeaviateObject.builder()
-      .className("Soup")
-      .id(newObjID)
-      .properties(new HashMap<String, java.lang.Object>() {
-        {
-          put("name", "JustSoup");
-          put("description", "soup with id");
-        }
-      })
-      .build();
+        .className("Soup")
+        .id(newObjID)
+        .properties(new HashMap<String, java.lang.Object>() {
+          {
+            put("name", "JustSoup");
+            put("description", "soup with id");
+          }
+        })
+        .build();
 
     // Insert additional test data
     syncClient.batch()
-      .objectsBatcher()
-      .withObjects(soupWithID)
-      .run();
+        .objectsBatcher()
+        .withObjects(soupWithID)
+        .run();
 
     Result<GraphQLResponse> result = doGet(get -> get.withClassName("Soup")
-      .withNearObject(nearObjectArgument)
-      .withFields(field("name"), _additional("distance")));
+        .withNearObject(nearObjectArgument)
+        .withFields(field("name"), _additional("distance")));
 
     List<?> soups = extractClass(result, "Get", "Soup");
     assertEquals(1, soups.size(), "wrong number of soups");
@@ -157,14 +177,14 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
   @SuppressWarnings("unchecked")
   public void testBm25() {
     Bm25Argument bm25 = gql.arguments()
-      .bm25ArgBuilder()
-      .query("innovation")
-      .properties(new String[]{ "description" })
-      .build();
+        .bm25ArgBuilder()
+        .query("innovation")
+        .properties(new String[] { "description" })
+        .build();
 
     Result<GraphQLResponse> result = doGet(get -> get.withClassName("Pizza")
-      .withBm25(bm25)
-      .withFields(field("description"), _additional("id", "distance")));
+        .withBm25(bm25)
+        .withFields(field("description"), _additional("id", "distance")));
 
     List<?> pizzas = extractClass(result, "Get", "Pizza");
     assertEquals(1, pizzas.size(), "wrong number of pizzas");
@@ -176,14 +196,14 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
   @Test
   public void testHybrid() {
     HybridArgument hybrid = gql.arguments()
-      .hybridArgBuilder()
-      .query("some say revolution")
-      .alpha(0.8f)
-      .build();
+        .hybridArgBuilder()
+        .query("some say revolution")
+        .alpha(0.8f)
+        .build();
 
     Result<GraphQLResponse> result = doGet(get -> get.withClassName("Pizza")
-      .withHybrid(hybrid)
-      .withFields(field("description"), _additional("id")));
+        .withHybrid(hybrid)
+        .withFields(field("description"), _additional("id")));
 
     List<?> pizzas = extractClass(result, "Get", "Pizza");
     assertFalse(pizzas.isEmpty(), "didn't get any pizzas");
@@ -192,19 +212,19 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
   @Test
   public void testGraphQLGetWithNearTextAndCertainty() {
     NearTextMoveParameters moveAway = NearTextMoveParameters.builder()
-      .concepts(new String[]{ "Universally" })
-      .force(0.8f)
-      .build();
+        .concepts(new String[] { "Universally" })
+        .force(0.8f)
+        .build();
     NearTextArgument nearText = gql.arguments()
-      .nearTextArgBuilder()
-      .concepts(new String[]{ "some say revolution" })
-      .moveAwayFrom(moveAway)
-      .certainty(0.8f)
-      .build();
+        .nearTextArgBuilder()
+        .concepts(new String[] { "some say revolution" })
+        .moveAwayFrom(moveAway)
+        .certainty(0.8f)
+        .build();
 
     Result<GraphQLResponse> result = doGet(get -> get.withClassName("Pizza")
-      .withNearText(nearText)
-      .withFields(field("name"), _additional("certainty")));
+        .withNearText(nearText)
+        .withFields(field("name"), _additional("certainty")));
 
     List<?> pizzas = extractClass(result, "Get", "Pizza");
     assertEquals(1, pizzas.size(), "wrong number of pizzas");
@@ -213,19 +233,19 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
   @Test
   public void testGraphQLGetWithNearTextAndDistance() {
     NearTextMoveParameters moveAway = NearTextMoveParameters.builder()
-      .concepts(new String[]{ "Universally" })
-      .force(0.8f)
-      .build();
+        .concepts(new String[] { "Universally" })
+        .force(0.8f)
+        .build();
     NearTextArgument nearText = gql.arguments()
-      .nearTextArgBuilder()
-      .concepts(new String[]{ "some say revolution" })
-      .moveAwayFrom(moveAway)
-      .distance(0.4f)
-      .build();
+        .nearTextArgBuilder()
+        .concepts(new String[] { "some say revolution" })
+        .moveAwayFrom(moveAway)
+        .distance(0.4f)
+        .build();
 
     Result<GraphQLResponse> result = doGet(get -> get.withClassName("Pizza")
-      .withNearText(nearText)
-      .withFields(field("name"), _additional("distance")));
+        .withNearText(nearText)
+        .withFields(field("name"), _additional("distance")));
 
     List<?> pizzas = extractClass(result, "Get", "Pizza");
     assertEquals(1, pizzas.size(), "wrong number of pizzas");
@@ -236,56 +256,56 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
     String newObjID1 = "6baed48e-2afe-4be4-a09d-b00a955d962b";
     String newObjID2 = "6baed48e-2afe-4be4-a09d-b00a955d962a";
     WeaviateObject pizzaWithID = WeaviateObject.builder()
-      .className("Pizza")
-      .id(newObjID1)
-      .properties(new HashMap<String, java.lang.Object>() {
-        {
-          put("name", "JustPizza1");
-          put("description", "Universally pizza with id");
-        }
-      })
-      .build();
+        .className("Pizza")
+        .id(newObjID1)
+        .properties(new HashMap<String, java.lang.Object>() {
+          {
+            put("name", "JustPizza1");
+            put("description", "Universally pizza with id");
+          }
+        })
+        .build();
     WeaviateObject pizzaWithID2 = WeaviateObject.builder()
-      .className("Pizza")
-      .id(newObjID2)
-      .properties(new HashMap<String, java.lang.Object>() {
-        {
-          put("name", "JustPizza2");
-          put("description", "Universally pizza with some other id");
-        }
-      })
-      .build();
+        .className("Pizza")
+        .id(newObjID2)
+        .properties(new HashMap<String, java.lang.Object>() {
+          {
+            put("name", "JustPizza2");
+            put("description", "Universally pizza with some other id");
+          }
+        })
+        .build();
 
     NearTextMoveParameters moveAway = NearTextMoveParameters.builder()
-      .objects(new NearTextMoveParameters.ObjectMove[]{ NearTextMoveParameters.ObjectMove.builder()
-        .id(newObjID1).build()
-      })
-      .force(0.9f)
-      .build();
+        .objects(new NearTextMoveParameters.ObjectMove[] { NearTextMoveParameters.ObjectMove.builder()
+            .id(newObjID1).build()
+        })
+        .force(0.9f)
+        .build();
     NearTextMoveParameters moveTo = NearTextMoveParameters.builder()
-      .objects(new NearTextMoveParameters.ObjectMove[]{ NearTextMoveParameters.ObjectMove.builder()
-        .id(newObjID2).build()
-      })
-      .force(0.9f)
-      .build();
+        .objects(new NearTextMoveParameters.ObjectMove[] { NearTextMoveParameters.ObjectMove.builder()
+            .id(newObjID2).build()
+        })
+        .force(0.9f)
+        .build();
     NearTextArgument nearText = gql.arguments()
-      .nearTextArgBuilder()
-      .concepts(new String[]{ "Universally pizza with id" })
-      .moveAwayFrom(moveAway)
-      .moveTo(moveTo)
-      .certainty(0.4f)
-      .build();
+        .nearTextArgBuilder()
+        .concepts(new String[] { "Universally pizza with id" })
+        .moveAwayFrom(moveAway)
+        .moveTo(moveTo)
+        .certainty(0.4f)
+        .build();
 
     // Insert additional test data
     Result<ObjectGetResponse[]> insert = syncClient.batch()
-      .objectsBatcher()
-      .withObjects(pizzaWithID, pizzaWithID2)
-      .run();
+        .objectsBatcher()
+        .withObjects(pizzaWithID, pizzaWithID2)
+        .run();
     assumeTrue("all test objects inserted successfully", insert.getResult().length == 2);
 
     Result<GraphQLResponse> result = doGet(get -> get.withClassName("Pizza")
-      .withNearText(nearText)
-      .withFields(field("name"), _additional("certainty")));
+        .withNearText(nearText)
+        .withFields(field("name"), _additional("certainty")));
 
     List<?> pizzas = extractClass(result, "Get", "Pizza");
     assertEquals(6, pizzas.size(), "wrong number of pizzas");
@@ -296,56 +316,56 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
     String newObjID1 = "6baed48e-2afe-4be4-a09d-b00a955d962b";
     String newObjID2 = "6baed48e-2afe-4be4-a09d-b00a955d962a";
     WeaviateObject pizzaWithID = WeaviateObject.builder()
-      .className("Pizza")
-      .id(newObjID1)
-      .properties(new HashMap<String, java.lang.Object>() {
-        {
-          put("name", "JustPizza1");
-          put("description", "Universally pizza with id");
-        }
-      })
-      .build();
+        .className("Pizza")
+        .id(newObjID1)
+        .properties(new HashMap<String, java.lang.Object>() {
+          {
+            put("name", "JustPizza1");
+            put("description", "Universally pizza with id");
+          }
+        })
+        .build();
     WeaviateObject pizzaWithID2 = WeaviateObject.builder()
-      .className("Pizza")
-      .id(newObjID2)
-      .properties(new HashMap<String, java.lang.Object>() {
-        {
-          put("name", "JustPizza2");
-          put("description", "Universally pizza with some other id");
-        }
-      })
-      .build();
+        .className("Pizza")
+        .id(newObjID2)
+        .properties(new HashMap<String, java.lang.Object>() {
+          {
+            put("name", "JustPizza2");
+            put("description", "Universally pizza with some other id");
+          }
+        })
+        .build();
 
     NearTextMoveParameters moveAway = NearTextMoveParameters.builder()
-      .objects(new NearTextMoveParameters.ObjectMove[]{ NearTextMoveParameters.ObjectMove.builder()
-        .id(newObjID1).build()
-      })
-      .force(0.9f)
-      .build();
+        .objects(new NearTextMoveParameters.ObjectMove[] { NearTextMoveParameters.ObjectMove.builder()
+            .id(newObjID1).build()
+        })
+        .force(0.9f)
+        .build();
     NearTextMoveParameters moveTo = NearTextMoveParameters.builder()
-      .objects(new NearTextMoveParameters.ObjectMove[]{ NearTextMoveParameters.ObjectMove.builder()
-        .id(newObjID2).build()
-      })
-      .force(0.9f)
-      .build();
+        .objects(new NearTextMoveParameters.ObjectMove[] { NearTextMoveParameters.ObjectMove.builder()
+            .id(newObjID2).build()
+        })
+        .force(0.9f)
+        .build();
     NearTextArgument nearText = gql.arguments()
-      .nearTextArgBuilder()
-      .concepts(new String[]{ "Universally pizza with id" })
-      .moveAwayFrom(moveAway)
-      .moveTo(moveTo)
-      .distance(0.6f)
-      .build();
+        .nearTextArgBuilder()
+        .concepts(new String[] { "Universally pizza with id" })
+        .moveAwayFrom(moveAway)
+        .moveTo(moveTo)
+        .distance(0.6f)
+        .build();
 
     // Insert additional test data
     Result<ObjectGetResponse[]> insert = syncClient.batch()
-      .objectsBatcher()
-      .withObjects(pizzaWithID, pizzaWithID2)
-      .run();
+        .objectsBatcher()
+        .withObjects(pizzaWithID, pizzaWithID2)
+        .run();
     assumeTrue("all test objects inserted successfully", insert.getResult().length == 2);
 
     Result<GraphQLResponse> result = doGet(get -> get.withClassName("Pizza")
-      .withNearText(nearText)
-      .withFields(field("name"), _additional("distance")));
+        .withNearText(nearText)
+        .withFields(field("name"), _additional("distance")));
 
     List<?> pizzas = extractClass(result, "Get", "Pizza");
     assertEquals(6, pizzas.size(), "wrong number of pizzas");
@@ -354,15 +374,15 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
   @Test
   public void testGraphQLGetWithNearTextAndLimitAndCertainty() {
     NearTextArgument nearText = gql.arguments()
-      .nearTextArgBuilder()
-      .concepts(new String[]{ "some say revolution" })
-      .certainty(0.8f)
-      .build();
+        .nearTextArgBuilder()
+        .concepts(new String[] { "some say revolution" })
+        .certainty(0.8f)
+        .build();
 
     Result<GraphQLResponse> result = doGet(get -> get.withClassName("Pizza")
-      .withNearText(nearText)
-      .withLimit(1)
-      .withFields(field("name"), _additional("certainty")));
+        .withNearText(nearText)
+        .withLimit(1)
+        .withFields(field("name"), _additional("certainty")));
 
     List<?> pizzas = extractClass(result, "Get", "Pizza");
     assertEquals(1, pizzas.size(), "wrong number of pizzas");
@@ -371,15 +391,15 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
   @Test
   public void testGraphQLGetWithNearTextAndLimitAndDistance() {
     NearTextArgument nearText = gql.arguments()
-      .nearTextArgBuilder()
-      .concepts(new String[]{ "some say revolution" })
-      .distance(0.4f)
-      .build();
+        .nearTextArgBuilder()
+        .concepts(new String[] { "some say revolution" })
+        .distance(0.4f)
+        .build();
 
     Result<GraphQLResponse> result = doGet(get -> get.withClassName("Pizza")
-      .withNearText(nearText)
-      .withLimit(1)
-      .withFields(field("name"), _additional("distance")));
+        .withNearText(nearText)
+        .withLimit(1)
+        .withFields(field("name"), _additional("distance")));
 
     List<?> pizzas = extractClass(result, "Get", "Pizza");
     assertEquals(1, pizzas.size(), "wrong number of pizzas");
@@ -390,21 +410,22 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
     Field name = field("name");
     WhereArgument whereFullString = whereText("name", Operator.Equal, "Frutti di Mare");
     WhereArgument wherePartString = whereText("name", Operator.Equal, "Frutti");
-    WhereArgument whereFullText = whereText("description", Operator.Equal, "Universally accepted to be the best pizza ever created.");
+    WhereArgument whereFullText = whereText("description", Operator.Equal,
+        "Universally accepted to be the best pizza ever created.");
     WhereArgument wherePartText = whereText("description", Operator.Equal, "Universally");
     // when
     Result<GraphQLResponse> resultFullString = doGet(get -> get.withWhere(whereFullString)
-      .withClassName("Pizza")
-      .withFields(name));
+        .withClassName("Pizza")
+        .withFields(name));
     Result<GraphQLResponse> resultPartString = doGet(get -> get.withWhere(wherePartString)
-      .withClassName("Pizza")
-      .withFields(name));
+        .withClassName("Pizza")
+        .withFields(name));
     Result<GraphQLResponse> resultFullText = doGet(get -> get.withWhere(whereFullText)
-      .withClassName("Pizza")
-      .withFields(name));
+        .withClassName("Pizza")
+        .withFields(name));
     Result<GraphQLResponse> resultPartText = doGet(get -> get.withWhere(wherePartText)
-      .withClassName("Pizza")
-      .withFields(name));
+        .withClassName("Pizza")
+        .withFields(name));
     // then
     assertWhereResultSize(1, resultFullString, "Pizza");
     assertWhereResultSize(0, resultPartString, "Pizza");
@@ -417,8 +438,8 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
     WhereArgument whereString = whereText("name", Operator.Equal, "Frutti di Mare");
 
     Result<GraphQLResponse> result = doGet(get -> get.withWhere(whereString)
-      .withClassName("Pizza")
-      .withFields(field("name")));
+        .withClassName("Pizza")
+        .withFields(field("name")));
 
     assertWhereResultSize(1, result, "Pizza");
   }
@@ -430,69 +451,79 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
     WhereArgument whereDate = whereDate("bestBefore", Operator.GreaterThan, cal.getTime());
 
     Result<GraphQLResponse> resultDate = doGet(get -> get.withWhere(whereDate)
-      .withClassName("Pizza")
-      .withFields(field("name")));
+        .withClassName("Pizza")
+        .withFields(field("name")));
 
     List<Map<String, Object>> result = extractClass(resultDate, "Get", "Pizza");
     Assertions.assertThat(result)
-      .hasSize(3)
-      .extracting(el -> (String) el.get("name"))
-      .contains("Frutti di Mare", "Hawaii", "Doener");
+        .hasSize(3)
+        .extracting(el -> (String) el.get("name"))
+        .contains("Frutti di Mare", "Hawaii", "Doener");
   }
 
+  /**
+   * @see https://github.com/weaviate/java-client/pull/456#issuecomment-3270249876
+   */
+  @Ignore("Regression in Explorer API in v1.33")
   @Test
   public void testGraphQLExploreWithCertainty() {
-    ExploreFields[] fields = new ExploreFields[]{ ExploreFields.CERTAINTY, ExploreFields.BEACON, ExploreFields.CLASS_NAME };
-    String[] concepts = new String[]{ "pineapple slices", "ham" };
+    ExploreFields[] fields = new ExploreFields[] { ExploreFields.CERTAINTY, ExploreFields.BEACON,
+        ExploreFields.CLASS_NAME };
+    String[] concepts = new String[] { "pineapple slices", "ham" };
     NearTextMoveParameters moveTo = gql.arguments()
-      .nearTextMoveParameterBuilder()
-      .concepts(new String[]{ "Pizza" })
-      .force(0.3f)
-      .build();
+        .nearTextMoveParameterBuilder()
+        .concepts(new String[] { "Pizza" })
+        .force(0.3f)
+        .build();
     NearTextMoveParameters moveAwayFrom = gql.arguments()
-      .nearTextMoveParameterBuilder()
-      .concepts(new String[]{ "toast", "bread" })
-      .force(0.4f)
-      .build();
+        .nearTextMoveParameterBuilder()
+        .concepts(new String[] { "toast", "bread" })
+        .force(0.4f)
+        .build();
     NearTextArgument withNearText = gql.arguments()
-      .nearTextArgBuilder()
-      .concepts(concepts)
-      .certainty(0.40f)
-      .moveTo(moveTo)
-      .moveAwayFrom(moveAwayFrom)
-      .build();
+        .nearTextArgBuilder()
+        .concepts(concepts)
+        .certainty(0.40f)
+        .moveTo(moveTo)
+        .moveAwayFrom(moveAwayFrom)
+        .build();
 
     Result<GraphQLResponse> result = doExplore(explore -> explore.withFields(fields)
-      .withNearText(withNearText));
+        .withNearText(withNearText));
 
     List<?> got = extractQueryResult(result, "Explore");
     assertEquals(6, got.size());
   }
 
+  /**
+   * @see https://github.com/weaviate/java-client/pull/456#issuecomment-3270249876
+   */
+  @Ignore("Regression in Explorer API in v1.33")
   @Test
   public void testGraphQLExploreWithDistance() {
-    ExploreFields[] fields = new ExploreFields[]{ ExploreFields.CERTAINTY, ExploreFields.BEACON, ExploreFields.CLASS_NAME };
-    String[] concepts = new String[]{ "pineapple slices", "ham" };
+    ExploreFields[] fields = new ExploreFields[] { ExploreFields.CERTAINTY, ExploreFields.BEACON,
+        ExploreFields.CLASS_NAME };
+    String[] concepts = new String[] { "pineapple slices", "ham" };
     NearTextMoveParameters moveTo = gql.arguments()
-      .nearTextMoveParameterBuilder()
-      .concepts(new String[]{ "Pizza" })
-      .force(0.3f)
-      .build();
+        .nearTextMoveParameterBuilder()
+        .concepts(new String[] { "Pizza" })
+        .force(0.3f)
+        .build();
     NearTextMoveParameters moveAwayFrom = gql.arguments()
-      .nearTextMoveParameterBuilder()
-      .concepts(new String[]{ "toast", "bread" })
-      .force(0.4f)
-      .build();
+        .nearTextMoveParameterBuilder()
+        .concepts(new String[] { "toast", "bread" })
+        .force(0.4f)
+        .build();
     NearTextArgument withNearText = gql.arguments()
-      .nearTextArgBuilder()
-      .concepts(concepts)
-      .distance(0.80f)
-      .moveTo(moveTo)
-      .moveAwayFrom(moveAwayFrom)
-      .build();
+        .nearTextArgBuilder()
+        .concepts(concepts)
+        .distance(0.80f)
+        .moveTo(moveTo)
+        .moveAwayFrom(moveAwayFrom)
+        .build();
 
     Result<GraphQLResponse> result = doExplore(explore -> explore.withFields(fields)
-      .withNearText(withNearText));
+        .withNearText(withNearText));
 
     List<?> got = extractQueryResult(result, "Explore");
     assertEquals(6, got.size());
@@ -501,7 +532,7 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
   @Test
   public void testGraphQLAggregate() {
     Result<GraphQLResponse> result = doAggregate(aggregate -> aggregate.withFields(meta("count"))
-      .withClassName("Pizza"));
+        .withClassName("Pizza"));
 
     assertAggregateMetaCount(result, "Pizza", 1, 4.0d);
   }
@@ -510,26 +541,26 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
   public void testGraphQLAggregateWithWhereFilter() {
     String newObjID = "6baed48e-2afe-4be4-a09d-b00a955d96ee";
     WeaviateObject pizzaWithID = WeaviateObject.builder()
-      .className("Pizza")
-      .id(newObjID)
-      .properties(new HashMap<String, java.lang.Object>() {
-        {
-          put("name", "JustPizza");
-          put("description", "pizza with id");
-        }
-      })
-      .build();
+        .className("Pizza")
+        .id(newObjID)
+        .properties(new HashMap<String, java.lang.Object>() {
+          {
+            put("name", "JustPizza");
+            put("description", "pizza with id");
+          }
+        })
+        .build();
 
     // Insert additional test data
     Result<ObjectGetResponse[]> insert = syncClient.batch()
-      .objectsBatcher()
-      .withObjects(pizzaWithID)
-      .run();
+        .objectsBatcher()
+        .withObjects(pizzaWithID)
+        .run();
     assumeTrue("all test objects inserted successfully", insert.getResult().length == 1);
 
     Result<GraphQLResponse> result = doAggregate(aggregate -> aggregate.withFields(meta("count"))
-      .withClassName("Pizza")
-      .withWhere(whereText("id", Operator.Equal, newObjID)));
+        .withClassName("Pizza")
+        .withWhere(whereText("id", Operator.Equal, newObjID)));
 
     assertAggregateMetaCount(result, "Pizza", 1, 1.0d);
   }
@@ -539,27 +570,27 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
     // given
     String newObjID = "6baed48e-2afe-4be4-a09d-b00a955d96ee";
     WeaviateObject pizzaWithID = WeaviateObject.builder()
-      .className("Pizza")
-      .id(newObjID)
-      .properties(new HashMap<String, java.lang.Object>() {
-        {
-          put("name", "JustPizza");
-          put("description", "pizza with id");
-        }
-      })
-      .build();
+        .className("Pizza")
+        .id(newObjID)
+        .properties(new HashMap<String, java.lang.Object>() {
+          {
+            put("name", "JustPizza");
+            put("description", "pizza with id");
+          }
+        })
+        .build();
 
     // Insert additional test objects
     Result<ObjectGetResponse[]> insert = syncClient.batch()
-      .objectsBatcher()
-      .withObjects(pizzaWithID)
-      .run();
+        .objectsBatcher()
+        .withObjects(pizzaWithID)
+        .run();
     assumeTrue("all test objects inserted successfully", insert.getResult().length == 1);
 
     Result<GraphQLResponse> result = doAggregate(aggregate -> aggregate.withFields(meta("count"))
-      .withClassName("Pizza")
-      .withGroupBy("name")
-      .withWhere(whereText("id", Operator.Equal, newObjID)));
+        .withClassName("Pizza")
+        .withGroupBy("name")
+        .withWhere(whereText("id", Operator.Equal, newObjID)));
 
     assertAggregateMetaCount(result, "Pizza", 1, 1.0d);
   }
@@ -568,26 +599,26 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
   public void testGraphQLAggregateWithGroupedBy() {
     String newObjID = "6baed48e-2afe-4be4-a09d-b00a955d96ee";
     WeaviateObject pizzaWithID = WeaviateObject.builder()
-      .className("Pizza")
-      .id(newObjID)
-      .properties(new HashMap<String, java.lang.Object>() {
-        {
-          put("name", "JustPizza");
-          put("description", "pizza with id");
-        }
-      })
-      .build();
+        .className("Pizza")
+        .id(newObjID)
+        .properties(new HashMap<String, java.lang.Object>() {
+          {
+            put("name", "JustPizza");
+            put("description", "pizza with id");
+          }
+        })
+        .build();
 
     // Insert additional test data
     Result<ObjectGetResponse[]> insert = syncClient.batch()
-      .objectsBatcher()
-      .withObjects(pizzaWithID)
-      .run();
+        .objectsBatcher()
+        .withObjects(pizzaWithID)
+        .run();
     assumeTrue("all test objects inserted successfully", insert.getResult().length == 1);
 
     Result<GraphQLResponse> result = doAggregate(aggregate -> aggregate.withClassName("Pizza")
-      .withFields(meta("count"))
-      .withGroupBy("name"));
+        .withFields(meta("count"))
+        .withGroupBy("name"));
 
     assertAggregateMetaCount(result, "Pizza", 5, 1.0d);
   }
@@ -595,16 +626,16 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
   @Test
   public void testGraphQLAggregateWithNearVector() {
     Result<GraphQLResponse> getVector = doGet(get -> get.withClassName("Pizza")
-      .withFields(_additional("vector")));
+        .withFields(_additional("vector")));
     Float[] vector = extractVector(getVector, "Get", "Pizza");
     NearVectorArgument nearVector = NearVectorArgument.builder()
-      .certainty(0.7f)
-      .vector(vector)
-      .build();
+        .certainty(0.7f)
+        .vector(vector)
+        .build();
 
     Result<GraphQLResponse> result = doAggregate(aggregate -> aggregate.withClassName("Pizza")
-      .withFields(meta("count"))
-      .withNearVector(nearVector));
+        .withFields(meta("count"))
+        .withNearVector(nearVector));
 
     assertAggregateMetaCount(result, "Pizza", 1, 4.0d);
   }
@@ -612,17 +643,17 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
   @Test
   public void testGraphQLAggregateWithNearObjectAndCertainty() {
     Result<GraphQLResponse> getId = doGet(get -> get.withClassName("Pizza")
-      .withFields(_additional("id")));
+        .withFields(_additional("id")));
     String id = extractAdditional(getId, "Get", "Pizza", "id");
 
     // when
     NearObjectArgument nearObject = NearObjectArgument.builder()
-      .certainty(0.7f)
-      .id(id)
-      .build();
+        .certainty(0.7f)
+        .id(id)
+        .build();
     Result<GraphQLResponse> result = doAggregate(aggregate -> aggregate.withClassName("Pizza")
-      .withFields(meta("count"))
-      .withNearObject(nearObject));
+        .withFields(meta("count"))
+        .withNearObject(nearObject));
 
     assertAggregateMetaCount(result, "Pizza", 1, 4.0d);
   }
@@ -630,16 +661,16 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
   @Test
   public void testGraphQLAggregateWithNearObjectAndDistance() {
     Result<GraphQLResponse> getId = doGet(get -> get.withClassName("Pizza")
-      .withFields(_additional("id")));
+        .withFields(_additional("id")));
     String id = extractAdditional(getId, "Get", "Pizza", "id");
 
     NearObjectArgument nearObject = NearObjectArgument.builder()
-      .distance(0.3f)
-      .id(id)
-      .build();
+        .distance(0.3f)
+        .id(id)
+        .build();
     Result<GraphQLResponse> result = doAggregate(aggregate -> aggregate.withFields(meta("count"))
-      .withClassName("Pizza")
-      .withNearObject(nearObject));
+        .withClassName("Pizza")
+        .withNearObject(nearObject));
 
     assertAggregateMetaCount(result, "Pizza", 1, 4.0d);
   }
@@ -647,13 +678,13 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
   @Test
   public void testGraphQLAggregateWithNearTextAndCertainty() {
     NearTextArgument nearText = NearTextArgument.builder()
-      .certainty(0.7f)
-      .concepts(new String[]{ "pizza" })
-      .build();
+        .certainty(0.7f)
+        .concepts(new String[] { "pizza" })
+        .build();
 
     Result<GraphQLResponse> result = doAggregate(aggregate -> aggregate.withClassName("Pizza")
-      .withFields(meta("count"))
-      .withNearText(nearText));
+        .withFields(meta("count"))
+        .withNearText(nearText));
 
     assertAggregateMetaCount(result, "Pizza", 1, 4.0d);
   }
@@ -661,13 +692,13 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
   @Test
   public void testGraphQLAggregateWithNearTextAndDistance() {
     NearTextArgument nearText = NearTextArgument.builder()
-      .distance(0.6f)
-      .concepts(new String[]{ "pizza" })
-      .build();
+        .distance(0.6f)
+        .concepts(new String[] { "pizza" })
+        .build();
 
     Result<GraphQLResponse> result = doAggregate(aggregate -> aggregate.withClassName("Pizza")
-      .withFields(meta("count"))
-      .withNearText(nearText));
+        .withFields(meta("count"))
+        .withNearText(nearText));
 
     assertAggregateMetaCount(result, "Pizza", 1, 4.0d);
   }
@@ -676,14 +707,14 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
   public void testGraphQLAggregateWithObjectLimitAndCertainty() {
     int limit = 1;
     NearTextArgument nearText = NearTextArgument.builder()
-      .certainty(0.7f)
-      .concepts(new String[]{ "pizza" })
-      .build();
+        .certainty(0.7f)
+        .concepts(new String[] { "pizza" })
+        .build();
 
     Result<GraphQLResponse> result = doAggregate(aggregate -> aggregate.withClassName("Pizza")
-      .withFields(meta("count"))
-      .withNearText(nearText)
-      .withObjectLimit(limit));
+        .withFields(meta("count"))
+        .withNearText(nearText)
+        .withObjectLimit(limit));
 
     assertAggregateMetaCount(result, "Pizza", 1, (double) limit);
   }
@@ -692,14 +723,14 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
   public void testGraphQLAggregateWithObjectLimitAndDistance() {
     int limit = 1;
     NearTextArgument nearText = NearTextArgument.builder()
-      .distance(0.3f)
-      .concepts(new String[]{ "pizza" })
-      .build();
+        .distance(0.3f)
+        .concepts(new String[] { "pizza" })
+        .build();
 
     Result<GraphQLResponse> result = doAggregate(aggregate -> aggregate.withClassName("Pizza")
-      .withFields(meta("count"))
-      .withNearText(nearText)
-      .withObjectLimit(limit));
+        .withFields(meta("count"))
+        .withNearText(nearText)
+        .withObjectLimit(limit));
 
     assertAggregateMetaCount(result, "Pizza", 1, (double) limit);
   }
@@ -707,15 +738,15 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
   @Test
   public void testGraphQLGetWithGroup() {
     GroupArgument group = gql.arguments()
-      .groupArgBuilder()
-      .type(GroupType.merge)
-      .force(1.0f)
-      .build();
+        .groupArgBuilder()
+        .type(GroupType.merge)
+        .force(1.0f)
+        .build();
 
     Result<GraphQLResponse> result = doGet(get -> get.withClassName("Soup")
-      .withFields(field("name"))
-      .withGroup(group)
-      .withLimit(7));
+        .withFields(field("name"))
+        .withGroup(group)
+        .withLimit(7));
 
     List<?> soups = extractClass(result, "Get", "Soup");
     assertEquals(1, soups.size(), "wrong number of soups");
@@ -724,22 +755,22 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
   @Test
   public void testGraphQLGetWithSort() {
     SortArgument byNameDesc = sort(SortOrder.desc, "name");
-    String[] expectedByNameDesc = new String[]{ "Quattro Formaggi", "Hawaii", "Frutti di Mare", "Doener" };
+    String[] expectedByNameDesc = new String[] { "Quattro Formaggi", "Hawaii", "Frutti di Mare", "Doener" };
 
     SortArgument byPriceAsc = sort(SortOrder.asc, "price");
-    String[] expectedByPriceAsc = new String[]{ "Hawaii", "Doener", "Quattro Formaggi", "Frutti di Mare" };
+    String[] expectedByPriceAsc = new String[] { "Hawaii", "Doener", "Quattro Formaggi", "Frutti di Mare" };
 
     Field name = field("name");
 
     Result<GraphQLResponse> resultByNameDesc = doGet(get -> get.withClassName("Pizza")
-      .withSort(byNameDesc)
-      .withFields(name));
+        .withSort(byNameDesc)
+        .withFields(name));
     Result<GraphQLResponse> resultByDescriptionAsc = doGet(get -> get.withClassName("Pizza")
-      .withSort(byPriceAsc)
-      .withFields(name));
+        .withSort(byPriceAsc)
+        .withFields(name));
     Result<GraphQLResponse> resultByNameDescByPriceAsc = doGet(get -> get.withClassName("Pizza")
-      .withSort(byNameDesc, byPriceAsc)
-      .withFields(name));
+        .withSort(byNameDesc, byPriceAsc)
+        .withFields(name));
 
     assertObjectNamesEqual(resultByNameDesc, "Get", "Pizza", expectedByNameDesc);
     assertObjectNamesEqual(resultByDescriptionAsc, "Get", "Pizza", expectedByPriceAsc);
@@ -750,17 +781,17 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
   public void testGraphQLGetWithTimestampFilters() {
     Field additional = _additional("id", "creationTimeUnix", "lastUpdateTimeUnix");
     Result<GraphQLResponse> expected = doGet(get -> get.withClassName("Pizza")
-      .withFields(additional));
+        .withFields(additional));
 
     String expectedCreateTime = extractAdditional(expected, "Get", "Pizza", "creationTimeUnix");
     String expectedUpdateTime = extractAdditional(expected, "Get", "Pizza", "lastUpdateTimeUnix");
 
     Result<GraphQLResponse> createTimeResult = doGet(get -> get.withClassName("Pizza")
-      .withWhere(whereText("_creationTimeUnix", Operator.Equal, expectedCreateTime))
-      .withFields(additional));
+        .withWhere(whereText("_creationTimeUnix", Operator.Equal, expectedCreateTime))
+        .withFields(additional));
     Result<GraphQLResponse> updateTimeResult = doGet(get -> get.withClassName("Pizza")
-      .withWhere(whereText("_lastUpdateTimeUnix", Operator.Equal, expectedCreateTime))
-      .withFields(additional));
+        .withWhere(whereText("_lastUpdateTimeUnix", Operator.Equal, expectedCreateTime))
+        .withFields(additional));
 
     String resultCreateTime = extractAdditional(createTimeResult, "Get", "Pizza", "creationTimeUnix");
     assertEquals(expectedCreateTime, resultCreateTime);
@@ -772,9 +803,9 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
   @Test
   public void testGraphQLGetUsingCursorAPI() {
     Result<GraphQLResponse> result = doGet(get -> get.withClassName("Pizza")
-      .withAfter("00000000-0000-0000-0000-000000000000")
-      .withLimit(10)
-      .withFields(field("name")));
+        .withAfter("00000000-0000-0000-0000-000000000000")
+        .withLimit(10)
+        .withFields(field("name")));
 
     List<?> pizzas = extractClass(result, "Get", "Pizza");
     assertEquals(3, pizzas.size(), "wrong number of pizzas");
@@ -783,9 +814,9 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
   @Test
   public void testGraphQLGetUsingLimitAndOffset() {
     Result<GraphQLResponse> result = doGet(get -> get.withClassName("Pizza")
-      .withOffset(3)
-      .withLimit(4)
-      .withFields(field("name")));
+        .withOffset(3)
+        .withLimit(4)
+        .withFields(field("name")));
 
     List<?> pizzas = extractClass(result, "Get", "Pizza");
     assertEquals(1, pizzas.size(), "wrong number of pizzas");
@@ -793,91 +824,100 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
 
   @Test
   public void testGraphQLGetWithGroupBy() {
-    Field[] hits = new Field[]{ Field.builder()
-      .name("ofDocument")
-      .fields(new Field[]{ Field.builder()
-        .name("... on Document")
-        .fields(new Field[]{ Field.builder()
-          .name("_additional{id}").build() }).build()
-      }).build(), Field.builder()
-      .name("_additional{id distance}").build(),
+    Field[] hits = new Field[] { Field.builder()
+        .name("ofDocument")
+        .fields(new Field[] { Field.builder()
+            .name("... on Document")
+            .fields(new Field[] { Field.builder()
+                .name("_additional{id}").build() })
+            .build()
+        }).build(), Field.builder()
+            .name("_additional{id distance}").build(),
     };
 
     Field group = Field.builder()
-      .name("group")
-      .fields(new Field[]{ Field.builder()
-        .name("id").build(), Field.builder()
-        .name("groupedBy")
-        .fields(new Field[]{ Field.builder()
-          .name("value").build(), Field.builder()
-          .name("path").build(),
-        }).build(), Field.builder()
-        .name("count").build(), Field.builder()
-        .name("maxDistance").build(), Field.builder()
-        .name("minDistance").build(), Field.builder()
-        .name("hits")
-        .fields(hits).build(),
-      })
-      .build();
+        .name("group")
+        .fields(new Field[] { Field.builder()
+            .name("id").build(),
+            Field.builder()
+                .name("groupedBy")
+                .fields(new Field[] { Field.builder()
+                    .name("value").build(),
+                    Field.builder()
+                        .name("path").build(),
+                }).build(),
+            Field.builder()
+                .name("count").build(),
+            Field.builder()
+                .name("maxDistance").build(),
+            Field.builder()
+                .name("minDistance").build(),
+            Field.builder()
+                .name("hits")
+                .fields(hits).build(),
+        })
+        .build();
 
     Field _additional = Field.builder()
-      .name("_additional")
-      .fields(new Field[]{ group })
-      .build();
+        .name("_additional")
+        .fields(new Field[] { group })
+        .build();
     Field ofDocument = Field.builder()
-      .name("ofDocument{__typename}")
-      .build(); // Property that we group by
+        .name("ofDocument{__typename}")
+        .build(); // Property that we group by
 
     GroupByArgument groupBy = client.graphQL()
-      .arguments()
-      .groupByArgBuilder()
-      .path(new String[]{ "ofDocument" })
-      .groups(3)
-      .objectsPerGroup(10)
-      .build();
+        .arguments()
+        .groupByArgBuilder()
+        .path(new String[] { "ofDocument" })
+        .groups(3)
+        .objectsPerGroup(10)
+        .build();
     NearObjectArgument nearObject = client.graphQL()
-      .arguments()
-      .nearObjectArgBuilder()
-      .id("00000000-0000-0000-0000-000000000001")
-      .build();
+        .arguments()
+        .nearObjectArgBuilder()
+        .id("00000000-0000-0000-0000-000000000001")
+        .build();
 
     passageSchema.createAndInsertData(syncClient);
 
     try {
       Result<GraphQLResponse> result = doGet(get -> get.withClassName(passageSchema.PASSAGE)
-        .withNearObject(nearObject)
-        .withGroupBy(groupBy)
-        .withFields(ofDocument, _additional));
+          .withNearObject(nearObject)
+          .withGroupBy(groupBy)
+          .withFields(ofDocument, _additional));
 
       List<Map<String, Object>> passages = extractClass(result, "Get", passageSchema.PASSAGE);
       assertEquals(3, passages.size(), "wrong number of passages");
 
-      // This part of assertions is almost verbatim from package io.weaviate.integration.client.graphql.ClientGraphQLTest
-      // because it involves a lot of inner classes that we don't won't to redefine here.
+      // This part of assertions is almost verbatim from package
+      // io.weaviate.integration.client.graphql.ClientGraphQLTest
+      // because it involves a lot of inner classes that we don't won't to redefine
+      // here.
       List<Group> groups = getGroups(passages);
       Assertions.assertThat(groups)
-        .isNotNull()
-        .hasSize(3);
+          .isNotNull()
+          .hasSize(3);
       for (int i = 0; i < 3; i++) {
         Assertions.assertThat(groups.get(i).minDistance)
-          .isEqualTo(groups.get(i)
-            .getHits()
-            .get(0)
-            .get_additional()
-            .getDistance());
+            .isEqualTo(groups.get(i)
+                .getHits()
+                .get(0)
+                .get_additional()
+                .getDistance());
         Assertions.assertThat(groups.get(i).maxDistance)
-          .isEqualTo(groups.get(i)
-            .getHits()
-            .get(groups.get(i)
-              .getHits()
-              .size() - 1)
-            .get_additional()
-            .getDistance());
+            .isEqualTo(groups.get(i)
+                .getHits()
+                .get(groups.get(i)
+                    .getHits()
+                    .size() - 1)
+                .get_additional()
+                .getDistance());
       }
       checkGroupElements(expectedHitsA, groups.get(0)
-        .getHits());
+          .getHits());
       checkGroupElements(expectedHitsB, groups.get(1)
-        .getHits());
+          .getHits());
     } finally {
       passageSchema.cleanupWeaviate(syncClient);
     }
@@ -885,87 +925,94 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
 
   @Test
   public void testGraphQLGetWithGroupByWithHybrid() {
-    Field[] hits = new Field[]{ Field.builder()
-      .name("content").build(), Field.builder()
-      .name("_additional{id distance}").build(),
+    Field[] hits = new Field[] { Field.builder()
+        .name("content").build(),
+        Field.builder()
+            .name("_additional{id distance}").build(),
     };
     Field group = Field.builder()
-      .name("group")
-      .fields(new Field[]{ Field.builder()
-        .name("id").build(), Field.builder()
-        .name("groupedBy")
-        .fields(new Field[]{ Field.builder()
-          .name("value").build(), Field.builder()
-          .name("path").build(),
-        }).build(), Field.builder()
-        .name("count").build(), Field.builder()
-        .name("maxDistance").build(), Field.builder()
-        .name("minDistance").build(), Field.builder()
-        .name("hits")
-        .fields(hits).build(),
-      })
-      .build();
+        .name("group")
+        .fields(new Field[] { Field.builder()
+            .name("id").build(),
+            Field.builder()
+                .name("groupedBy")
+                .fields(new Field[] { Field.builder()
+                    .name("value").build(),
+                    Field.builder()
+                        .name("path").build(),
+                }).build(),
+            Field.builder()
+                .name("count").build(),
+            Field.builder()
+                .name("maxDistance").build(),
+            Field.builder()
+                .name("minDistance").build(),
+            Field.builder()
+                .name("hits")
+                .fields(hits).build(),
+        })
+        .build();
     Field _additional = Field.builder()
-      .name("_additional")
-      .fields(new Field[]{ group })
-      .build();
+        .name("_additional")
+        .fields(new Field[] { group })
+        .build();
     Field content = Field.builder()
-      .name("content")
-      .build(); // Property that we group by
+        .name("content")
+        .build(); // Property that we group by
     GroupByArgument groupBy = client.graphQL()
-      .arguments()
-      .groupByArgBuilder()
-      .path(new String[]{ "content" })
-      .groups(3)
-      .objectsPerGroup(10)
-      .build();
+        .arguments()
+        .groupByArgBuilder()
+        .path(new String[] { "content" })
+        .groups(3)
+        .objectsPerGroup(10)
+        .build();
 
     NearTextArgument nearText = NearTextArgument.builder()
-      .concepts(new String[]{ "Passage content 2" })
-      .build();
+        .concepts(new String[] { "Passage content 2" })
+        .build();
     HybridArgument hybrid = HybridArgument.builder()
-      .searches(HybridArgument.Searches.builder()
-        .nearText(nearText)
-        .build())
-      .query("Passage content 2")
-      .alpha(0.9f)
-      .build();
+        .searches(HybridArgument.Searches.builder()
+            .nearText(nearText)
+            .build())
+        .query("Passage content 2")
+        .alpha(0.9f)
+        .build();
 
     passageSchema.createAndInsertData(syncClient);
 
     try {
       Result<GraphQLResponse> groupByResult = doGet(get -> get.withClassName(passageSchema.PASSAGE)
-        .withHybrid(hybrid)
-        .withGroupBy(groupBy)
-        .withFields(content, _additional));
+          .withHybrid(hybrid)
+          .withGroupBy(groupBy)
+          .withFields(content, _additional));
 
       List<Map<String, Object>> result = extractClass(groupByResult, "Get", passageSchema.PASSAGE);
       Assertions.assertThat(result)
-        .isNotNull()
-        .hasSize(3);
+          .isNotNull()
+          .hasSize(3);
       List<Group> groups = getGroups(result);
       Assertions.assertThat(groups)
-        .isNotNull()
-        .hasSize(3);
+          .isNotNull()
+          .hasSize(3);
       for (int i = 0; i < 3; i++) {
         if (i == 0) {
           Assertions.assertThat(groups.get(i).groupedBy.value)
-            .isEqualTo("Passage content 2");
+              .isEqualTo("Passage content 2");
         }
         Assertions.assertThat(groups.get(i).minDistance)
-          .isEqualTo(groups.get(i)
-            .getHits()
-            .get(0)
-            .get_additional()
-            .getDistance());
+            .isEqualTo(groups.get(i)
+                .getHits()
+                .get(0)
+                .get_additional()
+                .getDistance());
         Assertions.assertThat(groups.get(i).maxDistance)
-          .isEqualTo(groups.get(i)
-            .getHits()
-            .get(groups.get(i)
-              .getHits()
-              .size() - 1)
-            .get_additional()
-            .getDistance());
+            .isEqualTo(groups.get(i)
+                .getHits()
+                .get(groups.get(i)
+                    .getHits()
+                    .size() - 1)
+                .get_additional()
+                .getDistance());
       }
     } finally {
       passageSchema.cleanupWeaviate(syncClient);
@@ -976,45 +1023,46 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
   public void shouldSupportSearchByUUID() {
     String className = "ClassUUID";
     WeaviateClass clazz = WeaviateClass.builder()
-      .className(className)
-      .description("class with uuid properties")
-      .properties(Arrays.asList(
-        Property.builder()
-          .dataType(Collections.singletonList(DataType.UUID))
-          .name("uuidProp")
-          .build(), Property.builder()
-          .dataType(Collections.singletonList(DataType.UUID_ARRAY))
-          .name("uuidArrayProp")
-          .build()
-      ))
-      .build();
+        .className(className)
+        .description("class with uuid properties")
+        .properties(Arrays.asList(
+            Property.builder()
+                .dataType(Collections.singletonList(DataType.UUID))
+                .name("uuidProp")
+                .build(),
+            Property.builder()
+                .dataType(Collections.singletonList(DataType.UUID_ARRAY))
+                .name("uuidArrayProp")
+                .build()))
+        .build();
 
     String id = "abefd256-8574-442b-9293-9205193737ee";
     Map<String, Object> properties = new HashMap<>();
     properties.put("uuidProp", "7aaa79d3-a564-45db-8fa8-c49e20b8a39a");
-    properties.put("uuidArrayProp", new String[]{ "f70512a3-26cb-4ae4-9369-204555917f15", "9e516f40-fd54-4083-a476-f4675b2b5f92"
-    });
+    properties.put("uuidArrayProp",
+        new String[] { "f70512a3-26cb-4ae4-9369-204555917f15", "9e516f40-fd54-4083-a476-f4675b2b5f92"
+        });
 
     Result<Boolean> createStatus = syncClient.schema()
-      .classCreator()
-      .withClass(clazz)
-      .run();
+        .classCreator()
+        .withClass(clazz)
+        .run();
     Assertions.assertThat(createStatus)
-      .isNotNull()
-      .returns(false, Result::hasErrors)
-      .returns(true, Result::getResult);
+        .isNotNull()
+        .returns(false, Result::hasErrors)
+        .returns(true, Result::getResult);
 
     Result<WeaviateObject> objectStatus = syncClient.data()
-      .creator()
-      .withClassName(className)
-      .withID(id)
-      .withProperties(properties)
-      .run();
+        .creator()
+        .withClassName(className)
+        .withID(id)
+        .withProperties(properties)
+        .run();
     Assertions.assertThat(objectStatus)
-      .isNotNull()
-      .returns(false, Result::hasErrors)
-      .extracting(Result::getResult)
-      .isNotNull();
+        .isNotNull()
+        .returns(false, Result::hasErrors)
+        .extracting(Result::getResult)
+        .isNotNull();
 
     Field fieldId = _additional("id");
     WhereArgument whereUuid = whereText("uuidProp", Operator.Equal, "7aaa79d3-a564-45db-8fa8-c49e20b8a39a");
@@ -1022,26 +1070,26 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
     WhereArgument whereUuidArray2 = whereText("uuidArrayProp", Operator.Equal, "9e516f40-fd54-4083-a476-f4675b2b5f92");
 
     Result<GraphQLResponse> resultUuid = doGet(get -> get.withWhere(whereUuid)
-      .withClassName(className)
-      .withFields(fieldId));
+        .withClassName(className)
+        .withFields(fieldId));
     Result<GraphQLResponse> resultUuidArray1 = doGet(get -> get.withWhere(whereUuidArray1)
-      .withClassName(className)
-      .withFields(fieldId));
+        .withClassName(className)
+        .withFields(fieldId));
     Result<GraphQLResponse> resultUuidArray2 = doGet(get -> get.withWhere(whereUuidArray2)
-      .withClassName(className)
-      .withFields(fieldId));
+        .withClassName(className)
+        .withFields(fieldId));
 
-    assertIds(className, resultUuid, new String[]{ id });
-    assertIds(className, resultUuidArray1, new String[]{ id });
-    assertIds(className, resultUuidArray2, new String[]{ id });
+    assertIds(className, resultUuid, new String[] { id });
+    assertIds(className, resultUuidArray1, new String[] { id });
+    assertIds(className, resultUuidArray2, new String[] { id });
 
     Result<Boolean> deleteStatus = syncClient.schema()
-      .allDeleter()
-      .run();
+        .allDeleter()
+        .run();
     Assertions.assertThat(deleteStatus)
-      .isNotNull()
-      .returns(false, Result::hasErrors)
-      .returns(true, Result::getResult);
+        .isNotNull()
+        .returns(false, Result::hasErrors)
+        .returns(true, Result::getResult);
   }
 
   private Result<GraphQLResponse> doGet(Consumer<Get> build) {
@@ -1049,7 +1097,7 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
     build.accept(get);
     try {
       return get.run()
-        .get();
+          .get();
     } catch (InterruptedException | ExecutionException e) {
       fail("graphQL.get(): " + e.getMessage());
       return null;
@@ -1061,7 +1109,7 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
     build.accept(raw);
     try {
       return raw.run()
-        .get();
+          .get();
     } catch (InterruptedException | ExecutionException e) {
       fail("graphQL.raw(): " + e.getMessage());
       return null;
@@ -1073,7 +1121,7 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
     build.accept(explore);
     try {
       return explore.run()
-        .get();
+          .get();
     } catch (InterruptedException | ExecutionException e) {
       fail("graphQL.explore(): " + e.getMessage());
       return null;
@@ -1085,7 +1133,7 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
     build.accept(aggregate);
     try {
       return aggregate.run()
-        .get();
+          .get();
     } catch (InterruptedException | ExecutionException e) {
       fail("graphQL.aggregate(): " + e.getMessage());
       return null;
@@ -1094,10 +1142,10 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
 
   private SortArgument sort(SortOrder ord, String... properties) {
     return gql.arguments()
-      .sortArgBuilder()
-      .path(properties)
-      .order(ord)
-      .build();
+        .sortArgBuilder()
+        .path(properties)
+        .order(ord)
+        .build();
   }
 
   private void assertWhereResultSize(int expectedSize, Result<GraphQLResponse> result, String className) {
@@ -1105,9 +1153,9 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
     assertEquals(expectedSize, getClass.size());
   }
 
-
   @SuppressWarnings("unchecked")
-  private <T> T extractAdditional(Result<GraphQLResponse> result, String queryType, String className, String fieldName) {
+  private <T> T extractAdditional(Result<GraphQLResponse> result, String queryType, String className,
+      String fieldName) {
     List<?> objects = extractClass(result, queryType, className);
 
     Map<String, Map<String, Object>> firstObject = (Map<String, Map<String, Object>>) objects.get(0);
@@ -1121,13 +1169,14 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
     Float[] out = new Float[vector.size()];
     for (int i = 0; i < vector.size(); i++) {
       out[i] = vector.get(i)
-        .floatValue();
+          .floatValue();
     }
     return out;
   }
 
   @SuppressWarnings("unchecked")
-  private void assertAggregateMetaCount(Result<GraphQLResponse> result, String className, int wantObjects, Double wantCount) {
+  private void assertAggregateMetaCount(Result<GraphQLResponse> result, String className, int wantObjects,
+      Double wantCount) {
     List<?> objects = extractClass(result, "Aggregate", className);
 
     assertEquals(wantObjects, objects.size(), "wrong number of objects");
@@ -1136,12 +1185,13 @@ public class ClientGraphQLTest extends AbstractAsyncClientTest {
     assertEquals(wantCount, meta.get("count"), "wrong meta:count");
   }
 
-  private void assertObjectNamesEqual(Result<GraphQLResponse> result, String queryType, String className, String[] want) {
+  private void assertObjectNamesEqual(Result<GraphQLResponse> result, String queryType, String className,
+      String[] want) {
     List<Map<String, String>> objects = extractClass(result, queryType, className);
     assertEquals(want.length, objects.size());
     for (int i = 0; i < want.length; i++) {
       assertEquals(want[i], objects.get(i)
-        .get("name"), String.format("%s[%d] has wrong name", className.toLowerCase(), i));
+          .get("name"), String.format("%s[%d] has wrong name", className.toLowerCase(), i));
     }
   }
 }

--- a/src/test/java/io/weaviate/integration/client/async/groups/ClientGroupsTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/groups/ClientGroupsTest.java
@@ -1,0 +1,45 @@
+package io.weaviate.integration.client.async.groups;
+
+import java.util.List;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.WeaviateAuthClient;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.async.groups.Groups;
+import io.weaviate.client.v1.auth.exception.AuthException;
+import io.weaviate.client.v1.rbac.model.Role;
+import io.weaviate.integration.client.async.rbac.ClientRbacTest;
+import io.weaviate.integration.tests.groups.ClientGroupsTestSuite;
+
+public class ClientGroupsTest extends ClientRbacTest implements ClientGroupsTestSuite.Oidc {
+  private final Groups groups;
+
+  public ClientGroupsTest(Config config, String apiKey) {
+    super(config, apiKey);
+    try {
+      this.groups = WeaviateAuthClient.apiKey(config, apiKey).async().groups();
+    } catch (AuthException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public Result<List<Role>> getAssignedRoles(String groupId) {
+    return rethrow(() -> groups.oidc().assignedRolesGetter().withGroupId(groupId).run());
+  }
+
+  @Override
+  public Result<List<String>> getKnownGroupNames() {
+    return rethrow(() -> groups.oidc().knownGroupNamesGetter().run());
+  }
+
+  @Override
+  public Result<?> assignRoles(String groupId, String... roles) {
+    return rethrow(() -> groups.oidc().roleAssigner().withGroupId(groupId).witRoles(roles).run());
+  }
+
+  @Override
+  public Result<?> revokeRoles(String groupId, String... roles) {
+    return rethrow(() -> groups.oidc().roleRevoker().withGroupId(groupId).witRoles(roles).run());
+  }
+}

--- a/src/test/java/io/weaviate/integration/client/async/rbac/ClientRbacTest.java
+++ b/src/test/java/io/weaviate/integration/client/async/rbac/ClientRbacTest.java
@@ -9,6 +9,7 @@ import io.weaviate.client.WeaviateAuthClient;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.v1.async.rbac.Roles;
 import io.weaviate.client.v1.auth.exception.AuthException;
+import io.weaviate.client.v1.rbac.model.GroupAssignment;
 import io.weaviate.client.v1.rbac.model.Permission;
 import io.weaviate.client.v1.rbac.model.Role;
 import io.weaviate.client.v1.rbac.model.UserAssignment;
@@ -93,5 +94,11 @@ public class ClientRbacTest implements ClientRbacTestSuite.Rbac {
   @Override
   public Result<List<UserAssignment>> getUserAssignments(String role) {
     return rethrow(() -> roles.userAssignmentsGetter().withRole(role).run());
+  }
+
+  @Override
+
+  public Result<List<GroupAssignment>> getGroupAssignments(String role) {
+    return rethrow(() -> roles.groupAssignmentsGetter().withRole(role).run());
   }
 }

--- a/src/test/java/io/weaviate/integration/client/graphql/ClientGraphQLTest.java
+++ b/src/test/java/io/weaviate/integration/client/graphql/ClientGraphQLTest.java
@@ -880,6 +880,10 @@ public class ClientGraphQLTest extends AbstractClientGraphQLTest {
         .contains("Frutti di Mare", "Hawaii", "Doener");
   }
 
+  /**
+   * @see https://github.com/weaviate/java-client/pull/456#issuecomment-3270249876
+   */
+  @Ignore("Regression in Explorer API in v1.33")
   @Test
   public void testGraphQLExploreWithCertainty() {
     // given
@@ -916,6 +920,10 @@ public class ClientGraphQLTest extends AbstractClientGraphQLTest {
     assertEquals(6, get.size());
   }
 
+  /**
+   * @see https://github.com/weaviate/java-client/pull/456#issuecomment-3270249876
+   */
+  @Ignore("Regression in Explorer API in v1.33")
   @Test
   public void testGraphQLExploreWithDistance() {
     // given

--- a/src/test/java/io/weaviate/integration/client/groups/ClientGroupsTest.java
+++ b/src/test/java/io/weaviate/integration/client/groups/ClientGroupsTest.java
@@ -1,0 +1,45 @@
+package io.weaviate.integration.client.groups;
+
+import java.util.List;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.WeaviateAuthClient;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.auth.exception.AuthException;
+import io.weaviate.client.v1.groups.Groups;
+import io.weaviate.client.v1.rbac.model.Role;
+import io.weaviate.integration.client.rbac.ClientRbacTest;
+import io.weaviate.integration.tests.groups.ClientGroupsTestSuite;
+
+public class ClientGroupsTest extends ClientRbacTest implements ClientGroupsTestSuite.Oidc {
+  private final Groups groups;
+
+  public ClientGroupsTest(Config config, String apiKey) {
+    super(config, apiKey);
+    try {
+      this.groups = WeaviateAuthClient.apiKey(config, apiKey).groups();
+    } catch (AuthException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public Result<List<Role>> getAssignedRoles(String groupId) {
+    return groups.oidc().assignedRolesGetter().withGroupId(groupId).run();
+  }
+
+  @Override
+  public Result<List<String>> getKnownGroupNames() {
+    return groups.oidc().knownGroupNamesGetter().run();
+  }
+
+  @Override
+  public Result<?> assignRoles(String groupId, String... roles) {
+    return groups.oidc().roleAssigner().withGroupId(groupId).witRoles(roles).run();
+  }
+
+  @Override
+  public Result<?> revokeRoles(String groupId, String... roles) {
+    return groups.oidc().roleRevoker().withGroupId(groupId).witRoles(roles).run();
+  }
+}

--- a/src/test/java/io/weaviate/integration/client/rbac/ClientRbacTest.java
+++ b/src/test/java/io/weaviate/integration/client/rbac/ClientRbacTest.java
@@ -7,6 +7,7 @@ import io.weaviate.client.WeaviateAuthClient;
 import io.weaviate.client.base.Result;
 import io.weaviate.client.v1.auth.exception.AuthException;
 import io.weaviate.client.v1.rbac.Roles;
+import io.weaviate.client.v1.rbac.model.GroupAssignment;
 import io.weaviate.client.v1.rbac.model.Permission;
 import io.weaviate.client.v1.rbac.model.Role;
 import io.weaviate.client.v1.rbac.model.UserAssignment;
@@ -71,5 +72,10 @@ public class ClientRbacTest implements ClientRbacTestSuite.Rbac {
   @Override
   public Result<List<UserAssignment>> getUserAssignments(String role) {
     return roles.userAssignmentsGetter().withRole(role).run();
+  }
+
+  @Override
+  public Result<List<GroupAssignment>> getGroupAssignments(String role) {
+    return roles.groupAssignmentsGetter().withRole(role).run();
   }
 }

--- a/src/test/java/io/weaviate/integration/tests/backup/BackupTestSuite.java
+++ b/src/test/java/io/weaviate/integration/tests/backup/BackupTestSuite.java
@@ -15,6 +15,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.apache.http.HttpStatus;
+import org.assertj.core.api.InstanceOfAssertFactories;
 
 import io.weaviate.client.base.Result;
 import io.weaviate.client.base.WeaviateError;
@@ -404,8 +405,8 @@ public class BackupTestSuite {
         .returns(DOCKER_COMPOSE_BACKUPS_DIR + "/" + backupId, BackupRestoreResponse::getPath)
         .returns(BACKEND, BackupRestoreResponse::getBackend)
         .returns(RestoreStatus.FAILED, BackupRestoreResponse::getStatus)
-        .returns("could not restore classes: [\"Pizza\": class name Pizza already exists]",
-            BackupRestoreResponse::getError);
+        .extracting(BackupRestoreResponse::getError, InstanceOfAssertFactories.STRING)
+        .contains("could not restore classes");
   }
 
   public static void testFailOnCreateOfExistingBackup(Supplier<Result<BackupCreateResponse>> supplierCreate,

--- a/src/test/java/io/weaviate/integration/tests/groups/ClientGroupsTestSuite.java
+++ b/src/test/java/io/weaviate/integration/tests/groups/ClientGroupsTestSuite.java
@@ -1,0 +1,155 @@
+package io.weaviate.integration.tests.groups;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.testcontainers.weaviate.WeaviateContainer;
+
+import com.jparams.junit4.JParamsTestRunner;
+import com.jparams.junit4.data.DataMethod;
+import com.jparams.junit4.description.Name;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.rbac.model.GroupAssignment;
+import io.weaviate.client.v1.rbac.model.Role;
+import io.weaviate.integration.client.WeaviateDockerImage;
+import io.weaviate.integration.client.WeaviateWithRbacContainer;
+import io.weaviate.integration.tests.rbac.ClientRbacTestSuite;
+
+@RunWith(JParamsTestRunner.class)
+public class ClientGroupsTestSuite {
+
+  private static final String adminUser = "john-doe";
+  private static final String API_KEY = WeaviateWithRbacContainer.makeSecret(adminUser);
+
+  @Rule
+  public TestName currentTest = new TestName();
+
+  @ClassRule
+  public static WeaviateContainer weaviate = new WeaviateWithRbacContainer(
+      WeaviateDockerImage.WEAVIATE_DOCKER_IMAGE,
+      adminUser);
+
+  public static Config config() {
+    return new Config("http", weaviate.getHttpHostAddress());
+  }
+
+  public static Object[][] clients() {
+    try {
+      return new Object[][] {
+          { "sync",
+              (Supplier<Oidc>) () -> new io.weaviate.integration.client.groups.ClientGroupsTest(config(), API_KEY) },
+          { "async",
+              (Supplier<Oidc>) () -> new io.weaviate.integration.client.async.groups.ClientGroupsTest(config(),
+                  API_KEY) }
+      };
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @DataMethod(source = ClientGroupsTestSuite.class, method = "clients")
+  @Name("{0}")
+  @Test
+  public void testAssignGetRevoke(String _kind, Supplier<Oidc> oidcHandle) {
+    Oidc oidc = oidcHandle.get();
+    String groupId = "./assign-group";
+    String[] roles = new String[] { "viewer", "admin" };
+
+    oidc.revokeRoles(groupId, roles);
+    Assertions.assertThat(oidc.getAssignedRoles(groupId))
+        .extracting(Result::getResult, InstanceOfAssertFactories.LIST)
+        .isEmpty();
+
+    oidc.assignRoles(groupId, roles);
+    Assertions.assertThat(oidc.getAssignedRoles(groupId))
+        .extracting(Result::getResult, InstanceOfAssertFactories.list(Role.class))
+        .extracting(Role::getName).containsOnly(roles);
+
+    oidc.revokeRoles(groupId, roles);
+    Assertions.assertThat(oidc.getAssignedRoles(groupId).getResult()).isEmpty();
+  }
+
+  @DataMethod(source = ClientGroupsTestSuite.class, method = "clients")
+  @Name("{0}")
+  @Test
+  public void testGetAllKnownRoleGroups(String _kind, Supplier<Oidc> oidcHandle) {
+    Oidc oidc = oidcHandle.get();
+    String group1 = "./group-1";
+    String group2 = "./group-2";
+
+    oidc.assignRoles(group1, "viewer");
+    oidc.assignRoles(group2, "viewer");
+
+    Assertions.assertThat(oidc.getKnownGroupNames())
+        .extracting(Result::getResult, InstanceOfAssertFactories.list(String.class))
+        .containsOnly(group1, group2);
+
+    oidc.revokeRoles(group1, "viewer");
+    oidc.revokeRoles(group2, "viewer");
+
+    Assertions.assertThat(oidc.getKnownGroupNames())
+        .extracting(Result::getResult, InstanceOfAssertFactories.LIST)
+        .isEmpty();
+  }
+
+  @DataMethod(source = ClientGroupsTestSuite.class, method = "clients")
+  @Name("{0}")
+  @Test
+  public void testGetGroupAssignments(String _kind, Supplier<Oidc> oidcHandle) {
+    Oidc oidc = oidcHandle.get();
+    String role = roleName("testGroupAssignmentsRole");
+
+    oidc.deleteRole(role);
+    oidc.createRole(role);
+
+    Assertions.assertThat(oidc.getGroupAssignments(role))
+        .extracting(Result::getResult, InstanceOfAssertFactories.LIST)
+        .isEmpty();
+
+    oidc.assignRoles("./group-1", role);
+    oidc.assignRoles("./group-2", role);
+
+    Assertions.assertThat(oidc.getGroupAssignments(role))
+        .extracting(Result::getResult, InstanceOfAssertFactories.list(GroupAssignment.class))
+        .extracting(GroupAssignment::getGroupId)
+        .containsOnly("./group-1", "./group-2");
+
+    oidc.revokeRoles("./group-1", role);
+    oidc.revokeRoles("./group-2", role);
+    Assertions.assertThat(oidc.getGroupAssignments(role))
+        .extracting(Result::getResult, InstanceOfAssertFactories.LIST)
+        .isEmpty();
+  }
+
+  /** Prefix the role with the name of the current test for easier debugging */
+  private String roleName(String name) {
+    return String.format("%s-%s", currentTest.getMethodName(), name);
+  }
+
+  /**
+   * Sync and async test suits should provide an implementation of this interface.
+   * This way the test suite can be written once with very little
+   * boilerplate/overhead.
+   *
+   * Extends {@link ClientRbacTestSuite.Rbac} because many tests require the
+   * functionality for creating / deleting / verifying roles.
+   */
+  public interface Oidc extends ClientRbacTestSuite.Rbac {
+    Result<List<Role>> getAssignedRoles(String groupId);
+
+    Result<List<String>> getKnownGroupNames();
+
+    Result<?> assignRoles(String groupId, String... roles);
+
+    Result<?> revokeRoles(String groupId, String... roles);
+  }
+}

--- a/src/test/java/io/weaviate/integration/tests/misc/MiscTestSuite.java
+++ b/src/test/java/io/weaviate/integration/tests/misc/MiscTestSuite.java
@@ -1,12 +1,13 @@
 package io.weaviate.integration.tests.misc;
 
-import io.weaviate.client.base.Result;
-import io.weaviate.client.v1.misc.model.Meta;
 import static io.weaviate.integration.client.WeaviateVersion.EXPECTED_WEAVIATE_VERSION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.misc.model.Meta;
 
 public class MiscTestSuite {
   public static void assertLivenessOrReadiness(Result<Boolean> result) {
@@ -19,8 +20,5 @@ public class MiscTestSuite {
     assertNull(meta.getError());
     assertEquals("http://[::]:8080", meta.getResult().getHostname());
     assertEquals(EXPECTED_WEAVIATE_VERSION, meta.getResult().getVersion());
-    assertEquals("{backup-filesystem={backupsPath=/tmp/backups}, " +
-      "generative-openai={documentationHref=https://platform.openai.com/docs/api-reference/completions, name=Generative Search - OpenAI}, " +
-      "text2vec-contextionary={version=en0.16.0-v1.2.1, wordCount=818072.0}}", meta.getResult().getModules().toString());
   }
 }

--- a/src/test/java/io/weaviate/integration/tests/rbac/ClientRbacTestSuite.java
+++ b/src/test/java/io/weaviate/integration/tests/rbac/ClientRbacTestSuite.java
@@ -29,6 +29,7 @@ import io.weaviate.client.v1.rbac.model.BackupsPermission;
 import io.weaviate.client.v1.rbac.model.ClusterPermission;
 import io.weaviate.client.v1.rbac.model.CollectionsPermission;
 import io.weaviate.client.v1.rbac.model.DataPermission;
+import io.weaviate.client.v1.rbac.model.GroupAssignment;
 import io.weaviate.client.v1.rbac.model.NodesPermission;
 import io.weaviate.client.v1.rbac.model.Permission;
 import io.weaviate.client.v1.rbac.model.ReplicatePermission;
@@ -319,6 +320,8 @@ public class ClientRbacTestSuite {
     Result<List<Role>> getAll();
 
     Result<List<String>> getAssignedUsers(String role);
+
+    Result<List<GroupAssignment>> getGroupAssignments(String role);
 
     Result<List<UserAssignment>> getUserAssignments(String role);
 

--- a/src/test/java/io/weaviate/integration/tests/rbac/ClientRbacTestSuite.java
+++ b/src/test/java/io/weaviate/integration/tests/rbac/ClientRbacTestSuite.java
@@ -30,6 +30,7 @@ import io.weaviate.client.v1.rbac.model.ClusterPermission;
 import io.weaviate.client.v1.rbac.model.CollectionsPermission;
 import io.weaviate.client.v1.rbac.model.DataPermission;
 import io.weaviate.client.v1.rbac.model.GroupAssignment;
+import io.weaviate.client.v1.rbac.model.GroupsPermission;
 import io.weaviate.client.v1.rbac.model.NodesPermission;
 import io.weaviate.client.v1.rbac.model.Permission;
 import io.weaviate.client.v1.rbac.model.ReplicatePermission;
@@ -139,6 +140,7 @@ public class ClientRbacTestSuite {
     String myCollection = "Pizza";
     String myCollectionAlias = "PizzaAlias";
     String myShard = "shard-123";
+    String myGroup = "my-group";
 
     Permission<?>[] wantPermissions = new Permission<?>[] {
         Permission.alias(myCollectionAlias, myCollection, AliasPermission.Action.CREATE),
@@ -148,6 +150,7 @@ public class ClientRbacTestSuite {
         Permission.roles(viewerRole, RolesPermission.Action.CREATE),
         Permission.collections(myCollection, CollectionsPermission.Action.CREATE),
         Permission.data(myCollection, DataPermission.Action.UPDATE),
+        Permission.groups(myGroup, "oidc", GroupsPermission.Action.READ),
         Permission.tenants(TenantsPermission.Action.DELETE),
         Permission.users(UsersPermission.Action.READ),
         Permission.replicate(myCollection, myShard, ReplicatePermission.Action.READ),


### PR DESCRIPTION
This PR add a new `groups` namespace for assigning / revoking roles to _user groups_ rather than individual users. The API is similar to that in `users` namespace:

```java
client.groups().oidc()
  .roleAssigner()
  .withGroupId('fifth-floor-empl')
  .withRoles(analystRole, researcherRole).run();

client.groups().oidc()
  .assignedRolesGetter()
  .withGroupId('fifth-floor-empl').run();

client.groups().oidc()
  .knownGroupNamesGetter().run();

client.groups().oidc()
  .roleRevoker()
  .withGroupId('fifth-floor-empl')
  .withRoles(researcherRole).run();
```

Complimenting that are GroupsPermissions which a role can now have:

```java
client.roles().creator()
  .withName('group-admin')
  .withPermissions(
      Permission.groups("general", "oidc", 
        GroupsPermission.Action.READ, 
        GroupsPermission.Action.ASSIGN_AND_REVOKE)).run();
```