### PR TITLE
feat(query): add diversity selection parameter to supported query types

### DIFF
--- a/src/it/java/io/weaviate/integration/SearchITest.java
+++ b/src/it/java/io/weaviate/integration/SearchITest.java
@@ -32,6 +32,7 @@ import io.weaviate.client6.v1.api.collections.data.ObjectReference;
 import io.weaviate.client6.v1.api.collections.generate.GenerativeObject;
 import io.weaviate.client6.v1.api.collections.generate.TaskOutput;
 import io.weaviate.client6.v1.api.collections.generative.DummyGenerative;
+import io.weaviate.client6.v1.api.collections.query.Diversity;
 import io.weaviate.client6.v1.api.collections.query.FetchObjectById;
 import io.weaviate.client6.v1.api.collections.query.Filter;
 import io.weaviate.client6.v1.api.collections.query.GroupBy;
@@ -883,5 +884,18 @@ public class SearchITest extends ConcurrentTest {
             .extracting(QueryProfile.ShardProfile::searches,
                 InstanceOfAssertFactories.map(String.class, String.class))
             .isNotEmpty());
+  }
+
+  @Test
+  public void testDiversity() throws Exception {
+    Version.V137.orSkip();
+
+    var things = client.collections.use(COLLECTION);
+    var resp = things.query.nearVector(searchVector,
+        opt -> opt.diversity(Diversity.mmr(div -> div.limit(3))));
+
+    Assertions.assertThat(resp)
+        .extracting(QueryResponse::objects, InstanceOfAssertFactories.LIST)
+        .hasSize(3);
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/BaseVectorSearchBuilder.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/BaseVectorSearchBuilder.java
@@ -7,6 +7,7 @@ abstract class BaseVectorSearchBuilder<SelfT extends BaseVectorSearchBuilder<Sel
   Float distance;
   Float certainty;
   Rerank rerank;
+  Diversity diversity;
 
   /**
    * Discard objects whose vectors are further away
@@ -43,6 +44,15 @@ abstract class BaseVectorSearchBuilder<SelfT extends BaseVectorSearchBuilder<Sel
   @SuppressWarnings("unchecked")
   public SelfT rerank(Rerank rerank) {
     this.rerank = rerank;
+    return (SelfT) this;
+  }
+
+  /**
+   * Apply diversity selection to the query results.
+   */
+  @SuppressWarnings("unchecked")
+  public SelfT diversity(Diversity diversity) {
+    this.diversity = diversity;
     return (SelfT) this;
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/Diversity.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/Diversity.java
@@ -1,0 +1,83 @@
+package io.weaviate.client6.v1.api.collections.query;
+
+import java.util.function.Function;
+
+import io.weaviate.client6.v1.internal.ObjectBuilder;
+import io.weaviate.client6.v1.internal.TaggedUnion;
+import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoBaseSearch;
+
+public interface Diversity extends TaggedUnion<Diversity.Kind, Object> {
+  public enum Kind {
+    MMR;
+  }
+
+  /** Use {@link Mmr} diversity selection. */
+  public static Mmr mmr(Function<Mmr.Builder, ObjectBuilder<Mmr>> fn) {
+    return Mmr.of(fn);
+  }
+
+  /** Return this diversity as concrete {@link Mmr} type. */
+  public default Mmr asMmr() {
+    return _as(Diversity.Kind.MMR);
+  }
+
+  /** Maximal Marginal Relevance diversity selection. */
+  public record Mmr(Integer limit, Float balance) implements Diversity {
+
+    @Override
+    public Diversity.Kind _kind() {
+      return Diversity.Kind.MMR;
+    }
+
+    @Override
+    public Object _self() {
+      return this;
+    }
+
+    public static Mmr of(Function<Builder, ObjectBuilder<Mmr>> fn) {
+      return fn.apply(new Builder()).build();
+    }
+
+    public Mmr(Builder builder) {
+      this(builder.limit, builder.balance);
+    }
+
+    public static class Builder implements ObjectBuilder<Mmr> {
+      private Integer limit;
+      private Float balance;
+
+      public Builder limit(int limit) {
+        this.limit = limit;
+        return this;
+      }
+
+      public Builder balance(float balance) {
+        this.balance = balance;
+        return this;
+      }
+
+      @Override
+      public Mmr build() {
+        return new Mmr(this);
+      }
+    }
+  }
+
+  public default WeaviateProtoBaseSearch.Selection.Builder toProto() {
+    var selection = WeaviateProtoBaseSearch.Selection.newBuilder();
+    switch (_kind()) {
+      case MMR:
+        var mmrBuilder = WeaviateProtoBaseSearch.Selection.MMR.newBuilder();
+        var mmr = asMmr();
+        if (mmr.limit() != null) {
+          mmrBuilder.setLimit(mmr.limit());
+        }
+        if (mmr.balance() != null) {
+          mmrBuilder.setBalance(mmr.balance());
+        }
+        selection.setMmr(mmrBuilder);
+        break;
+    }
+    return selection;
+  }
+}

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/NearAudio.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/NearAudio.java
@@ -10,7 +10,13 @@ import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoAggregate;
 import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoBaseSearch;
 import io.weaviate.client6.v1.internal.grpc.protocol.WeaviateProtoSearchGet;
 
-public record NearAudio(Target searchTarget, Float distance, Float certainty, Rerank rerank, BaseQueryOptions common)
+public record NearAudio(
+    Target searchTarget,
+    Float distance,
+    Float certainty,
+    Rerank rerank,
+    Diversity diversity,
+    BaseQueryOptions common)
     implements QueryOperator, AggregateObjectFilter {
 
   public static NearAudio of(String audio) {
@@ -35,6 +41,7 @@ public record NearAudio(Target searchTarget, Float distance, Float certainty, Re
         builder.distance,
         builder.certainty,
         builder.rerank,
+        builder.diversity,
         builder.baseOptions());
   }
 
@@ -81,7 +88,9 @@ public record NearAudio(Target searchTarget, Float distance, Float certainty, Re
     } else if (distance != null) {
       nearAudio.setDistance(distance);
     }
-
+    if (diversity != null) {
+      nearAudio.setSelection(diversity.toProto());
+    }
     return nearAudio;
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/NearDepth.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/NearDepth.java
@@ -15,6 +15,7 @@ public record NearDepth(
     Float distance,
     Float certainty,
     Rerank rerank,
+    Diversity diversity,
     BaseQueryOptions common)
     implements QueryOperator, AggregateObjectFilter {
 
@@ -40,6 +41,7 @@ public record NearDepth(
         builder.distance,
         builder.certainty,
         builder.rerank,
+        builder.diversity,
         builder.baseOptions());
   }
 
@@ -85,6 +87,9 @@ public record NearDepth(
       nearDepth.setCertainty(certainty);
     } else if (distance != null) {
       nearDepth.setDistance(distance);
+    }
+    if (diversity != null) {
+      nearDepth.setSelection(diversity.toProto());
     }
     return nearDepth;
   }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/NearImage.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/NearImage.java
@@ -15,6 +15,7 @@ public record NearImage(
     Float distance,
     Float certainty,
     Rerank rerank,
+    Diversity diversity,
     BaseQueryOptions common)
     implements QueryOperator, AggregateObjectFilter {
 
@@ -40,6 +41,7 @@ public record NearImage(
         builder.distance,
         builder.certainty,
         builder.rerank,
+        builder.diversity,
         builder.baseOptions());
   }
 
@@ -85,6 +87,9 @@ public record NearImage(
       nearImage.setCertainty(certainty);
     } else if (distance != null) {
       nearImage.setDistance(distance);
+    }
+    if (diversity != null) {
+      nearImage.setSelection(diversity.toProto());
     }
     return nearImage;
   }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/NearImu.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/NearImu.java
@@ -15,6 +15,7 @@ public record NearImu(
     Float distance,
     Float certainty,
     Rerank rerank,
+    Diversity diversity,
     BaseQueryOptions common)
     implements QueryOperator, AggregateObjectFilter {
 
@@ -40,6 +41,7 @@ public record NearImu(
         builder.distance,
         builder.certainty,
         builder.rerank,
+        builder.diversity,
         builder.baseOptions());
   }
 
@@ -86,6 +88,10 @@ public record NearImu(
     } else if (distance != null) {
       nearImu.setDistance(distance);
     }
+    if (diversity != null) {
+      nearImu.setSelection(diversity.toProto());
+    }
+
     return nearImu;
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/NearObject.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/NearObject.java
@@ -13,6 +13,7 @@ public record NearObject(
     Float distance,
     Float certainty,
     Rerank rerank,
+    Diversity diversity,
     BaseQueryOptions common)
     implements QueryOperator, AggregateObjectFilter {
 
@@ -30,6 +31,7 @@ public record NearObject(
         builder.distance,
         builder.certainty,
         builder.rerank,
+        builder.diversity,
         builder.baseOptions());
   }
 
@@ -73,6 +75,9 @@ public record NearObject(
       nearObject.setCertainty(certainty);
     } else if (distance != null) {
       nearObject.setDistance(distance);
+    }
+    if (diversity != null) {
+      nearObject.setSelection(diversity.toProto());
     }
     return nearObject;
   }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/NearText.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/NearText.java
