### PR TITLE
deps: bump httpclient5 to v5.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <lombok.version>1.18.42</lombok.version>
     <gson.version>2.13.2</gson.version>
-    <httpclient.version>5.6</httpclient.version>
+    <httpclient.version>5.6.1</httpclient.version>
     <lang3.version>3.20.0</lang3.version>
     <junit.version>4.13.2</junit.version>
     <testcontainers.version>2.0.3</testcontainers.version>


### PR DESCRIPTION
This PR addresses a [CVE](https://github.com/weaviate/java-client/security/dependabot/8) in Apache's `httpclient5` reported by Dependabot.