### PR TITLE
v6: Fix copying / collecting maps with null values

### DIFF
--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/QueryRequest.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/QueryRequest.java
@@ -88,7 +88,13 @@ public record QueryRequest(QueryOperator operator, GroupBy groupBy) {
                     group.getMaxDistance(),
                     group.getNumberOfObjects(),
                     objects);
-              }).collect(Collectors.toMap(QueryResponseGroup::name, Function.identity()));
+              })
+              // Collectors.toMap() throws an NPE if either key or value in the map are null.
+              // In this specific case it is safe to use it, as the function in the map above
+              // always returns a QueryResponseGroup.
+              // The name of the group should not be null either, that's something we assume
+              // about the server's response.
+              .collect(Collectors.toMap(QueryResponseGroup::name, Function.identity()));
 
           return new QueryResponseGrouped<T>(allObjects, groups);
         }, () -> rpc.method(), () -> rpc.methodAsync());

--- a/src/main/java/io/weaviate/client6/v1/internal/MapUtil.java
+++ b/src/main/java/io/weaviate/client6/v1/internal/MapUtil.java
@@ -1,0 +1,42 @@
+package io.weaviate.client6.v1.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public final class MapUtil {
+  /** Prevent public initialization. */
+  private MapUtil() {
+  }
+
+  /**
+   * Collect stream entries into a map. Use this method whenever
+   * potential null keys or null values prohibit {@link Collectors#toMap}.
+   *
+   * <p>
+   * Example:
+   *
+   * <pre>{@code
+   * Map<Integer, Integer> = MapUtil.collect(
+   *  Stream.of(1, 2, 3),
+   *  Function.identity(), // use value as key
+   *  el -> el.equals(3) ? null : el;
+   * );
+   *
+   * // Result: {1: 1, 2: 2, 3: null};
+   * }</pre>
+   *
+   * @param stream Stream of elements {@link T}.
+   * @param keyFn  Transforms element {@link T} to key {@link K}.
+   * @param keyFn  Transforms element {@link T} to value {@link V}.
+   * @return Map
+   */
+  public static <K, V, T> Map<K, V> collect(Stream<T> stream, Function<T, K> keyFn, Function<T, V> valueFn) {
+    return stream.collect(
+        HashMap::new,
+        (m, el) -> m.put(keyFn.apply(el), valueFn.apply(el)),
+        HashMap::putAll);
+  }
+}

--- a/src/main/java/io/weaviate/client6/v1/internal/orm/MapReader.java
+++ b/src/main/java/io/weaviate/client6/v1/internal/orm/MapReader.java
@@ -1,16 +1,19 @@
 package io.weaviate.client6.v1.internal.orm;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 public class MapReader implements PropertiesReader<Map<String, Object>> {
   private final Map<String, Object> properties;
 
   public MapReader(Map<String, Object> properties) {
-    this.properties = properties;
+    // Defensive copy to ensure original properties are not modified
+    this.properties = Collections.unmodifiableMap(new HashMap<>(properties));
   }
 
   @Override
   public Map<String, Object> readProperties() {
-    return Map.copyOf(properties); // ensure original properties immutable
+    return properties;
   }
 }


### PR DESCRIPTION
OpenJDK has a [known bug](https://bugs.openjdk.java.net/browse/JDK-8148463) that doesn't accept null keys/values into `Collectors.toMap()`.

Since object properties (and, potentially, other values we receive from the server) may very well be null we need to work around that. This PR adds a simple `MapUtil.collect(...)` helper to safely create Maps from Streams.