@@ -20,6 +20,7 @@ public record NearText(
     Rerank rerank,
     Move moveTo,
     Move moveAway,
+    Diversity diversity,
     BaseQueryOptions common) implements QueryOperator, AggregateObjectFilter {
 
   public static NearText of(String... concepts) {
@@ -46,6 +47,7 @@ public record NearText(
         builder.rerank,
         builder.moveTo,
         builder.moveAway,
+        builder.diversity,
         builder.baseOptions());
   }
 
@@ -166,7 +168,9 @@ public record NearText(
       moveAway.appendTo(away);
       nearText.setMoveAway(away);
     }
-
+    if (diversity != null) {
+      nearText.setSelection(diversity.toProto());
+    }
     return nearText;
   }
 }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/NearThermal.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/NearThermal.java
@@ -14,6 +14,7 @@ public record NearThermal(Target searchTarget,
     Float distance,
     Float certainty,
     Rerank rerank,
+    Diversity diversity,
     BaseQueryOptions common)
     implements QueryOperator, AggregateObjectFilter {
 
@@ -39,6 +40,7 @@ public record NearThermal(Target searchTarget,
         builder.distance,
         builder.certainty,
         builder.rerank,
+        builder.diversity,
         builder.baseOptions());
   }
 
@@ -84,6 +86,9 @@ public record NearThermal(Target searchTarget,
       nearThermal.setCertainty(certainty);
     } else if (distance != null) {
       nearThermal.setDistance(distance);
+    }
+    if (diversity != null) {
+      nearThermal.setSelection(diversity.toProto());
     }
     return nearThermal;
   }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/NearVector.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/NearVector.java
