### PR TITLE
Add text2vec-digitalocean vectorizer module

### DIFF
--- a/src/main/java/io/weaviate/client6/v1/api/collections/VectorConfig.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/VectorConfig.java
@@ -36,6 +36,7 @@ import io.weaviate.client6.v1.api.collections.vectorizers.Text2VecDatabricksVect
 import io.weaviate.client6.v1.api.collections.vectorizers.Text2VecGoogleVectorizer;
 import io.weaviate.client6.v1.api.collections.vectorizers.Text2VecHuggingFaceVectorizer;
 import io.weaviate.client6.v1.api.collections.vectorizers.Text2VecJinaAiVectorizer;
+import io.weaviate.client6.v1.api.collections.vectorizers.Text2VecDigitalOceanVectorizer;
 import io.weaviate.client6.v1.api.collections.vectorizers.Text2VecMistralVectorizer;
 import io.weaviate.client6.v1.api.collections.vectorizers.Text2VecModel2VecVectorizer;
 import io.weaviate.client6.v1.api.collections.vectorizers.Text2VecMorphVectorizer;
@@ -59,6 +60,7 @@ public interface VectorConfig extends TaggedUnion<VectorConfig.Kind, Object> {
     TEXT2VEC_HUGGINGFACE("text2vec-huggingface"),
     REF2VEC_CENTROID("ref2vec-centroid"),
     TEXT2VEC_JINAAI("text2vec-jinaai"),
+    TEXT2VEC_DIGITALOCEAN("text2vec-digitalocean"),
     TEXT2VEC_MISTRAL("text2vec-mistral"),
     TEXT2VEC_MORPH("text2vec-morph"),
     TEXT2VEC_MODEL2VEC("text2vec-model2vec"),
@@ -1053,6 +1055,41 @@ public interface VectorConfig extends TaggedUnion<VectorConfig.Kind, Object> {
     return Map.entry(vectorName, Text2VecJinaAiVectorizer.of(fn));
   }
 
+  /** Create a vector index with an {@code text2vec-digitalocean} vectorizer. */
+  public static Map.Entry<String, VectorConfig> text2vecDigitalOcean() {
+    return text2vecDigitalOcean(VectorIndex.DEFAULT_VECTOR_NAME);
+  }
+
+  /**
+   * Create a vector index with an {@code text2vec-digitalocean} vectorizer.
+   *
+   * @param fn Lambda expression for optional parameters.
+   */
+  public static Map.Entry<String, VectorConfig> text2vecDigitalOcean(
+      Function<Text2VecDigitalOceanVectorizer.Builder, ObjectBuilder<Text2VecDigitalOceanVectorizer>> fn) {
+    return text2vecDigitalOcean(VectorIndex.DEFAULT_VECTOR_NAME, fn);
+  }
+
+  /**
+   * Create a named vector index with an {@code text2vec-digitalocean} vectorizer.
+   *
+   * @param vectorName Vector name.
+   */
+  public static Map.Entry<String, VectorConfig> text2vecDigitalOcean(String vectorName) {
+    return Map.entry(vectorName, Text2VecDigitalOceanVectorizer.of());
+  }
+
+  /**
+   * Create a named vector index with an {@code text2vec-digitalocean} vectorizer.
+   *
+   * @param vectorName Vector name.
+   * @param fn         Lambda expression for optional parameters.
+   */
+  public static Map.Entry<String, VectorConfig> text2vecDigitalOcean(String vectorName,
+      Function<Text2VecDigitalOceanVectorizer.Builder, ObjectBuilder<Text2VecDigitalOceanVectorizer>> fn) {
+    return Map.entry(vectorName, Text2VecDigitalOceanVectorizer.of(fn));
+  }
+
   /** Create a vector index with an {@code text2vec-mistral} vectorizer. */
   public static Map.Entry<String, VectorConfig> text2vecMistral() {
     return text2vecMistral(VectorIndex.DEFAULT_VECTOR_NAME);
@@ -1558,6 +1595,16 @@ public interface VectorConfig extends TaggedUnion<VectorConfig.Kind, Object> {
     return _as(VectorConfig.Kind.TEXT2VEC_JINAAI);
   }
 
+  /** Is this an instance of {@link Text2VecDigitalOceanVectorizer}? */
+  default public boolean isText2VecDigitalOcean() {
+    return _is(VectorConfig.Kind.TEXT2VEC_DIGITALOCEAN);
+  }
+
+  /** Convert this instance to {@link Text2VecDigitalOceanVectorizer}. */
+  default public Text2VecDigitalOceanVectorizer asText2VecDigitalOcean() {
+    return _as(VectorConfig.Kind.TEXT2VEC_DIGITALOCEAN);
+  }
+
   /** Is this an instance of {@link Text2VecMistralVectorizer}? */
   default public boolean isText2VecMistral() {
     return _is(VectorConfig.Kind.TEXT2VEC_MISTRAL);
@@ -1668,6 +1715,7 @@ public interface VectorConfig extends TaggedUnion<VectorConfig.Kind, Object> {
       addAdapter(gson, VectorConfig.Kind.TEXT2VEC_HUGGINGFACE, Text2VecHuggingFaceVectorizer.class);
       addAdapter(gson, VectorConfig.Kind.REF2VEC_CENTROID, Ref2VecCentroidVectorizer.class);
       addAdapter(gson, VectorConfig.Kind.TEXT2VEC_JINAAI, Text2VecJinaAiVectorizer.class);
+      addAdapter(gson, VectorConfig.Kind.TEXT2VEC_DIGITALOCEAN, Text2VecDigitalOceanVectorizer.class);
       addAdapter(gson, VectorConfig.Kind.TEXT2VEC_MISTRAL, Text2VecMistralVectorizer.class);
       addAdapter(gson, VectorConfig.Kind.TEXT2VEC_MORPH, Text2VecMorphVectorizer.class);
       addAdapter(gson, VectorConfig.Kind.TEXT2VEC_MODEL2VEC, Text2VecModel2VecVectorizer.class);

--- a/src/main/java/io/weaviate/client6/v1/api/collections/vectorizers/Text2VecDigitalOceanVectorizer.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/vectorizers/Text2VecDigitalOceanVectorizer.java
@@ -1,0 +1,132 @@
+package io.weaviate.client6.v1.api.collections.vectorizers;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+import com.google.gson.annotations.SerializedName;
+
+import io.weaviate.client6.v1.api.collections.Quantization;
+import io.weaviate.client6.v1.api.collections.VectorConfig;
+import io.weaviate.client6.v1.api.collections.VectorIndex;
+import io.weaviate.client6.v1.internal.ObjectBuilder;
+
+public record Text2VecDigitalOceanVectorizer(
+    @SerializedName("baseURL") String baseUrl,
+    @SerializedName("model") String model,
+
+    /**
+     * Weaviate defaults to {@code true} if the value is not provided.
+     * To avoid that we send "vectorizeClassName": false all the time
+     * and make it impossible to enable this feature, as it is deprecated.
+     */
+    @Deprecated @SerializedName("vectorizeClassName") boolean vectorizeCollectionName,
+    /** Properties included in the embedding. */
+    @SerializedName("properties") List<String> sourceProperties,
+    /** Vector index configuration. */
+    VectorIndex vectorIndex,
+    /** Vector quantization method. */
+    Quantization quantization) implements VectorConfig {
+
+  @Override
+  public VectorConfig.Kind _kind() {
+    return VectorConfig.Kind.TEXT2VEC_DIGITALOCEAN;
+  }
+
+  @Override
+  public Object _self() {
+    return this;
+  }
+
+  public static Text2VecDigitalOceanVectorizer of() {
+    return of(ObjectBuilder.identity());
+  }
+
+  public static Text2VecDigitalOceanVectorizer of(
+      Function<Builder, ObjectBuilder<Text2VecDigitalOceanVectorizer>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  /**
+   * Canonical constructor always sets {@link #vectorizeCollectionName} to false.
+   */
+  public Text2VecDigitalOceanVectorizer(
+      String baseUrl,
+      String model,
+
+      boolean vectorizeCollectionName,
+      List<String> sourceProperties,
+      VectorIndex vectorIndex,
+      Quantization quantization) {
+    this.baseUrl = baseUrl;
+    this.model = model;
+
+    this.vectorizeCollectionName = false;
+    this.sourceProperties = sourceProperties;
+    this.vectorIndex = vectorIndex;
+    this.quantization = quantization;
+  }
+
+  public Text2VecDigitalOceanVectorizer(Builder builder) {
+    this(
+        builder.baseUrl,
+        builder.model,
+
+        builder.vectorizeCollectionName,
+        builder.sourceProperties,
+        builder.vectorIndex,
+        builder.quantization);
+  }
+
+  public static class Builder implements ObjectBuilder<Text2VecDigitalOceanVectorizer> {
+    private final boolean vectorizeCollectionName = false;
+    private Quantization quantization;
+    private List<String> sourceProperties;
+    private VectorIndex vectorIndex = VectorIndex.DEFAULT_VECTOR_INDEX;
+
+    private String baseUrl;
+    private String model;
+
+    public Builder baseUrl(String baseUrl) {
+      this.baseUrl = baseUrl;
+      return this;
+    }
+
+    public Builder model(String model) {
+      this.model = model;
+      return this;
+    }
+
+    /** Add properties to include in the embedding. */
+    public Builder sourceProperties(String... properties) {
+      return sourceProperties(Arrays.asList(properties));
+    }
+
+    /** Add properties to include in the embedding. */
+    public Builder sourceProperties(List<String> properties) {
+      this.sourceProperties = properties;
+      return this;
+    }
+
+    /**
+     * Override default vector index configuration.
+     *
+     * <a href=
+     * "https://docs.weaviate.io/weaviate/config-refs/indexing/vector-index#hnsw-index-parameters">HNSW</a>
+     * is the default vector index.
+     */
+    public Builder vectorIndex(VectorIndex vectorIndex) {
+      this.vectorIndex = vectorIndex;
+      return this;
+    }
+
+    public Builder quantization(Quantization quantization) {
+      this.quantization = quantization;
+      return this;
+    }
+
+    public Text2VecDigitalOceanVectorizer build() {
+      return new Text2VecDigitalOceanVectorizer(this);
+    }
+  }
+}

--- a/src/test/java/io/weaviate/client6/v1/internal/json/JSONTest.java
+++ b/src/test/java/io/weaviate/client6/v1/internal/json/JSONTest.java
@@ -365,7 +365,7 @@ public class JSONTest {
         },
         {
             VectorConfig.class,
-            Text2VecDigitalOceanVectorizer.of(v -> v.model("qwen3-embedding-0.6b").baseUrl("https://inference.do-ai.run")),
+            Text2VecDigitalOceanVectorizer.of(v -> v.model("qwen3-embedding-0.6b").baseUrl("https://inference.do-ai.run").sourceProperties("a")),
             """
                 {
                   "vectorIndexType": "hnsw",
@@ -374,21 +374,6 @@ public class JSONTest {
                     "text2vec-digitalocean": {
                       "baseURL": "https://inference.do-ai.run",
                       "model": "qwen3-embedding-0.6b",
-                      "vectorizeClassName": false
-                    }
-                  }
-                }
-                    """,
-        },
-        {
-            VectorConfig.class,
-            Text2VecDigitalOceanVectorizer.of(v -> v.sourceProperties("a")),
-            """
-                {
-                  "vectorIndexType": "hnsw",
-                  "vectorIndexConfig": {},
-                  "vectorizer": {
-                    "text2vec-digitalocean": {
                       "properties": ["a"],
                       "vectorizeClassName": false
                     }

--- a/src/test/java/io/weaviate/client6/v1/internal/json/JSONTest.java
+++ b/src/test/java/io/weaviate/client6/v1/internal/json/JSONTest.java
@@ -55,6 +55,7 @@ import io.weaviate.client6.v1.api.collections.vectorizers.Text2VecDatabricksVect
 import io.weaviate.client6.v1.api.collections.vectorizers.Text2VecGoogleVectorizer;
 import io.weaviate.client6.v1.api.collections.vectorizers.Text2VecHuggingFaceVectorizer;
 import io.weaviate.client6.v1.api.collections.vectorizers.Text2VecJinaAiVectorizer;
+import io.weaviate.client6.v1.api.collections.vectorizers.Text2VecDigitalOceanVectorizer;
 import io.weaviate.client6.v1.api.collections.vectorizers.Text2VecMistralVectorizer;
 import io.weaviate.client6.v1.api.collections.vectorizers.Text2VecModel2VecVectorizer;
 import io.weaviate.client6.v1.api.collections.vectorizers.Text2VecMorphVectorizer;
@@ -340,6 +341,54 @@ public class JSONTest {
                   "vectorIndexConfig": {},
                   "vectorizer": {
                     "text2vec-mistral": {
+                      "properties": ["a"],
+                      "vectorizeClassName": false
+                    }
+                  }
+                }
+                    """,
+        },
+        {
+            VectorConfig.class,
+            Text2VecDigitalOceanVectorizer.of(),
+            """
+                {
+                  "vectorIndexType": "hnsw",
+                  "vectorIndexConfig": {},
+                  "vectorizer": {
+                    "text2vec-digitalocean": {
+                      "vectorizeClassName": false
+                    }
+                  }
+                }
+                    """,
+        },
+        {
+            VectorConfig.class,
+            Text2VecDigitalOceanVectorizer.of(v -> v.model("qwen3-embedding-0.6b").baseUrl("https://inference.do-ai.run")),
+            """
+                {
+                  "vectorIndexType": "hnsw",
+                  "vectorIndexConfig": {},
+                  "vectorizer": {
+                    "text2vec-digitalocean": {
+                      "baseURL": "https://inference.do-ai.run",
+                      "model": "qwen3-embedding-0.6b",
+                      "vectorizeClassName": false
+                    }
+                  }
+                }
+                    """,
+        },
+        {
+            VectorConfig.class,
+            Text2VecDigitalOceanVectorizer.of(v -> v.sourceProperties("a")),
+            """
+                {
+                  "vectorIndexType": "hnsw",
+                  "vectorIndexConfig": {},
+                  "vectorizer": {
+                    "text2vec-digitalocean": {
                       "properties": ["a"],
                       "vectorizeClassName": false
                     }


### PR DESCRIPTION
## Summary

- Adds support for the new `text2vec-digitalocean` vectorizer module, mirroring `text2vec-mistral` (shared shape: `model` + `baseURL` + `vectorizeClassName`)
- Registers the new `Kind.TEXT2VEC_DIGITALOCEAN` enum value and Gson type adapter in `VectorConfig`
- Exposes four factory overloads (`text2vecDigitalOcean()`, with fn, with name, with name + fn) and typed accessor helpers (`isText2VecDigitalOcean` / `asText2VecDigitalOcean`)

## API surface added

- `Text2VecDigitalOceanVectorizer` — record with Lombok-style builder, `baseUrl`, `model`, `sourceProperties`, `vectorIndex`, `quantization`
- `VectorConfig.Kind.TEXT2VEC_DIGITALOCEAN` — enum entry mapping to `"text2vec-digitalocean"`
- `VectorConfig.text2vecDigitalOcean(...)` — four factory overloads
- `VectorConfig.isText2VecDigitalOcean()` / `asText2VecDigitalOcean()` — typed cast helpers

## Test plan

- [x] 2 unit test cases added to `JSONTest` asserting JSON serialization: default (empty config) and all-parameters-set (model + baseURL + sourceProperties)
- [x] All 220 tests in `JSONTest` pass (`Tests run: 220, Failures: 0, Errors: 0`)
- [x] No unrelated files modified

## Review-feedback changes

Second commit (`c4eaf1b8`) merges two of the original test cases per @bevzzz's review — the `model + baseURL` case and the `sourceProperties` case both checked the same thing (a parameter serializes correctly when set), so they're now one combined case that exercises all parameters at once. The empty/default case stays because it covers a structurally different payload. This matches the leaner pattern used by other vectorizers in the same file.

Closes #569

Sibling PR (Python): weaviate/weaviate-python-client#2041

🤖 Generated with [Claude Code](https://claude.com/claude-code)