### PR TITLE
chore(config): annotate deprecated parameters in async replication config

### DIFF
--- a/src/main/java/io/weaviate/client6/v1/api/collections/Replication.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/Replication.java
@@ -98,6 +98,7 @@ public record Replication(
        *
        * @deprecated This paramter should be controled server-side.
        */
+      @Deprecated
       public Builder maxWorkers(int maxWorkers) {
         this.maxWorkers = maxWorkers;
         return this;
@@ -126,6 +127,7 @@ public record Replication(
        *
        * @deprecated This parameter should be controled server-side.
        */
+      @Deprecated
       public Builder aliveNodesCheckingFrequencyMillis(int aliveNodesCheckingFrequencyMillis) {
         this.aliveNodesCheckingFrequencyMillis = aliveNodesCheckingFrequencyMillis;
         return this;


### PR DESCRIPTION
This PR adds a `@Deprecated` annotation to methods of `Replication.Builder` for properties that are not returned / accepted by the server in the latest version.

Closes #571