### PR TITLE
test(oidc): fix assumption for client credentials test

### DIFF
--- a/src/it/java/io/weaviate/integration/OIDCSupportITest.java
+++ b/src/it/java/io/weaviate/integration/OIDCSupportITest.java
@@ -104,7 +104,7 @@ public class OIDCSupportITest extends ConcurrentTest {
 
   @Test
   public void test_clientCredentials() throws Exception {
-    Assume.assumeTrue("OKTA_CLIENT_SECRET is not set", OKTA_CLIENT_SECRET != null && OKTA_CLIENT_SECRET.isBlank());
+    Assume.assumeTrue("OKTA_CLIENT_SECRET is not set", OKTA_CLIENT_SECRET != null && !OKTA_CLIENT_SECRET.isBlank());
     Assume.assumeTrue("no internet connection", hasInternetConnection());
 
     // Check norwal client credentials flow works.


### PR DESCRIPTION
We want to skip `test_clientCredentials` if OKTA_CLIENT_SECRET is blank.