### PR TITLE
Add dedicated factory methods for Google Gemini vectorizer

### DIFF
--- a/src/main/java/io/weaviate/client6/v1/api/collections/VectorConfig.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/VectorConfig.java
@@ -352,9 +352,35 @@ public interface VectorConfig extends TaggedUnion<VectorConfig.Kind, Object> {
    * Create a vector index with an {@code multi2vec-google} vectorizer.
    *
    * @param location Geographic region the Google Cloud model runs in.
+   * @deprecated Use {@link #multi2vecGoogleVertex}.
    */
+  @Deprecated(forRemoval = true)
   public static Map.Entry<String, VectorConfig> multi2vecGoogle(String projectId, String location) {
-    return multi2vecGoogle(VectorIndex.DEFAULT_VECTOR_NAME, projectId, location);
+    return multi2vecGoogleVertex(projectId, location);
+  }
+
+  /**
+   * Create a vector index with an {@code multi2vec-google} vectorizer.
+   *
+   * @param location Geographic region the Google Cloud model runs in.
+   */
+  public static Map.Entry<String, VectorConfig> multi2vecGoogleVertex(String projectId, String location) {
+    return multi2vecGoogleVertex(VectorIndex.DEFAULT_VECTOR_NAME, projectId, location);
+  }
+
+  /**
+   * Create a vector index with an {@code multi2vec-google} vectorizer.
+   *
+   * @param location Geographic region the Google Cloud model runs in.
+   * @param fn       Lambda expression for optional parameters.
+   * @deprecated Use {@link #multi2vecGoogleVertex}.
+   */
+  @Deprecated(forRemoval = true)
+  public static Map.Entry<String, VectorConfig> multi2vecGoogle(
+      String projectId,
+      String location,
+      Function<Multi2VecGoogleVectorizer.VertexBuilder, ObjectBuilder<Multi2VecGoogleVectorizer>> fn) {
+    return multi2vecGoogleVertex(projectId, location, fn);
   }
 
   /**
@@ -363,11 +389,23 @@ public interface VectorConfig extends TaggedUnion<VectorConfig.Kind, Object> {
    * @param location Geographic region the Google Cloud model runs in.
    * @param fn       Lambda expression for optional parameters.
    */
-  public static Map.Entry<String, VectorConfig> multi2vecGoogle(
+  public static Map.Entry<String, VectorConfig> multi2vecGoogleVertex(
       String projectId,
       String location,
-      Function<Multi2VecGoogleVectorizer.Builder, ObjectBuilder<Multi2VecGoogleVectorizer>> fn) {
-    return multi2vecGoogle(VectorIndex.DEFAULT_VECTOR_NAME, projectId, location, fn);
+      Function<Multi2VecGoogleVectorizer.VertexBuilder, ObjectBuilder<Multi2VecGoogleVectorizer>> fn) {
+    return multi2vecGoogleVertex(VectorIndex.DEFAULT_VECTOR_NAME, projectId, location, fn);
+  }
+
+  /**
+   * Create a named vector index with an {@code multi2vec-google} vectorizer.
+   *
+   * @param vectorName Vector name.
+   * @param location   Geographic region the Google Cloud model runs in.
+   * @deprecated Use {@link #multi2vecGoogleVertex}.
+   */
+  @Deprecated(forRemoval = true)
+  public static Map.Entry<String, VectorConfig> multi2vecGoogle(String vectorName, String projectId, String location) {
+    return multi2vecGoogleVertex(vectorName, projectId, location);
   }
 
   /**
@@ -376,8 +414,24 @@ public interface VectorConfig extends TaggedUnion<VectorConfig.Kind, Object> {
    * @param vectorName Vector name.
    * @param location   Geographic region the Google Cloud model runs in.
    */
-  public static Map.Entry<String, VectorConfig> multi2vecGoogle(String vectorName, String projectId, String location) {
-    return Map.entry(vectorName, Multi2VecGoogleVectorizer.of(projectId, location));
+  public static Map.Entry<String, VectorConfig> multi2vecGoogleVertex(String vectorName, String projectId,
+      String location) {
+    return Map.entry(vectorName, Multi2VecGoogleVectorizer.vertex(projectId, location));
+  }
+
+  /**
+   * Create a named vector index with an {@code multi2vec-google} vectorizer.
+   *
+   * @param vectorName Vector name.
+   * @param location   Geographic region the Google Cloud model runs in.
+   * @param fn         Lambda expression for optional parameters.
+   * @deprecated Use {@link #multi2vecGoogleVertex}.
+   */
+  @Deprecated(forRemoval = true)
+  public static Map.Entry<String, VectorConfig> multi2vecGoogle(String vectorName,
+      String projectId, String location,
+      Function<Multi2VecGoogleVectorizer.VertexBuilder, ObjectBuilder<Multi2VecGoogleVectorizer>> fn) {
+    return multi2vecGoogleVertex(vectorName, projectId, location, fn);
   }
 
   /**
@@ -387,10 +441,47 @@ public interface VectorConfig extends TaggedUnion<VectorConfig.Kind, Object> {
    * @param location   Geographic region the Google Cloud model runs in.
    * @param fn         Lambda expression for optional parameters.
    */
-  public static Map.Entry<String, VectorConfig> multi2vecGoogle(String vectorName,
+  public static Map.Entry<String, VectorConfig> multi2vecGoogleVertex(String vectorName,
       String projectId, String location,
-      Function<Multi2VecGoogleVectorizer.Builder, ObjectBuilder<Multi2VecGoogleVectorizer>> fn) {
-    return Map.entry(vectorName, Multi2VecGoogleVectorizer.of(projectId, location, fn));
+      Function<Multi2VecGoogleVectorizer.VertexBuilder, ObjectBuilder<Multi2VecGoogleVectorizer>> fn) {
+    return Map.entry(vectorName, Multi2VecGoogleVectorizer.vertex(projectId, location, fn));
+  }
+
+  /**
+   * Create a vector index with an {@code multi2vec-google} vectorizer.
+   */
+  public static Map.Entry<String, VectorConfig> multi2vecGoogleGemini() {
+    return multi2vecGoogleGemini(VectorIndex.DEFAULT_VECTOR_NAME);
+  }
+
+  /**
+   * Create a vector index with an {@code multi2vec-google} vectorizer.
+   *
+   * @param fn Lambda expression for optional parameters.
+   */
+  public static Map.Entry<String, VectorConfig> multi2vecGoogleGemini(
+      Function<Multi2VecGoogleVectorizer.GeminiBuilder, ObjectBuilder<Multi2VecGoogleVectorizer>> fn) {
+    return multi2vecGoogleGemini(VectorIndex.DEFAULT_VECTOR_NAME, fn);
+  }
+
+  /**
+   * Create a named vector index with an {@code multi2vec-google} vectorizer.
+   *
+   * @param vectorName Vector name.
+   */
+  public static Map.Entry<String, VectorConfig> multi2vecGoogleGemini(String vectorName) {
+    return Map.entry(vectorName, Multi2VecGoogleVectorizer.gemini());
+  }
+
+  /**
+   * Create a named vector index with an {@code multi2vec-google} vectorizer.
+   *
+   * @param vectorName Vector name.
+   * @param fn         Lambda expression for optional parameters.
+   */
+  public static Map.Entry<String, VectorConfig> multi2vecGoogleGemini(String vectorName,
+      Function<Multi2VecGoogleVectorizer.GeminiBuilder, ObjectBuilder<Multi2VecGoogleVectorizer>> fn) {
+    return Map.entry(vectorName, Multi2VecGoogleVectorizer.gemini(fn));
   }
 
   /** Create a vector index with an {@code multi2vec-jinaai} vectorizer. */

--- a/src/main/java/io/weaviate/client6/v1/api/collections/vectorizers/Multi2VecGoogleVectorizer.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/vectorizers/Multi2VecGoogleVectorizer.java
@@ -15,6 +15,7 @@ import io.weaviate.client6.v1.internal.ObjectBuilder;
 public record Multi2VecGoogleVectorizer(
     @SerializedName("projectId") String projectId,
     @SerializedName("model") String model,
+    @SerializedName("apiEndpoint") String apiEndpoint,
     @SerializedName("dimensions") Integer dimensions,
     @SerializedName("location") String location,
     @SerializedName("videoIntervalSeconds") Integer videoIntervalSeconds,
@@ -59,20 +60,42 @@ public record Multi2VecGoogleVectorizer(
     return this;
   }
 
+  @Deprecated(forRemoval = true)
   public static Multi2VecGoogleVectorizer of(String projectId, String location) {
     return of(projectId, location, ObjectBuilder.identity());
   }
 
+  @Deprecated(forRemoval = true)
   public static Multi2VecGoogleVectorizer of(
       String projectId,
       String location,
       Function<Builder, ObjectBuilder<Multi2VecGoogleVectorizer>> fn) {
-    return fn.apply(new Builder(projectId, location)).build();
+    return fn.apply(new VertexBuilder(projectId, location)).build();
+  }
+
+  public static Multi2VecGoogleVectorizer vertex(String projectId, String location) {
+    return vertex(projectId, location, ObjectBuilder.identity());
+  }
+
+  public static Multi2VecGoogleVectorizer vertex(
+      String projectId,
+      String location,
+      Function<VertexBuilder, ObjectBuilder<Multi2VecGoogleVectorizer>> fn) {
+    return fn.apply(new VertexBuilder(projectId, location)).build();
+  }
+
+  public static Multi2VecGoogleVectorizer gemini() {
+    return gemini(ObjectBuilder.identity());
+  }
+
+  public static Multi2VecGoogleVectorizer gemini(Function<GeminiBuilder, ObjectBuilder<Multi2VecGoogleVectorizer>> fn) {
+    return fn.apply(new GeminiBuilder()).build();
   }
 
   public Multi2VecGoogleVectorizer(
       String projectId,
       String model,
+      String apiEndpoint,
       Integer dimensions,
       String location,
       Integer videoIntervalSeconds,
@@ -84,6 +107,7 @@ public record Multi2VecGoogleVectorizer(
       Quantization quantization) {
 
     this.projectId = projectId;
+    this.apiEndpoint = apiEndpoint;
     this.model = model;
     this.dimensions = dimensions;
     this.location = location;
@@ -100,6 +124,7 @@ public record Multi2VecGoogleVectorizer(
     this(
         builder.projectId,
         builder.model,
+        builder.apiEndpoint,
         builder.dimensions,
         builder.location,
         builder.videoIntervalSeconds,
@@ -122,19 +147,30 @@ public record Multi2VecGoogleVectorizer(
     private List<String> textFields;
     private List<Float> textWeights;
 
-    private final String projectId;
+    private String projectId;
+    private String apiEndpoint;
     private String model;
     private String location;
     private Integer dimensions;
     private Integer videoIntervalSeconds;
 
+    @Deprecated(forRemoval = true)
     public Builder(String projectId, String location) {
       this.projectId = projectId;
       this.location = location;
     }
 
+    protected Builder(String apiEndpoint) {
+      this.apiEndpoint = apiEndpoint;
+    }
+
     public Builder model(String model) {
       this.model = model;
+      return this;
+    }
+
+    protected Builder apiEndpoint(String apiEndpoint) {
+      this.apiEndpoint = apiEndpoint;
       return this;
     }
 
@@ -262,6 +298,26 @@ public record Multi2VecGoogleVectorizer(
     @Override
     public Multi2VecGoogleVectorizer build() {
       return new Multi2VecGoogleVectorizer(this);
+    }
+  }
+
+  public static class GeminiBuilder extends Builder {
+    public static final String BASE_URL = "generativelanguage.googleapis.com";
+
+    public GeminiBuilder() {
+      super(BASE_URL);
+    }
+  }
+
+  public static class VertexBuilder extends Builder {
+
+    public VertexBuilder(String projectId, String location) {
+      super(projectId, location);
+    }
+
+    public VertexBuilder apiEndpoint(String apiEndpoint) {
+      super.apiEndpoint(apiEndpoint);
+      return this;
     }
   }
 }

--- a/src/test/java/io/weaviate/client6/v1/internal/json/JSONTest.java
+++ b/src/test/java/io/weaviate/client6/v1/internal/json/JSONTest.java
@@ -787,14 +787,19 @@ public class JSONTest {
         },
         {
             VectorConfig.class,
-            Multi2VecGoogleVectorizer.of("project-id", "location",
-                v -> v.imageFields("a", "b").textFields("c").videoFields("d")),
+            Multi2VecGoogleVectorizer.vertex("project-id", "location",
+                m2v -> m2v
+                    .apiEndpoint("example.com")
+                    .imageFields("a", "b")
+                    .textFields("c")
+                    .videoFields("d")),
             """
                 {
                   "vectorIndexType": "hnsw",
                   "vectorIndexConfig": {},
                   "vectorizer": {
                     "multi2vec-google": {
+                      "apiEndpoint": "example.com",
                       "projectId": "project-id",
                       "location": "location",
                       "imageFields": ["a", "b"],
@@ -807,13 +812,17 @@ public class JSONTest {
         },
         {
             VectorConfig.class,
-            Multi2VecGoogleVectorizer.of("project-id", "location", v -> v.imageFields("a")),
+            Multi2VecGoogleVectorizer.vertex("project-id", "location",
+                m2v -> m2v
+                    .apiEndpoint("example.com")
+                    .imageFields("a")),
             """
                 {
                   "vectorIndexType": "hnsw",
                   "vectorIndexConfig": {},
                   "vectorizer": {
                     "multi2vec-google": {
+                      "apiEndpoint": "example.com",
                       "projectId": "project-id",
                       "location": "location",
                       "imageFields": ["a"]
@@ -824,14 +833,20 @@ public class JSONTest {
         },
         {
             VectorConfig.class,
-            Multi2VecGoogleVectorizer.of("project-id", "location",
-                v -> v.imageField("a", 0.1f).imageField("b", 0.1f).textField("c", 0.8f).videoField("d", 0.99f)),
+            Multi2VecGoogleVectorizer.vertex("project-id", "location",
+                m2v -> m2v
+                    .apiEndpoint("example.com")
+                    .imageField("a", 0.1f)
+                    .imageField("b", 0.1f)
+                    .textField("c", 0.8f)
+                    .videoField("d", 0.99f)),
             """
                 {
                   "vectorIndexType": "hnsw",
                   "vectorIndexConfig": {},
                   "vectorizer": {
                     "multi2vec-google": {
+                      "apiEndpoint": "example.com",
                       "projectId": "project-id",
                       "location": "location",
                       "imageFields": ["a", "b"],
@@ -842,6 +857,37 @@ public class JSONTest {
                         "textWeights":[0.8],
                         "videoWeights":[0.99]
                        }
+                    }
+                  }
+                }
+                    """,
+        },
+        {
+            VectorConfig.class,
+            Multi2VecGoogleVectorizer.gemini(),
+            """
+                {
+                  "vectorIndexType": "hnsw",
+                  "vectorIndexConfig": {},
+                  "vectorizer": {
+                    "multi2vec-google": {
+                      "apiEndpoint": "generativelanguage.googleapis.com"
+                    }
+                  }
+                }
+                    """,
+        },
+        {
+            VectorConfig.class,
+            Multi2VecGoogleVectorizer.gemini(m2v -> m2v.dimensions(768)),
+            """
+                {
+                  "vectorIndexType": "hnsw",
+                  "vectorIndexConfig": {},
+                  "vectorizer": {
+                    "multi2vec-google": {
+                      "apiEndpoint": "generativelanguage.googleapis.com",
+                      "dimensions": 768
                     }
                   }
                 }


### PR DESCRIPTION
This PR introduces dedicated factory method `Multi2VecGoogleVectorizer::gemini` that provides configuration options tailored to the Gemini API.

Additionally, we rename `-Google` methods to `-GoogleVertex` (similarly to how we have it in the `generate/` module) and deprecate the older methods.

There's a slight breaking change in that `Multi2VecGoogleVectorizer::vertex` accepts `VertexBuilder` and not the base `Builder`. This is necessary to expose `apiEndpoint` setter for Vertex, but not for Gemini configuration. Users that use the lambda shorthand should not be affected at all; only explicit use of the builder type would need to be updated, e.g.:

```java
Function<Multi2VecGoogleVectorizer.Builder, ObjectBuilder<Multi2VecGoogleVectorizer>> fn = opt -> opt.dimensions(768);
VectorConfig.multi2vecGoogle(fn); // Doesn't compile
VectorConfig.multi2vecGoogleVertex(fn); // Doesn't compile
VectorConfig.muli2vecGoogleVertex(builder -> builder.dimensions(768)); // Compiles as before
```