### PR TITLE
feat(vectorizers): add optional dimensions to text2vec-aws vectorizer

### DIFF
--- a/src/main/java/io/weaviate/client6/v1/api/collections/vectorizers/Text2VecAwsVectorizer.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/vectorizers/Text2VecAwsVectorizer.java
@@ -18,6 +18,7 @@ public record Text2VecAwsVectorizer(
     @SerializedName("service") Service service,
     @SerializedName("targetModel") String targetModel,
     @SerializedName("targetVariant") String targetVariant,
+    @SerializedName("dimensions") Integer dimensions,
 
     /**
      * Weaviate defaults to {@code true} if the value is not provided.
@@ -83,6 +84,7 @@ public record Text2VecAwsVectorizer(
       Service service,
       String targetModel,
       String targetVariant,
+      Integer dimensions,
 
       boolean vectorizeCollectionName,
       List<String> sourceProperties,
@@ -94,6 +96,7 @@ public record Text2VecAwsVectorizer(
     this.service = service;
     this.targetModel = targetModel;
     this.targetVariant = targetVariant;
+    this.dimensions = dimensions;
 
     this.vectorizeCollectionName = false;
     this.sourceProperties = sourceProperties;
@@ -109,6 +112,7 @@ public record Text2VecAwsVectorizer(
         builder.service,
         builder.targetModel,
         builder.targetVariant,
+        builder.dimensions,
 
         builder.vectorizeCollectionName,
         builder.sourceProperties,
@@ -128,6 +132,7 @@ public record Text2VecAwsVectorizer(
     private String region;
     private String targetModel;
     private String targetVariant;
+    private Integer dimensions;
 
     protected Builder(Service service) {
       this.service = service;
@@ -157,6 +162,11 @@ public record Text2VecAwsVectorizer(
 
     public Builder targetVariant(String targetVariant) {
       this.targetVariant = targetVariant;
+      return this;
+    }
+
+    public Builder dimensions(int dimensions) {
+      this.dimensions = dimensions;
       return this;
     }
 

--- a/src/test/java/io/weaviate/client6/v1/internal/json/JSONTest.java
+++ b/src/test/java/io/weaviate/client6/v1/internal/json/JSONTest.java
@@ -171,7 +171,7 @@ public class JSONTest {
         },
         {
             VectorConfig.class,
-            Text2VecAwsVectorizer.bedrock("amazon.titan-embed-text-v2:0"),
+            Text2VecAwsVectorizer.bedrock("amazon.titan-embed-text-v2:0", v -> v.dimensions(512)),
             """
                 {
                   "vectorIndexType": "hnsw",
@@ -180,6 +180,7 @@ public class JSONTest {
                     "text2vec-aws": {
                       "service": "bedrock",
                       "model": "amazon.titan-embed-text-v2:0",
+                      "dimensions": 512,
                       "vectorizeClassName": false
                     }
                   }


### PR DESCRIPTION
Adds an optional `dimensions` parameter (output embedding dimensionality) to the `text2vec-aws` vectorizer config. Omitted when unset, so the server applies its default.

Closes #579