### PR TITLE
fix: remove typos in PQ config and add unit tests

### DIFF
--- a/src/main/java/io/weaviate/client6/v1/api/collections/quantizers/PQ.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/quantizers/PQ.java
@@ -12,7 +12,7 @@ public record PQ(
     @SerializedName("centroids") Integer centroids,
     @SerializedName("segments") Integer segments,
     @SerializedName("encoder_type") EncoderType encoderType,
-    @SerializedName("encoder_distribusion") EncoderDistribution encoderDistribution,
+    @SerializedName("encoder_distribution") EncoderDistribution encoderDistribution,
     @SerializedName("training_limit") Integer trainingLimit,
     @SerializedName("bit_compression") Boolean bitCompression) implements Quantization {
 
@@ -24,15 +24,15 @@ public record PQ(
   }
 
   public enum EncoderDistribution {
-    @SerializedName("log-normal")
-    NORMAL,
     @SerializedName("normal")
+    NORMAL,
+    @SerializedName("log-normal")
     LOG_NORMAL;
   }
 
   @Override
   public Quantization.Kind _kind() {
-    return Quantization.Kind.RQ;
+    return Quantization.Kind.PQ;
   }
 
   @Override

--- a/src/test/java/io/weaviate/client6/v1/internal/json/JSONTest.java
+++ b/src/test/java/io/weaviate/client6/v1/internal/json/JSONTest.java
@@ -28,6 +28,7 @@ import io.weaviate.client6.v1.api.collections.WeaviateObject;
 import io.weaviate.client6.v1.api.collections.data.BatchReference;
 import io.weaviate.client6.v1.api.collections.data.Reference;
 import io.weaviate.client6.v1.api.collections.data.ReferenceAddManyResponse;
+import io.weaviate.client6.v1.api.collections.quantizers.PQ;
 import io.weaviate.client6.v1.api.collections.rerankers.CohereReranker;
 import io.weaviate.client6.v1.api.collections.vectorindex.Distance;
 import io.weaviate.client6.v1.api.collections.vectorindex.Flat;
@@ -144,6 +145,76 @@ public class JSONTest {
                   "vectorIndexType": "flat",
                   "vectorizer": {"none": {}},
                   "vectorIndexConfig": {"vectorCacheMaxObjects": 100}
+                }
+                """,
+        },
+        {
+            VectorConfig.class,
+            SelfProvidedVectorizer.of(none -> none
+                .quantization(Quantization.pq(pq -> pq
+                    .centroids(8)
+                    .encoderDistribution(PQ.EncoderDistribution.NORMAL)
+                    .encoderType(PQ.EncoderType.TILE)
+                    .segments(16)
+                    .trainingLimit(1024)
+                    .bitCompression(true)))),
+            """
+                {
+                  "vectorIndexType": "hnsw",
+                  "vectorizer": {"none": {}},
+                  "vectorIndexConfig": {
+                    "pq": {
+                      "enabled": true,
+                      "centroids": 8,
+                      "encoder_distribution": "normal",
+                      "encoder_type": "tile",
+                      "segments": 16,
+                      "training_limit": 1024,
+                      "bit_compression": true
+                    }
+                  }
+                }
+                """,
+        },
+        {
+            VectorConfig.class,
+            SelfProvidedVectorizer.of(none -> none
+                .quantization(Quantization.sq(sq -> sq
+                    .rescoreLimit(10)
+                    .trainingLimit(1024)
+                    .cache(true)))),
+            """
+                {
+                  "vectorIndexType": "hnsw",
+                  "vectorizer": {"none": {}},
+                  "vectorIndexConfig": {
+                    "sq": {
+                      "enabled": true,
+                      "rescore_limit": 10,
+                      "training_limit": 1024,
+                      "cache": true
+                    }
+                  }
+                }
+                """,
+        },
+        {
+            VectorConfig.class,
+            SelfProvidedVectorizer.of(none -> none
+                .quantization(Quantization.rq(rq -> rq
+                    .rescoreLimit(10)
+                    .bits(8)))),
+            """
+                {
+                  "vectorIndexType": "hnsw",
+                  "vectorizer": {"none": {}},
+                  "vectorIndexConfig": {
+                    "rq": {
+                      "enabled": true,
+                      "rescore_limit": 10,
+                      "bits": 8
+                    }
+                  }
                 }
                 """,
         },


### PR DESCRIPTION
User noticed that collections with PQ quantization could not be created to due a malformed JSON -- `PQ.class` reported a wrong `Quantization.Kind`. Tests revealed another 2 typos:

- encoder_distribu`s`ion
- EncoderDistribution enum values mapped to wrong JSON values