### PR TITLE
Fix Ranked Fusion Function being treated as Relative Score Function

### DIFF
--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/Hybrid.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/Hybrid.java
@@ -182,8 +182,10 @@ public record Hybrid(
       switch (fusionType) {
         case RANKED:
           hybrid.setFusionType(WeaviateProtoBaseSearch.Hybrid.FusionType.FUSION_TYPE_RANKED);
+          break;
         case RELATIVE_SCORE:
           hybrid.setFusionType(WeaviateProtoBaseSearch.Hybrid.FusionType.FUSION_TYPE_RELATIVE_SCORE);
+          break;
       }
     }
 


### PR DESCRIPTION
This branch contains the required break statement to fix the issue described in [ISSUE #572](https://github.com/weaviate/java-client/issues/572).