### PR TITLE
ci: add hidden-unicode lint via weaviate/weaviate composite

### DIFF
--- a/.github/workflows/pr-security-lint.yaml
+++ b/.github/workflows/pr-security-lint.yaml
@@ -1,0 +1,35 @@
+name: PR Security Lint
+
+# SECURITY: This workflow uses pull_request_target intentionally so that the
+# workflow definition runs from the BASE branch (main), not the PR. The
+# composite action it invokes lives at a pinned 40-char SHA in
+# weaviate/weaviate — attackers cannot alter the lint logic via a PR or by
+# tampering with an upstream tag.
+#
+# Rules:
+#   1. Do NOT add `ref: ${{ github.event.pull_request.head.sha }}` or any
+#      reference to PR-controlled refs. The composite uses the GitHub API to
+#      fetch the diff text — no PR code is ever executed.
+#   2. Do NOT add secrets to this workflow. The pull_request_target context
+#      grants a token with write access to the base repo and access to all
+#      repo secrets if any are referenced. We reference none and request
+#      minimal permissions; keep it that way.
+#   3. Keep the composite action pinned to a full-length commit SHA. Tag or
+#      branch refs would let an upstream change alter the lint logic at
+#      execution time.
+on:
+  pull_request_target:
+
+permissions: {}
+
+jobs:
+  hidden-unicode:
+    name: hidden unicode characters
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read   # required by the composite's `gh pr diff` call
+    steps:
+      - uses: weaviate/weaviate/.github/actions/security-lint@3e52fc80a244f4644d4facc6a4e705ea6eda9039 # PR #11093
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          github-token: ${{ github.token }}


### PR DESCRIPTION
## Summary

Adds a `pr-security-lint.yaml` workflow that scans every PR diff for hidden Unicode / trojan-source characters (https://trojansource.codes/) by delegating to the reusable composite action shipped in weaviate/weaviate#11093 — pinned to the merge commit `3e52fc80a244f4644d4facc6a4e705ea6eda9039`.

This replaces the per-repo bash that other clients had been carrying separately. java-client previously had no unicode scan; this is net-new coverage.

## Why a composite, not inline bash

Single source of truth for the scan logic across all 5 client repos. The composite is pinned to a 40-char SHA, so an upstream change can't alter what runs here without an explicit version bump in this file.

## Security notes

- `pull_request_target` runs the workflow definition from the base branch, never from the PR.
- `permissions: {}` at workflow level; `pull-requests: read` is the only grant.
- No secrets are referenced. The composite uses the default `github.token` only to fetch the diff via the GitHub API.
- No PR-controlled refs are checked out — the composite operates purely on the diff text.

## Tradeoffs of delegating to an upstream composite

**Pros**
- Single source of truth for the scan logic — fixes/improvements ship to all 5 SDKs via one SHA bump per repo, not by syncing 5 copies of bash.
- Composite is pinned to a 40-char SHA, so upstream tag retargeting can't change what runs here without a reviewable diff.
- `pull_request_target` runs the workflow definition from the base branch and the composite never checks out PR-controlled refs — a malicious PR can't alter the linter that's checking it.
- Minimal blast radius: `permissions: {}` at workflow level, `pull-requests: read` at job level, no secrets referenced.
- Composable — adding more scanners upstream (shell-script lint, etc.) propagates to every client automatically.

**Cons**
- Cross-repo runtime coupling: deleting or restructuring `weaviate/weaviate/.github/actions/security-lint` breaks all 5 clients until the SHA is bumped.
- `pull_request_target` is a foot-gun — a future editor adding `ref: pull_request.head.sha` or referencing a secret would re-introduce the attack surface this design is built to avoid. The file header warns against it, but the discipline lives in the reviewer.
- SHA-bump treadmill: upstream improvements don't propagate until each client opens a PR to bump the pinned SHA. Dependabot can automate this if we wire it up.
- Failure logs reference a path inside `weaviate/weaviate` rather than this repo, so debugging a false positive requires hopping to another repo to read the script.
- Cold-start adds a small network fetch of the composite per run.
## Test plan

- [ ] Workflow runs on this PR and passes (clean diff)
- [ ] Probe with a follow-up commit containing a zero-width space to confirm the linter rejects it

🤖 Generated with [Claude Code](https://claude.com/claude-code)