### PR TITLE
chore(pom.xml): upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,20 +58,20 @@
     <lang3.version>3.20.0</lang3.version>
     <junit.version>4.13.2</junit.version>
     <testcontainers.version>2.0.3</testcontainers.version>
-    <assertj-core.version>3.27.6</assertj-core.version>
+    <assertj-core.version>3.27.7</assertj-core.version>
     <jparams.version>1.0.4</jparams.version>
     <mockito.version>5.21.0</mockito.version>
     <slf4j.version>2.0.17</slf4j.version>
     <logback.version>1.5.18</logback.version>
     <mock-server.version>5.14.0</mock-server.version>
     <jackson.version>2.21</jackson.version>
-    <oauth2-oidc-sdk.version>11.31.1</oauth2-oidc-sdk.version>
+    <oauth2-oidc-sdk.version>11.33</oauth2-oidc-sdk.version>
     <mock-server.version>5.15.0</mock-server.version>
-    <protobuf.java.version>4.33.4</protobuf.java.version>
-    <protobuf.java-util.version>4.33.4</protobuf.java-util.version>
-    <grpc-netty-shaded.version>1.78.0</grpc-netty-shaded.version>
-    <grpc-protobuf.version>1.78.0</grpc-protobuf.version>
-    <grpc-stub.version>1.78.0</grpc-stub.version>
+    <protobuf.java.version>4.33.5</protobuf.java.version>
+    <protobuf.java-util.version>4.33.5</protobuf.java-util.version>
+    <grpc-netty-shaded.version>1.79.0</grpc-netty-shaded.version>
+    <grpc-protobuf.version>1.79.0</grpc-protobuf.version>
+    <grpc-stub.version>1.79.0</grpc-stub.version>
     <annotations-api.version>6.0.53</annotations-api.version>
   </properties>
 


### PR DESCRIPTION
This PR upgrades dependencies to their latest versions: `mvn versions:update-properties`

Patches this vulnerability: https://github.com/weaviate/java-client/security/dependabot/7
