### PR TITLE
v6: Guard against `null` Quantizer in config update

### DIFF
--- a/src/it/java/io/weaviate/containers/Weaviate.java
+++ b/src/it/java/io/weaviate/containers/Weaviate.java
@@ -19,6 +19,8 @@ import org.testcontainers.weaviate.WeaviateContainer;
 import io.weaviate.ConcurrentTest;
 import io.weaviate.client6.v1.api.Config;
 import io.weaviate.client6.v1.api.WeaviateClient;
+import io.weaviate.client6.v1.api.collections.Generative;
+import io.weaviate.client6.v1.api.collections.Reranker;
 import io.weaviate.client6.v1.internal.ObjectBuilder;
 import io.weaviate.client6.v1.internal.VersionSupport.SemanticVersion;
 
@@ -154,6 +156,7 @@ public class Weaviate extends WeaviateContainer {
     private Map<String, String> environment = new HashMap<>();
 
     public Builder() {
+      addModules(Reranker.Kind.DUMMY.jsonValue(), Generative.Kind.DUMMY.jsonValue());
       enableAutoSchema(false);
     }
 

--- a/src/main/java/io/weaviate/client6/v1/api/collections/config/UpdateCollectionRequest.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/config/UpdateCollectionRequest.java
@@ -40,7 +40,7 @@ public record UpdateCollectionRequest(CollectionConfig updated, CollectionConfig
           for (var origVector : request.original.vectors().entrySet()) {
             var vectorName = origVector.getKey();
             var origQuantization = origVector.getValue().quantization();
-            if (vectors.has(vectorName)) {
+            if (vectors.has(vectorName) && origQuantization != null) {
               vectors
                   .get(vectorName).getAsJsonObject()
                   .get("vectorIndexConfig").getAsJsonObject()


### PR DESCRIPTION
The code used to assume a quantizer was always preset, but in cases where `skipDefaultQuantization: false` and no other vectorizer matches, the quantizer is unset after de-serialization.

We add a simple null-check to guard against using an unset value. 

The default Weaviate container in integration tests now also has `generative-dummy` and `reranker-dummy` modules enabled so that they can be used in any test suite without additional setup.