### PR TITLE
v6: use clientId from OIDC config on the server

### DIFF
--- a/src/it/java/io/weaviate/integration/OIDCSupportITest.java
+++ b/src/it/java/io/weaviate/integration/OIDCSupportITest.java
@@ -103,11 +103,11 @@ public class OIDCSupportITest extends ConcurrentTest {
 
   @Test
   public void test_clientCredentials() throws Exception {
-    Assume.assumeTrue("OKTA_CLIENT_SECRET is not set", OKTA_CLIENT_SECRET != null && !OKTA_CLIENT_SECRET.isBlank());
+    Assume.assumeTrue("OKTA_CLIENT_SECRET is not set", OKTA_CLIENT_SECRET != null && OKTA_CLIENT_SECRET.isBlank());
     Assume.assumeTrue("no internet connection", hasInternetConnection());
 
     // Check norwal client credentials flow works.
-    var cc = Authentication.clientCredentials(OKTA_CLIENT_ID, OKTA_CLIENT_SECRET, List.of());
+    var cc = Authentication.clientCredentials(OKTA_CLIENT_SECRET, List.of());
     var auth = SpyTokenProvider.spyOn(cc);
     pingWeaviate(oktaContainer, auth);
     pingWeaviateAsync(oktaContainer, auth);

--- a/src/main/java/io/weaviate/client6/v1/api/Authentication.java
+++ b/src/main/java/io/weaviate/client6/v1/api/Authentication.java
@@ -59,7 +59,6 @@ public interface Authentication {
   /**
    * Authenticate using Client Credentials authorization grant.
    *
-   * @param clientId     Client ID.
    * @param clientSecret Client secret.
    * @param scopes       Client scopes.
    *
@@ -67,13 +66,13 @@ public interface Authentication {
    * @throws WeaviateOAuthException if an error occurred at any point while
    *                                obtaining a new token.
    */
-  public static Authentication clientCredentials(String clientId, String clientSecret, List<String> scopes) {
+  public static Authentication clientCredentials(String clientSecret, List<String> scopes) {
     return transport -> {
       OidcConfig oidc = OidcUtils.getConfig(transport).withScopes(scopes);
       if (oidc.scopes().isEmpty() && TokenProvider.isMicrosoft(oidc)) {
-        oidc = oidc.withScopes(clientId + "/.default");
+        oidc = oidc.withScopes(oidc.clientId() + "/.default");
       }
-      return TokenProvider.clientCredentials(oidc, clientId, clientSecret);
+      return TokenProvider.clientCredentials(oidc, clientSecret);
     };
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/internal/TokenProvider.java
+++ b/src/main/java/io/weaviate/client6/v1/internal/TokenProvider.java
@@ -145,15 +145,14 @@ public interface TokenProvider extends AutoCloseable {
    * Create a TokenProvider that uses Client Credentials authorization grant.
    *
    * @param oidc         OIDC config.
-   * @param clientId     Client ID.
    * @param clientSecret Client secret.
    *
    * @return Internal TokenProvider implementation.
    * @throws WeaviateOAuthException if an error occurred at any point while
    *                                obtaining a new token.
    */
-  public static TokenProvider clientCredentials(OidcConfig oidc, String clientId, String clientSecret) {
-    final var provider = NimbusTokenProvider.clientCredentials(oidc, clientId, clientSecret);
+  public static TokenProvider clientCredentials(OidcConfig oidc, String clientSecret) {
+    final var provider = NimbusTokenProvider.clientCredentials(oidc, clientSecret);
     return reuse(null, provider, DEFAULT_EARLY_EXPIRY);
   }
 

--- a/src/main/java/io/weaviate/client6/v1/internal/oidc/nimbus/NimbusTokenProvider.java
+++ b/src/main/java/io/weaviate/client6/v1/internal/oidc/nimbus/NimbusTokenProvider.java
@@ -55,15 +55,14 @@ public final class NimbusTokenProvider implements TokenProvider {
    * Create a TokenProvider that uses Client Credentials authorization grant.
    *
    * @param oidc         OIDC config.
-   * @param clientId     Client ID.
    * @param clientSecret Client secret.
    *
    * @return A new instance of NimbusTokenProvider. Instances are never cached.
    * @throws WeaviateOAuthException if an error occured at any point of the
    *                                exchange process.
    */
-  public static NimbusTokenProvider clientCredentials(OidcConfig oidc, String clientId, String clientSecret) {
-    return new NimbusTokenProvider(oidc, Flow.clientCredentials(clientId, clientSecret));
+  public static NimbusTokenProvider clientCredentials(OidcConfig oidc, String clientSecret) {
+    return new NimbusTokenProvider(oidc, Flow.clientCredentials(oidc.clientId(), clientSecret));
   }
 
   private NimbusTokenProvider(OidcConfig oidc, Flow flow) {


### PR DESCRIPTION
When authenticating via the Client Credentials flow, Java client can fetch Client ID from the server's OIDC configuration and doesn't need the user to pass that on creation.

We were already parsing `clientId` in `OidcConfig`, so this will just make sure that we use it correctly.