### PR TITLE
ci: pin GitHub Actions to server SHAs

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -16,7 +16,7 @@ jobs:
       || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Unpack secrets
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
@@ -37,7 +37,7 @@ jobs:
           -Dcentral-publishing.waitUntil=published \
           deploy
       - name: Archive artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: jar-files
           path: "target/*.jar"
@@ -49,12 +49,12 @@ jobs:
     needs: [ release ]
     steps:
       - name: Download artifacts to append to release
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: jar-files
           path: target
       - name: Create a GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           generate_release_notes: true
           draft: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,8 +19,8 @@ jobs:
     name: Cache Maven dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: "zulu"
           java-version: "17"
@@ -31,8 +31,8 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: "zulu"
           java-version: "17"
@@ -46,12 +46,12 @@ jobs:
     steps:
       - name: Login to Docker Hub
         if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - id: cache-check
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         env:
           DOCKER_CACHE_KEY: docker-images-${{ env.IMG2VEC }}-${{ env.MINIO }}-${{ env.MODEL2VEC }}
         with:
@@ -59,7 +59,7 @@ jobs:
           key: ${{ env.DOCKER_CACHE_KEY }}
           lookup-only: true # Only check if cache exists, don't download
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
           android: true
@@ -77,7 +77,7 @@ jobs:
           docker save $IMG2VEC $MINIO -o $DOCKER_IMAGES_TAR
       - name: Cache images
         if: steps.cache-check.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         env:
           DOCKER_CACHE_KEY: docker-images-${{ env.IMG2VEC }}-${{ env.MINIO }}-${{ env.MODEL2VEC }}
         with:
@@ -94,16 +94,16 @@ jobs:
         WEAVIATE_VERSION:
           ["1.32.24", "1.33.11", "1.34.7", "1.35.2", "1.36.9", "1.37.0-rc.0"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         env:
           DOCKER_CACHE_KEY: docker-images-${{ env.IMG2VEC }}-${{ env.MINIO }}-${{ env.MODEL2VEC }}
         with:
           path: ${{ env.DOCKER_IMAGES_TAR }}
           key: ${{ env.DOCKER_CACHE_KEY }}
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
           android: true
@@ -117,7 +117,7 @@ jobs:
           if [ -f $DOCKER_IMAGES_TAR ]; then
             docker load -i $DOCKER_IMAGES_TAR
           fi
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         name: Setup JDK
         with:
           distribution: "zulu"


### PR DESCRIPTION
## Summary
- Pin all `uses:` refs in GitHub Actions workflows to the same commit SHAs used by `weaviate/weaviate`, so this client stays in lockstep with the server
- Preserve the tag (e.g. `# v6`) as a trailing comment for readability

## Context
Initial consolidation pass. Going forward, GitHub's repo-level ["Require actions to be pinned to a full-length commit SHA"](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/) policy (shipped 2025-08-15) will enforce SHA pinning at execution time for every workflow — so no custom linter is needed in this repo.

The scope was originally broader (included `linter_actions_pinned.sh`, `linter_hidden_unicode.sh`, and a `pr-security-lint.yaml` workflow). Those are dropped here: the native policy makes the SHA linter redundant, and the hidden-Unicode scan will return in a follow-up that delegates to a shared composite action in `weaviate/weaviate`.

## Test plan
- [ ] CI workflows run and pass on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)