### PR TITLE
Batch: Publish the total number of failed tasks

### DIFF
--- a/src/main/java/io/weaviate/client6/v1/api/collections/batch/BatchContext.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/batch/BatchContext.java
@@ -136,6 +136,8 @@ public final class BatchContext<PropertiesT> implements Closeable {
   private final CollectionDescriptor<PropertiesT> collectionDescriptor;
   private final CollectionHandleDefaults collectionHandleDefaults;
 
+  private volatile int numberOfErrors;
+
   /**
    * Internal execution service. Its lifecycle is bound to that of the
    * BatchContext: it's started when the context is initialized
@@ -314,10 +316,23 @@ public final class BatchContext<PropertiesT> implements Closeable {
     // Remove the task from the WIP list as soon as it completes,
     // successfully or otherwise. Note, that TaskHandle::done future
     // only completes exceptionally after all retries have been exhausted.
-    taskHandle.done().whenComplete((__, t) -> wip.remove(taskHandle.id()));
+    taskHandle.done().whenComplete((__, t) -> {
+      if (t != null) {
+        numberOfErrors++;
+      }
+      wip.remove(taskHandle.id());
+    });
 
     queue.put(taskHandle);
     return taskHandle;
+  }
+
+  /**
+   * Get the current tally of failed tasks.
+   * An object is only considered failed if it can no longer be retried.
+   */
+  public int numberOfErrors() {
+    return numberOfErrors;
   }
 
   void start() {

--- a/src/main/java/io/weaviate/client6/v1/api/collections/batch/BatchContext.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/batch/BatchContext.java
@@ -136,6 +136,11 @@ public final class BatchContext<PropertiesT> implements Closeable {
   private final CollectionDescriptor<PropertiesT> collectionDescriptor;
   private final CollectionHandleDefaults collectionHandleDefaults;
 
+  /**
+   * Tally of the failed items. This value is only written to from
+   * {@link #retryService} thread, which processes the incoming
+   * {@link Event.Results}; making it {@code volatile} is sufficient.
+   */
   private volatile int numberOfErrors;
 
   /**

--- a/src/test/java/io/weaviate/client6/v1/api/collections/batch/BatchContextTest.java
+++ b/src/test/java/io/weaviate/client6/v1/api/collections/batch/BatchContextTest.java
@@ -502,9 +502,13 @@ public class BatchContextTest {
         .noneMatch(CompletableFuture::isCompletedExceptionally);
 
     Assertions.assertThat(tasks.subList(BATCH_SIZE - 1, BATCH_SIZE))
-        .as("last %d tasks succeeded", BATCH_SIZE)
+        .as("last %d tasks failed", BATCH_SIZE)
         .extracting(TaskHandle::done)
         .allMatch(CompletableFuture::isCompletedExceptionally);
+
+    Assertions.assertThat(context.numberOfErrors())
+        .as("number of errors")
+        .isEqualTo(BATCH_SIZE);
   }
 
   @Test
@@ -570,7 +574,6 @@ public class BatchContextTest {
   private static final class OutboundStream {
     private final StreamObserver<Event> stream;
     private final Executor eventThread;
-    private final List<Event> pendingEvents = new ArrayList<>();
 
     OutboundStream(StreamObserver<Event> stream, Executor eventThread) {
       this.stream = stream;


### PR DESCRIPTION
This PR adds a `ctx.numberOfErrors()` to check the number of tasks which failed since the batch was started.