### PR TITLE
v6: Assertions

### DIFF
--- a/src/main/java/io/weaviate/client6/v1/api/collections/Vectors.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/Vectors.java
@@ -186,7 +186,9 @@ public class Vectors {
                 vector = float_1d.fromJsonTree(array);
               }
 
-              assert (vector instanceof float[]) || (vector instanceof float[][]) : "invalid vector type";
+              assert (vector instanceof float[]) || (vector instanceof float[][])
+                  : "invalid vector type " + vector.getClass();
+
               namedVectors.put(vectorName, vector);
             }
           }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/aggregate/AggregateRequest.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/aggregate/AggregateRequest.java
@@ -4,8 +4,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-import io.weaviate.client6.v1.internal.DateUtil;
 import io.weaviate.client6.v1.api.collections.CollectionHandleDefaults;
+import io.weaviate.client6.v1.internal.DateUtil;
 import io.weaviate.client6.v1.internal.grpc.Rpc;
 import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateGrpc.WeaviateBlockingStub;
 import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateGrpc.WeaviateFutureStub;
@@ -79,7 +79,7 @@ public record AggregateRequest(Aggregation aggregation, GroupBy groupBy) {
           } else if (groupBy.hasBooleans()) {
             groupedBy = new GroupedBy<>(property, groupBy.getBooleans().getValuesList().toArray(Boolean[]::new));
           } else {
-            assert false : "(aggregate) branch not covered";
+            throw new IllegalArgumentException(property + " data type is not supported");
           }
 
           var properties = unmarshalAggregation(result.getAggregations());
@@ -148,7 +148,7 @@ public record AggregateRequest(Aggregation aggregation, GroupBy groupBy) {
             metric.hasMode() ? metric.getMode() : null,
             metric.hasSum() ? metric.getSum() : null);
       } else {
-        assert false : "branch not covered";
+        throw new IllegalArgumentException(property + " data type is not supported");
       }
 
       if (value != null) {

--- a/src/main/java/io/weaviate/client6/v1/api/collections/pagination/AsyncPage.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/pagination/AsyncPage.java
@@ -61,7 +61,9 @@ public final class AsyncPage<PropertiesT> implements Iterable<WeaviateObject<Pro
           // If it is null after the first iteration it is
           // because we haven't requested Metadata.UUID, in which
           // case pagination will continue to run unbounded.
-          assert nextCursor != null : "page cursor is null";
+          if (nextCursor == null) {
+            throw new IllegalStateException("page cursor is null");
+          }
           return new AsyncPage<>(nextCursor, pageSize, fetch, nextPage);
         });
   }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/pagination/CursorSpliterator.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/pagination/CursorSpliterator.java
@@ -45,7 +45,9 @@ public class CursorSpliterator<PropertiesT> implements Spliterator<WeaviateObjec
     // If it is null after the first iteration it is
     // because we haven't requested Metadata.UUID, in which
     // case pagination will continue to run unbounded.
-    assert cursor != null : "page cursor is null";
+    if (cursor == null) {
+      throw new IllegalStateException("page cursor is null");
+    }
 
     currentPage = nextPage.iterator();
     return tryAdvance(action);

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/QueryRequest.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/QueryRequest.java
@@ -256,7 +256,7 @@ public record QueryRequest(QueryOperator operator, GroupBy groupBy) {
         builder.setOffsetDateTimeArray(property, dates);
       }
     } else {
-      assert false : "(query) branch not covered";
+      throw new IllegalArgumentException(property + " data type is not supported");
     }
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/internal/orm/PojoDescriptor.java
+++ b/src/main/java/io/weaviate/client6/v1/internal/orm/PojoDescriptor.java
@@ -147,7 +147,7 @@ final class PojoDescriptor<T extends Record> implements CollectionDescriptor<T> 
       }
 
       if (ctor == null) {
-        throw new IllegalArgumentException(type.getCanonicalName() + " fields are not supported");
+        throw new IllegalArgumentException(type.getCanonicalName() + " property is not supported");
       }
 
       assert ctor != null;

--- a/src/main/java/io/weaviate/client6/v1/internal/orm/PojoReader.java
+++ b/src/main/java/io/weaviate/client6/v1/internal/orm/PojoReader.java
@@ -15,12 +15,15 @@ final class PojoReader<PropertiesT> implements PropertiesReader<PropertiesT> {
     var out = new HashMap<String, Object>();
     for (var field : properties.getClass().getDeclaredFields()) {
       var propertyName = PojoDescriptor.propertyName(field);
-      field.setAccessible(true);
-      try {
-        out.put(propertyName, field.get(properties));
-      } catch (IllegalAccessException e) {
-        assert e == null : e.getMessage();
+      if (field.trySetAccessible()) {
+        try {
+          out.put(propertyName, field.get(properties));
+        } catch (IllegalAccessException e) {
+          new RuntimeException("accessible flag set but access denied", e);
+        }
       }
+      // TODO: how do we handle the case where a property is not accessible?
+      // E.g. we weren't able to set `accessible` flag.
     }
     return out;
   }


### PR DESCRIPTION
Assertions should enforce invariants, not signal error conditions. Unlike Exceptions, AssertionErrors are not caught by catch (Exception e) and may be more unpredictable.

We should try to only ever use assertions for cases that can never happen unless there's been a programming mistake on our side.

Everything else, e.g. server responses, network errors, client's input (ORM) should be dealt with via exceptions.