@@ -12,6 +12,7 @@ public record NearVector(NearVectorTarget searchTarget,
     Float distance,
     Float certainty,
     Rerank rerank,
+    Diversity diversity,
     BaseQueryOptions common)
     implements QueryOperator, AggregateObjectFilter {
 
@@ -44,6 +45,7 @@ public record NearVector(NearVectorTarget searchTarget,
         builder.distance,
         builder.certainty,
         builder.rerank,
+        builder.diversity,
         builder.baseOptions());
   }
 
@@ -89,6 +91,10 @@ public record NearVector(NearVectorTarget searchTarget,
       nearVector.setCertainty(certainty);
     } else if (distance != null) {
       nearVector.setDistance(distance);
+    }
+
+    if (diversity != null) {
+      nearVector.setSelection(diversity.toProto());
     }
     return nearVector;
   }

--- a/src/main/java/io/weaviate/client6/v1/api/collections/query/NearVideo.java
+++ b/src/main/java/io/weaviate/client6/v1/api/collections/query/NearVideo.java
@@ -15,6 +15,7 @@ public record NearVideo(
     Float distance,
     Float certainty,
     Rerank rerank,
+    Diversity diversity,
     BaseQueryOptions common)
     implements QueryOperator, AggregateObjectFilter {
 
@@ -40,6 +41,7 @@ public record NearVideo(
         builder.distance,
         builder.certainty,
         builder.rerank,
+        builder.diversity,
         builder.baseOptions());
   }
 
@@ -85,6 +87,9 @@ public record NearVideo(
       nearVideo.setCertainty(certainty);
     } else if (distance != null) {
       nearVideo.setDistance(distance);
+    }
+    if (diversity != null) {
+      nearVideo.setSelection(diversity.toProto());
     }
     return nearVideo;
   }


### PR DESCRIPTION
This PR adds a new `Diversity` parameter to all vector query types

- NearMedia
- NearText
- NearVector
- NearObject