### PR TITLE
feat(backup): Support incremental backups

### DIFF
--- a/src/it/java/io/weaviate/integration/BackupITest.java
+++ b/src/it/java/io/weaviate/integration/BackupITest.java
@@ -245,7 +245,7 @@ public class BackupITest extends ConcurrentTest {
   @Test(expected = IllegalStateException.class)
   public void test_waitForCompletion_unknown() throws IOException, TimeoutException {
     var backup = new Backup("#1", "/tmp/bak/#1", "filesystem", List.of("Things"), BackupStatus.STARTED,
-        null, null, null, null, null);
+        null, null, null, null, null, null);
     backup.waitForCompletion(client);
   }
 

--- a/src/main/java/io/weaviate/client6/v1/api/backup/Backup.java
+++ b/src/main/java/io/weaviate/client6/v1/api/backup/Backup.java
@@ -35,6 +35,8 @@ public record Backup(
     @SerializedName("completedAt") OffsetDateTime completedAt,
     /** Backup size in GiB. */
     @SerializedName("size") Float sizeGiB,
+    /** Prefix for the incremental backup IDs. */
+    @SerializedName("incremental_base_backup_id") String prefixIncremental,
     /**
      * This value indicates if a backup is being created or restored from.
      * For operations like LIST this value is null.
@@ -55,6 +57,7 @@ public record Backup(
         startedAt,
         completedAt,
         sizeGiB,
+        prefixIncremental,
         operation);
   }
 

--- a/src/main/java/io/weaviate/client6/v1/api/backup/CreateBackupRequest.java
+++ b/src/main/java/io/weaviate/client6/v1/api/backup/CreateBackupRequest.java
@@ -26,6 +26,7 @@ public record CreateBackupRequest(BackupCreate body, String backend) {
       @SerializedName("id") String id,
       @SerializedName("include") List<String> includeCollections,
       @SerializedName("exclude") List<String> excludeCollections,
+      @SerializedName("incremental_base_backup_id") String prefixIncremental,
       @SerializedName("config") Config config) {
 
     private static record Config(
@@ -48,6 +49,7 @@ public record CreateBackupRequest(BackupCreate body, String backend) {
           builder.backupId,
           builder.includeCollections,
           builder.excludeCollections,
+          builder.prefixIncremental,
           new Config(
               builder.cpuPercentage,
               builder.compressionLevel,
@@ -58,6 +60,7 @@ public record CreateBackupRequest(BackupCreate body, String backend) {
     public static class Builder implements ObjectBuilder<BackupCreate> {
       private final String backupId;
 
+      private String prefixIncremental;
       private Integer cpuPercentage;
       private CompressionLevel compressionLevel;
       private String bucket;
@@ -67,6 +70,12 @@ public record CreateBackupRequest(BackupCreate body, String backend) {
 
       public Builder(String backupId) {
         this.backupId = backupId;
+      }
+
+      /** Prefix for incremental backup IDs. */
+      public Builder prefixIncremental(String prefixIncremental) {
+        this.prefixIncremental = prefixIncremental;
+        return this;
       }
 
       /** Collection that should be included in the backup. */


### PR DESCRIPTION
This PR adds a `prefixIncremental` parameter to CreateBackupRequest, which activates incremental backups when set. On the receiving end, `Backup` record now also exports `prefixIncremental` info for each backup obtained from list or get-status.

Closes #577 